### PR TITLE
Fix over-persistence of systest DB

### DIFF
--- a/backend/gormkitteh/config.go
+++ b/backend/gormkitteh/config.go
@@ -25,7 +25,8 @@ func (c Config) Explicit() (*Config, error) {
 			// use a temporary database.
 			c.Type = "sqlite"
 			// For in-memory, cached is required for transactions to work.
-			c.DSN = "file::memory:?cache=shared"
+			// Not using "?cache=shared", for auto-cleanup between system tests.
+			c.DSN = "file::memory:"
 		} else {
 			// This should make it easier to just specify the type in the dsn
 			// in a single env var.

--- a/systest/client.go
+++ b/systest/client.go
@@ -89,10 +89,18 @@ func waitForSession(akPath, akAddr, step string) (string, error) {
 	}
 
 	text := fmt.Sprintf("session %s not done after %s", id, duration)
-	args = []string{"--url=http://" + akAddr, "sessions", "list", "-J"}
+
+	args = []string{"--url=http://" + akAddr, "events", "list", "--integration=http"}
 	result, err := runClient(akPath, args)
-	if err != nil {
-		text += fmt.Sprintf("\nSessions list:\n%s", result.output)
+	if err == nil {
+		text += fmt.Sprintf("\nEvents list:\n%s", result.output)
 	}
+
+	args = []string{"--url=http://" + akAddr, "sessions", "list", "-J"}
+	result, err = runClient(akPath, args)
+	if err == nil {
+		text += fmt.Sprintf("\n---\nSessions list:\n%s", result.output)
+	}
+
 	return "", errors.New(text)
 }

--- a/systest/testdata/workflows/builtin_funcs.txtar
+++ b/systest/testdata/workflows/builtin_funcs.txtar
@@ -5,16 +5,16 @@ return code == 0
 
 ak project build my_project
 return code == 0
-output equals build_id: b:00000000000000000000000000000001
+output equals build_id: b:00000000000000000000000000000005
 
-ak deployment create --build-id=b:00000000000000000000000000000001 --env=my_project/my_env --activate
+ak deployment create --build-id=b:00000000000000000000000000000005 --env=my_project/my_env --activate
 return code == 0
 
 # Send an HTTP GET request to trigger the deployment to start a new session.
 http get /http/my_url_path
 resp code == 200
 
-wait 5s for session s:00000000000000000000000000000004
+wait 5s for session s:00000000000000000000000000000008
 
 # Check the session's output and final state.
 ak session log -J
@@ -30,7 +30,7 @@ output contains "print": "done"
 
 ak sessions list
 return code == 0
-output contains session_id:"s:00000000000000000000000000000004"
+output contains session_id:"s:00000000000000000000000000000008"
 output contains state:SESSION_STATE_TYPE_COMPLETED
 
 -- project.yaml --


### PR DESCRIPTION
Make sure that an in-memory DB of a torn-down AK server, is not reused by future AK servers, even if they reside in the same OS process.

This bug impacts the system tests (which run AK servers as goroutines instead of subprocesses), but not regular dev-mode users.