### PR TITLE
New system test with end-to-end session execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ test: test-race test-cli
 
 .PHONY: test-unit
 test-unit:
-	$(GOTEST) ./...
+	$(GOTEST) ./... -skip /workflows/builtin_funcs
 
 # Subset of "test-unit", for simplicity.
 .PHONY: test-system

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ endif
 .PHONY: test
 test: test-race test-cli
 
+# TODO(ENG-447): Fix HTTP trigger flakiness.
 .PHONY: test-unit
 test-unit:
 	$(GOTEST) ./... -skip /workflows/builtin_funcs

--- a/systest/README.md
+++ b/systest/README.md
@@ -50,7 +50,7 @@ and each part of a test's identifier (i.e. the txtar relative path under
 `testdata`) must match the corresponding element in the sequence.
 
 For example, to run only with the txtar files in/under `testdata/*foo*/*bar*`,
-including `testdata/*foo*/*bar*.txtar`
+including `testdata/*foo*/*bar*.txtar`:
 
 ```
 gotestsum -f testname -run /foo/bar
@@ -87,7 +87,7 @@ Each command may have optional "customization" and/or "check" lines below it.
 There's no limit on the number or repeatability of checks, e.g. you may
 specify multiple `contains` or `regex` checks per command.
 
-## Action: AK Client Command
+### Action: AK Client Command
 
 `ak [CLI commands, arguments, and flags]`
 
@@ -101,7 +101,7 @@ Note: May reference filenames embedded in the same txtar file.
 
 `return code == <integer>`
 
-## Action: HTTP Transaction
+### Action: HTTP Transaction
 
 `http <get|post> <URL>`
 
@@ -131,12 +131,19 @@ test integrations and sessions.
 
 `resp body <euqals|contains|regex> file <embedded txtar filename>`
 
+### Action: Wait for Session
+
+`wait <duration> for session <session ID>`
+
+Waits up to the specified duration (e.g. `10s`) for the specified session to
+be in the state `COMPLETED` or `ERROR`.
+
 ## Syntax Summary
 
 Actions:
 
 ```
-<ak | http <get | post> > <*>
+<ak | http <get | post> | wait> <*>
 ```
 
 Customizations:

--- a/systest/actions.go
+++ b/systest/actions.go
@@ -18,14 +18,12 @@ func runAction(t *testing.T, akPath, akAddr, step string) (any, error) {
 		args := []string{"--url=http://" + akAddr}
 		args = append(args, strings.Fields(match[3])...)
 		return runClient(akPath, args)
-	case "http":
-		return runActionHTTP(t, match[2], match[3])
+	case "http get", "http post":
+		method := strings.ToUpper(match[2])
+		return &httpRequest{method: method, url: match[3]}, nil
+	case "wait":
+		return waitForSession(akPath, akAddr, step)
 	default:
 		return nil, errors.New("unhandled action")
 	}
-}
-
-// TODO: Return an actual HTTP response, not a dummy *string.
-func runActionHTTP(t *testing.T, method, url string) (*string, error) {
-	return nil, errors.New("not implemented yet")
 }

--- a/systest/ak_test.go
+++ b/systest/ak_test.go
@@ -142,6 +142,9 @@ func runTestSteps(t *testing.T, steps []string, akPath, akAddr string) {
 				pendingReq = v
 			case string:
 				t.Log(v)
+			default:
+				t.Errorf("line %d: %s", i+1, step)
+				t.Fatalf("error: unhandled action result type: %T", v)
 			}
 			continue
 		}

--- a/systest/http.go
+++ b/systest/http.go
@@ -1,0 +1,67 @@
+package systest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	httpClientTimeout = 5 * time.Second
+)
+
+type httpRequest struct {
+	method  string
+	url     string
+	headers map[string]string
+	body    string
+}
+
+type httpResponse struct {
+	resp *http.Response
+	body string
+}
+
+func sendRequest(akAddr string, r httpRequest) (*httpResponse, error) {
+	u := r.url
+	var err error
+	if !strings.HasPrefix(u, "http") {
+		u, err = url.JoinPath("http://"+akAddr, u)
+		if err != nil {
+			return nil, fmt.Errorf("failed to construct request URL: %w", err)
+		}
+	}
+
+	var body io.Reader
+	if r.body != "" {
+		body = io.NopCloser(strings.NewReader(r.body))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), httpClientTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, r.method, u, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new HTTP request: %w", err)
+	}
+	for k, v := range r.headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send HTTP request: %w", err)
+	}
+
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read HTTP response body: %w", err)
+	}
+
+	return &httpResponse{resp: resp, body: string(b)}, nil
+}

--- a/systest/testdata/workflows/builtin_funcs.txtar
+++ b/systest/testdata/workflows/builtin_funcs.txtar
@@ -1,0 +1,77 @@
+# Apply, build, and deploy a project with a program that
+# runs all built-in AK functions, and an HTTP connection.
+ak manifest apply project.yaml
+return code == 0
+
+ak project build my_project
+return code == 0
+output equals build_id: b:00000000000000000000000000000001
+
+ak deployment create --build-id=b:00000000000000000000000000000001 --env=my_project/my_env --activate
+return code == 0
+
+# Send an HTTP GET request to trigger the deployment to start a new session.
+http get /http/my_url_path
+resp code == 200
+
+wait 5s for session s:00000000000000000000000000000004
+
+# Check the session's output and final state.
+ak session log -J
+return code == 0
+output contains "print": "1st random int with seed: 5"
+output contains "print": "2nd random int with seed: 2"
+output contains "print": "3rd random int with seed: 1"
+output contains "print": "Store set = OK"
+output contains "print": "Store get = value"
+output contains "Store del = 1"
+output regex "print": "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6} \+0000 UTC"
+output contains "print": "done"
+
+ak sessions list
+return code == 0
+output contains session_id:"s:00000000000000000000000000000004"
+output contains state:SESSION_STATE_TYPE_COMPLETED
+
+-- project.yaml --
+version: v1
+
+project:
+  name: my_project
+  paths:
+    - my_program.star
+  connections:
+    - name: my_connection
+      integration: http
+      token: my_url_path
+  envs:
+    - name: my_env
+      mappings:
+        - name: http
+          connection: my_project/my_connection
+          events:
+            - type: get
+              entrypoint: my_program.star:on_http_get
+
+-- my_program.star --
+def on_http_get(data):
+    # runtimes/starlarkrt/internal/libs/rand/rand.go
+    rand.seed(0x533d)
+    print("1st random int with seed: %d" % rand.intn(10))
+    print("2nd random int with seed: %d" % rand.intn(10))
+    print("3rd random int with seed: %d" % rand.intn(10))
+
+    # runtimes/starlarkrt/internal/bootstrap/bootstrap.star
+    sleep(1)
+
+    # integrations/redis/redis.go
+    key = "builtin_funcs_test_key"
+    if store.set(key, "value", ttl = "1m") == "OK":
+        print("Store set = OK")
+    print("Store get = %s" % store.get(key))
+    print("Store del = %d" % store.delete(key))
+
+    # backend/internal/akmodules/time/time.go
+    print(time.now())
+
+    print("done")


### PR DESCRIPTION
The new test - `systest/testdata/workflows/builtin_funcs.txtar` - has a dual purpose:

1. (The first but not only) automated test of end-to-end execution via AK
2. Test the functionality of AK built-in functions, which are non-standard but loaded automatically in Starlark

Two commands were added to the systest:

1. `http get|post`
2. `wait` (for a specific session to have the state `COMPLETED` or `ERROR`)

Note that this test possibly uncovers flakiness in AK's HTTP connection, which needs to be investigated further. So I'm adding the test to this PR, but for now skipping it in `make test-unit` - so we can manually run it anywhere, but without suffering from CI flakiness.