### PR TITLE
Fix system test timeouts in GitHub CI

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -23,27 +23,14 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: Download modules
         run: go mod download
       - name: Build
         run: make build bin
       - name: Test
         run: make test-unit
-
-  system-tests:
-    name: System tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Run gotestsum
-        run: go run gotest.tools/gotestsum@latest -f testname -- ./systest
 
   static-analysis:
     name: Static analysis

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -30,6 +30,21 @@ jobs:
       - name: Test
         run: make test-unit
 
+  system-tests:
+    name: System tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run gotestsum
+        run: go run gotest.tools/gotestsum@latest -f testname -- ./systest
+
   static-analysis:
     name: Static analysis
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ test: test-race test-cli
 
 .PHONY: test-unit
 test-unit:
-	$(GOTEST) ./...
+	$(GOTEST) ./... -skip TestSuite
 
 # Subset of "test-unit", for simplicity.
 .PHONY: test-system

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,12 @@ test: test-race test-cli
 
 .PHONY: test-unit
 test-unit:
-	$(GOTEST) ./... -skip TestSuite
+	$(GOTEST) ./...
+
+# Subset of "test-unit", for simplicity.
+.PHONY: test-system
+test-system:
+	$(GOTEST) ./systest
 
 .PHONY: test-cover
 test-cover:

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ test: test-race test-cli
 
 .PHONY: test-unit
 test-unit:
-	$(GOTEST) ./... -skip TestSuite
+	$(GOTEST) ./...
 
 # Subset of "test-unit", for simplicity.
 .PHONY: test-system

--- a/cmd/ak/cmd/up.go
+++ b/cmd/ak/cmd/up.go
@@ -34,8 +34,18 @@ var upCmd = common.StandardCommand(&cobra.Command{
 			return fmt.Errorf("mode: %w", err)
 		}
 
-		svc.New(common.Config(), basesvc.RunOptions{Mode: m}).Run()
+		ctx := cmd.Root().Context()
+		app := svc.New(common.Config(), basesvc.RunOptions{Mode: m})
+		if err := app.Start(ctx); err != nil {
+			return fmt.Errorf("fx app start: %w", err)
+		}
 
+		<-app.Wait()
+		fmt.Println() // End the output with "\n".
+
+		if err := app.Stop(ctx); err != nil {
+			return fmt.Errorf("fx app stop: %w", err)
+		}
 		return nil
 	},
 })

--- a/cmd/ak/common/render.go
+++ b/cmd/ak/common/render.go
@@ -3,30 +3,14 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"io"
+	"os"
 )
 
 type Renderer func(any)
 
 type Texter interface{ Text() string }
 
-var (
-	// If we ever decide to make rendering stateful, i.e. pass a reference of the
-	// calling command in [Render] calls, we could use the command's [OutOrStdout]
-	// and [ErrOrStderr] functions instead of these global variables.
-	outOrStdout, errOrStderr io.Writer
-
-	renderer Renderer = TextRenderer
-)
-
-func GetWriters() (io.Writer, io.Writer) {
-	return outOrStdout, errOrStderr
-}
-
-func SetWriters(out, err io.Writer) {
-	outOrStdout = out
-	errOrStderr = err
-}
+var renderer Renderer = TextRenderer
 
 func SetRenderer(r Renderer) { renderer = r }
 
@@ -43,7 +27,7 @@ func TextRenderer(o any) {
 	}
 
 	if out != "" {
-		fmt.Fprintln(outOrStdout, out)
+		fmt.Fprintln(os.Stdout, out)
 	}
 }
 
@@ -54,7 +38,7 @@ func JSONRenderer(o any) {
 		return
 	}
 
-	fmt.Fprintln(outOrStdout, string(text))
+	fmt.Fprintln(os.Stdout, string(text))
 }
 
 func NiceJSONRenderer(o any) {
@@ -64,11 +48,11 @@ func NiceJSONRenderer(o any) {
 		return
 	}
 
-	fmt.Fprintln(outOrStdout, string(text))
+	fmt.Fprintln(os.Stdout, string(text))
 }
 
 func renderError(err error) {
-	fmt.Fprintf(errOrStderr, "error: %v", err)
+	fmt.Fprintf(os.Stderr, "error: %v", err)
 }
 
 func Render(o any) { renderer(o) }

--- a/cmd/ak/main.go
+++ b/cmd/ak/main.go
@@ -2,13 +2,9 @@
 package main
 
 import (
-	"os"
-
 	"go.autokitteh.dev/autokitteh/cmd/ak/cmd"
-	"go.autokitteh.dev/autokitteh/cmd/ak/common"
 )
 
 func main() {
-	common.SetWriters(os.Stdout, os.Stderr)
 	cmd.Execute()
 }

--- a/systest/buffer.go
+++ b/systest/buffer.go
@@ -1,0 +1,52 @@
+package systest
+
+import (
+	"bytes"
+	"sync"
+)
+
+// mutexBuffer is a [bytes.Buffer], wrapped by a [sync.Mutex] to allow
+// multiple goroutines to share it without data races. We redirect the AK
+// server's output to it, to detect when the it's ready for the test to begin.
+// We can't use channels because we don't control - and can't interrupt - the
+// operation of [io.Copy] which uses this buffer as a destination.
+type mutexBuffer struct {
+	b *bytes.Buffer
+	*sync.Mutex
+}
+
+// newMutexBuffer initializes a new [bytes.Buffer], wrapped by a [sync.Mutex].
+func newMutexBuffer() *mutexBuffer {
+	return &mutexBuffer{b: new(bytes.Buffer), Mutex: new(sync.Mutex)}
+}
+
+// Write appends the contents of p to the buffer, growing the buffer as
+// needed. The return value n is the length of p; err is always nil. If
+// the buffer becomes too large, Write will panic with [ErrTooLarge].
+func (m *mutexBuffer) Write(p []byte) (int, error) {
+	m.Lock()
+	defer m.Unlock()
+	return m.b.Write(p)
+}
+
+// Bytes returns a slice of length b.Len() holding the unread portion of the
+// buffer. The slice is valid for use only until the next buffer modification
+// (that is, only until the next call to a method like [Buffer.Read], [Buffer.Write],
+// [Buffer.Reset], or [Buffer.Truncate]). The slice aliases the buffer content
+// at least until the next buffer modification, so immediate changes to the
+// slice will affect the result of future reads.
+func (m *mutexBuffer) Bytes() []byte {
+	m.Lock()
+	defer m.Unlock()
+	return m.b.Bytes()
+}
+
+// String returns the contents of the unread portion of the buffer
+// as a string. If the [Buffer] is a nil pointer, it returns "<nil>".
+//
+// To build strings more efficiently, see the strings.Builder type.
+func (m *mutexBuffer) String() string {
+	m.Lock()
+	defer m.Unlock()
+	return m.b.String()
+}

--- a/systest/checks.go
+++ b/systest/checks.go
@@ -65,8 +65,7 @@ func checkAKReturnCode(step string, ak *akResult) error {
 	}
 	if expected != ak.returnCode {
 		var sb strings.Builder
-		// Test log will already show what was expected, where, and why.
-		sb.WriteString(fmt.Sprintf("got return code %d", ak.returnCode))
+		sb.WriteString(fmt.Sprintf("got return code %d, want %d", ak.returnCode, expected))
 		// Append the AK output for context, if there is any.
 		if ak.output != "" {
 			sb.WriteString("\n" + ak.output)

--- a/systest/server.go
+++ b/systest/server.go
@@ -3,34 +3,27 @@ package systest
 import (
 	"bytes"
 	"context"
-	"os"
+	"regexp"
 	"testing"
 	"time"
 
 	"go.autokitteh.dev/autokitteh/cmd/ak/cmd"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
 )
 
 const (
 	serverReadyTimeout = 10 * time.Second
-	serverAddrFilename = "AK_SERVER_ADDR"
 )
 
-func startAKServer(ctx context.Context, combinedOutput *bytes.Buffer) {
-	cmd.RootCmd.SetArgs([]string{
-		"up",
-		"--config", "http.addr=:0",
-		"--config", "http.addr_filename=" + serverAddrFilename,
-		"--mode", "test",
-	})
-	cmd.RootCmd.SetOut(combinedOutput)
-	cmd.RootCmd.SetErr(combinedOutput)
-	// This is blocking for the entire duration of the test, so it's safe to
-	// ignore the error, and even to abort the goroutine with an internal panic.
-	kittehs.Must0(cmd.RootCmd.ExecuteContext(ctx))
+// Start the AK server, but in a goroutine rather than as a separate
+// subprocess: to support breakpoint debugging, and measure test coverage.
+func startAKServer(ctx context.Context) {
+	cmd.RootCmd.SetArgs([]string{"up", "--config", "http.addr=:0", "--mode", "test"})
+
+	// We don't care about execution errors here, the test will check this.
+	cmd.RootCmd.ExecuteContext(ctx) //nolint:errcheck
 }
 
-func waitForAKServer(t *testing.T, combinedOutput *bytes.Buffer) string {
+func waitForAKServer(t *testing.T, combinedOutput *mutexBuffer) string {
 	ready := make(chan time.Duration, 1)
 	timer := time.NewTimer(serverReadyTimeout)
 	go checkAKServer(combinedOutput, ready)
@@ -42,21 +35,20 @@ func waitForAKServer(t *testing.T, combinedOutput *bytes.Buffer) string {
 		timer.Stop()
 	case <-timer.C:
 		t.Errorf("ak server not ready after %s", serverReadyTimeout)
-		t.Fatalf("ak server output:\n%s", combinedOutput)
+		t.Fatalf("ak server combined output: %s", combinedOutput.String())
 	}
 
 	// Return the AK server's address, to be used by clients/tools.
-	akAddr, err := os.ReadFile(serverAddrFilename)
-	if err != nil {
-		t.Errorf("failed to read ak server address: %v", err)
-		t.Fatalf("ak server output:\n%s", combinedOutput.String())
+	re := regexp.MustCompile(`gRPC/HTTP:\s*(.*:\d+)`)
+	addr := re.FindStringSubmatch(combinedOutput.String())
+	if addr == nil {
+		t.Error("ak server address not found")
+		t.Fatalf("ak server combined output: %s", combinedOutput.String())
 	}
-	os.Remove(serverAddrFilename)
-	combinedOutput.Reset()
-	return string(akAddr)
+	return addr[1]
 }
 
-func checkAKServer(combinedOutput *bytes.Buffer, result chan<- time.Duration) {
+func checkAKServer(combinedOutput *mutexBuffer, result chan<- time.Duration) {
 	ready := []byte("ready")
 	start := time.Now()
 	for {
@@ -64,6 +56,6 @@ func checkAKServer(combinedOutput *bytes.Buffer, result chan<- time.Duration) {
 			result <- time.Since(start)
 			return
 		}
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/systest/testdata/up.txtar
+++ b/systest/testdata/up.txtar
@@ -1,8 +1,0 @@
-# Can't start another AK server listening to the same port.
-ak up --mode=test
-output contains bind: address already in use
-return code == 1
-
-# But the first AK server is unaffected by that.
-ak integrations list
-return code == 0


### PR DESCRIPTION
1. Data races due to incorrect sharing of AK server output
2. Previous systest additions in the CLI are no longer necessary
3. Indirect result: can read address from output, no need for file
4. "ak up" command didn't terminate when the test was done