### PR TITLE
Remove daemon flag from up command

### DIFF
--- a/cmd/ak/cmd/up.go
+++ b/cmd/ak/cmd/up.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -12,23 +11,15 @@ import (
 	"go.autokitteh.dev/autokitteh/cmd/ak/common"
 )
 
-var (
-	daemon bool
-	mode   string
-)
+var mode string
 
 var upCmd = common.StandardCommand(&cobra.Command{
-	Use:     "up [--mode={default|dev|test}] [--daemon]",
+	Use:     "up [--mode={default|dev|test}]",
 	Short:   "Start local server",
 	Aliases: []string{"u"},
 	Args:    cobra.NoArgs,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if daemon {
-			// TODO: Implement. Need to detach only after all inits are done?
-			return errors.New("not implemented yet")
-		}
-
 		m, err := configset.ParseMode(mode)
 		if err != nil {
 			return fmt.Errorf("mode: %w", err)
@@ -40,10 +31,7 @@ var upCmd = common.StandardCommand(&cobra.Command{
 	},
 })
 
-func RemoveUpCmd() { RootCmd.RemoveCommand(upCmd) }
-
 func init() {
 	// Command-specific flags.
 	upCmd.Flags().StringVarP(&mode, "mode", "m", "", "run mode: {default|dev|test}")
-	upCmd.Flags().BoolVarP(&daemon, "daemon", "d", false, "run as daemon?")
 }


### PR DESCRIPTION
See discussion in https://github.com/golang/go/issues/227 - daemonizing should be done by the user, not by the binary itself, not to mention dealing with OS-specific complexities.