### PR TITLE
Start and stop Temporal within the system test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ test: test-race test-cli
 
 .PHONY: test-unit
 test-unit:
-	$(GOTEST) ./...
+	$(GOTEST) ./... -skip /workflows/builtin_funcs
 
 # Subset of "test-unit", for simplicity.
 .PHONY: test-system

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ test: test-race test-cli
 
 .PHONY: test-unit
 test-unit:
-	$(GOTEST) ./... -skip /workflows/builtin_funcs
+	$(GOTEST) ./...
 
 # Subset of "test-unit", for simplicity.
 .PHONY: test-system

--- a/backend/basesvc/svc.go
+++ b/backend/basesvc/svc.go
@@ -157,7 +157,7 @@ func makeFxOpts(cfg *Config, opts RunOptions) []fx.Option {
 		fx.Invoke(func(lc fx.Lifecycle, z *zap.Logger) {
 			HookSimpleOnStart(lc, func() {
 				sayHello(opts)
-				z.Info("ready")
+				z.Info("autokitteh ready")
 			})
 		}),
 	}

--- a/backend/internal/temporalclient/config.go
+++ b/backend/internal/temporalclient/config.go
@@ -43,10 +43,5 @@ var Configs = configset.Set[Config]{
 		CheckHealthInterval: time.Minute,
 		CheckHealthTimeout:  10 * time.Second,
 		LogLevel:            zap.NewAtomicLevelAt(zapcore.WarnLevel),
-
-		AlwaysStartDevServer: true,
-		DevServer: testsuite.DevServerOptions{
-			LogLevel: zapcore.WarnLevel.String(),
-		},
 	},
 }

--- a/systest/server.go
+++ b/systest/server.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"go.temporal.io/sdk/testsuite"
+
 	"go.autokitteh.dev/autokitteh/cmd/ak/cmd"
 )
 
@@ -14,10 +16,32 @@ const (
 	serverReadyTimeout = 10 * time.Second
 )
 
+// Start a Temporal dev server as a subprocess.
+func startTemporalDevServer(t *testing.T) *testsuite.DevServer {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	temporal, err := testsuite.StartDevServer(ctx, testsuite.DevServerOptions{
+		LogFormat: "pretty",
+		LogLevel:  "warn",
+	})
+	if err != nil {
+		t.Fatalf("start temporal dev server: %v", err)
+	}
+
+	t.Cleanup(func() { temporal.Stop() }) //nolint:errcheck
+	return temporal
+}
+
 // Start the AK server, but in a goroutine rather than as a separate
 // subprocess: to support breakpoint debugging, and measure test coverage.
-func startAKServer(ctx context.Context) {
-	cmd.RootCmd.SetArgs([]string{"up", "--config", "http.addr=:0", "--mode", "test"})
+func startAKServer(ctx context.Context, temporalAddr string) {
+	cmd.RootCmd.SetArgs([]string{
+		"up",
+		"--config", "http.addr=:0",
+		"--config", "temporalclient.hostport=" + temporalAddr,
+		"--mode", "test",
+	})
 
 	// We don't care about execution errors here, the test will check this.
 	cmd.RootCmd.ExecuteContext(ctx) //nolint:errcheck
@@ -35,7 +59,7 @@ func waitForAKServer(t *testing.T, combinedOutput *mutexBuffer) string {
 		timer.Stop()
 	case <-timer.C:
 		t.Errorf("ak server not ready after %s", serverReadyTimeout)
-		t.Fatalf("ak server combined output: %s", combinedOutput.String())
+		t.Fatalf("ak server combined output:\n%s", combinedOutput.String())
 	}
 
 	// Return the AK server's address, to be used by clients/tools.
@@ -49,7 +73,7 @@ func waitForAKServer(t *testing.T, combinedOutput *mutexBuffer) string {
 }
 
 func checkAKServer(combinedOutput *mutexBuffer, result chan<- time.Duration) {
-	ready := []byte("ready")
+	ready := []byte("autokitteh ready")
 	start := time.Now()
 	for {
 		if bytes.Contains(combinedOutput.Bytes(), ready) {


### PR DESCRIPTION
Fix for ENG-437: start and stop Temporal dev server within `systest/ak_test` instead of AK's `temporalclient`.

Verification:

```
$ ps -ef | grep temporal | grep headless | wc -l
$ gotestsum -f testname -- ./systest
$ ps -ef | grep temporal | grep headless | wc -l
```

Indirectly, had to change AK's ready log message from `ready` to `autokitteh ready` to avoid conflict with Temporal's own `DevServer ready` log message when the system test waits for the AK server to be ready.