### PR TITLE
System test tweaks

### DIFF
--- a/systest/README.md
+++ b/systest/README.md
@@ -160,3 +160,15 @@ Checks:
 <return | resp> code == <integer>
 resp header <name> == <value>
 ```
+
+## Tips for Writing Tests
+
+If you're running an AK command, and checking both its return code and output:
+
+- When expecting success - check `return code == 0` first, and then
+  `output ...`, because if the AK command failed checking the output is
+  pointless
+- When expecting an error - check the `output` first, and then
+  `return code == <int>`, because if there are mismatches in any `output`
+  check, we print the actual output, but an incorrect error code is typically
+  just a minor bug or mistake

--- a/systest/checks.go
+++ b/systest/checks.go
@@ -26,6 +26,8 @@ func runCheck(step string, ak *akResult, resp *httpResponse) error {
 func checkAKOutput(step string, ak *akResult) error {
 	match := akCheckOutput.FindStringSubmatch(step)
 	want := strings.TrimSpace(match[3])
+	want = strings.TrimPrefix(want, "'")
+	want = strings.TrimSuffix(want, "'")
 	got := ak.output
 
 	if strings.HasPrefix(match[2], "file") {

--- a/systest/parse.go
+++ b/systest/parse.go
@@ -23,7 +23,7 @@ var (
 	waitAction = regexp.MustCompile(`^wait\s+(.+)\s+for\s+session\s+(.+)`)
 
 	// output <equals|contains|regex> [file] *
-	akCheckOutput = regexp.MustCompile(`^output\s+(equals|contains|regex)\s+(file\s+)?(.+)`)
+	akCheckOutput = regexp.MustCompile(`^output\s+(equals|contains|regex)\s+(file\s+)?(.+|'.*')`)
 	// return code == <int>
 	akCheckReturn = regexp.MustCompile(`^return\s+code\s*==\s*(\d+)$`)
 
@@ -34,7 +34,7 @@ var (
 
 	httpChecks = regexp.MustCompile(`^resp\s+(body|redirect|code|header)`)
 	// resp <body|redirect> <equals|contains|regex> [file] *
-	httpCheckOutput = regexp.MustCompile(`^resp\s+(body|redirect)\s+(equals|contains|regex)\s+(file\s+)?(.+)`)
+	httpCheckOutput = regexp.MustCompile(`^resp\s+(body|redirect)\s+(equals|contains|regex)\s+(file\s+)?(.+|'.*')`)
 	// resp code == <int>
 	httpCheckStatus = regexp.MustCompile(`^resp\s+code\s*==\s*(\d+)$`)
 	// resp header <name> == <value>

--- a/systest/testdata/completion.txtar
+++ b/systest/testdata/completion.txtar
@@ -1,13 +1,13 @@
 # The completion command exists.
 ak completion bash
-output contains bash completion for ak
 return code == 0
+output contains 'bash completion for ak'
 
 ak completion zsh
-output contains zsh completion for ak
 return code == 0
+output contains 'zsh completion for ak'
 
 # There's an error for unrecognized shell types.
 ak completion blah
-output equals Error: invalid argument "blah" for "ak completion"
+output equals 'Error: invalid argument "blah" for "ak completion"'
 return code == 1

--- a/systest/testdata/integrations/get.txtar
+++ b/systest/testdata/integrations/get.txtar
@@ -1,13 +1,30 @@
+# Negative tests: get nonexistent integration name/ID, with/out --fail flag.
+ak integration get foo
+return code == 0
+output equals ''
+
+ak integration get integration:deadbeefdeadbeefdeadbeefdeadbeef
+return code == 0
+output equals ''
+
+ak integration get foo --fail
+output equals 'Error: integration not found'
+return code == 10
+
+ak integration get integration:deadbeefdeadbeefdeadbeefdeadbeef --fail
+output equals 'Error: integration not found'
+return code == 10
+
 # Get integration by name.
 ak integration get http
 return code == 0
-output contains key:"get"
-output contains key:"post"
+output contains 'key:"get"'
+output contains 'key:"post"'
 
 # Get integration by ID.
 ak integration get integration:8000000000000000f1201a7ed83f7cd5
 return code == 0
-output contains unique_name:"http"
-output contains display_name:"HTTP"
-output contains logo_url:
-output contains functions:
+output contains 'unique_name:"http"'
+output contains 'display_name:"HTTP"'
+output contains 'logo_url:'
+output contains 'functions:'

--- a/systest/testdata/manifest/apply.txtar
+++ b/systest/testdata/manifest/apply.txtar
@@ -11,7 +11,7 @@ return code == 1
 # Successful application of an empty plan.
 ak manifest apply empty.yaml
 return code == 0
-output equals file expected_empty_plan.txt
+output equals ''
 
 # Successful dry run of a full project.
 ak manifest apply full.yaml --dry-run -J
@@ -68,8 +68,6 @@ Error: invalid YAML input: yaml: unmarshal errors:
 
 -- empty.yaml --
 version: v1
-
--- expected_empty_plan.txt --
 
 -- full.yaml --
 version: v1

--- a/systest/testdata/manifest/apply.txtar
+++ b/systest/testdata/manifest/apply.txtar
@@ -1,6 +1,6 @@
 # Graceful handling of a nonexistent manifest file.
 ak manifest apply nonexistent.yaml
-output equals Error: open nonexistent.yaml: no such file or directory
+output equals 'Error: open nonexistent.yaml: no such file or directory'
 return code == 1
 
 # Graceful handling of an invalid manifest file.
@@ -10,54 +10,54 @@ return code == 1
 
 # Successful application of an empty plan.
 ak manifest apply empty.yaml
-output equals file expected_on_empty.txt
 return code == 0
+output equals file expected_empty_plan.txt
 
 # Successful dry run of a full project.
 ak manifest apply full.yaml --dry-run -J
-output equals file expected_on_full_dry_run.json
 return code == 0
+output equals file expected_on_full_dry_run.json
 
 # Successful application of a full project.
 ak manifest apply full.yaml -J
-output equals file expected_on_full_apply.json
 return code == 0
+output equals file expected_on_full_apply.json
 
 # Check the actual project details.
 ak project get my_project -J
-output equals file expected_project_details.json
 return code == 0
+output equals file expected_project_details.json
 
 ak project get p:00000000000000000000000000000001 -J
-output equals file expected_project_details.json
 return code == 0
+output equals file expected_project_details.json
 
 # Check the actual connection details.
 ak connection get my_project/my_connection -J
-output equals file expected_connection_details.json
 return code == 0
+output equals file expected_connection_details.json
 
 # TODO: Add more tests - either here, or in separate `.txtar` files:  
 # - Specifying an env name  
 # - This command's flags  
 # - Other manifest commands since PR #6  
 ak connection get connection:00000000000000000000000000000003 -J
-output equals file expected_connection_details.json
 return code == 0
+output equals file expected_connection_details.json
 
 # Check the actual environment details.
 ak env get my_project/default -J
-output equals file expected_env_details.json
 return code == 0
+output equals file expected_env_details.json
 
 ak env get e:00000000000000000000000000000002 -J
-output equals file expected_env_details.json
 return code == 0
+output equals file expected_env_details.json
 
 # Check the actual trigger details.
 ak trigger get t:00000000000000000000000000000004 -J
-output equals file expected_trigger_details.json
 return code == 0
+output equals file expected_trigger_details.json
 
 -- invalid.yaml --
 This is an invalid YAML file to trigger an error
@@ -69,7 +69,7 @@ Error: invalid YAML input: yaml: unmarshal errors:
 -- empty.yaml --
 version: v1
 
--- expected_on_empty.txt --
+-- expected_empty_plan.txt --
 
 -- full.yaml --
 version: v1

--- a/systest/testdata/manifest/schema.txtar
+++ b/systest/testdata/manifest/schema.txtar
@@ -1,4 +1,4 @@
 # The manifest schema command exists.
 ak manifest schema
-output contains https://json-schema.org/
 return code == 0
+output contains 'https://json-schema.org/'

--- a/systest/testdata/version.txtar
+++ b/systest/testdata/version.txtar
@@ -1,5 +1,5 @@
 # The AK client's compile-time version is set (!= "unset"),
 # i.e. the client was built by "make".
 ak version
-output equals dev
 return code == 0
+output equals 'dev'

--- a/systest/testdata/workflows/builtin_funcs.txtar
+++ b/systest/testdata/workflows/builtin_funcs.txtar
@@ -33,8 +33,8 @@ output contains '"print": "done"'
 
 ak sessions list
 return code == 0
-output 'contains session_id:"s:00000000000000000000000000000008"'
-output 'contains state:SESSION_STATE_TYPE_COMPLETED'
+output contains 'session_id:"s:00000000000000000000000000000008"'
+output contains 'state:SESSION_STATE_TYPE_COMPLETED'
 
 -- project.yaml --
 version: v1

--- a/systest/testdata/workflows/builtin_funcs.txtar
+++ b/systest/testdata/workflows/builtin_funcs.txtar
@@ -8,7 +8,7 @@ return code == 0
 
 ak project build my_project
 return code == 0
-output equals build_id: b:00000000000000000000000000000005
+output equals 'build_id: b:00000000000000000000000000000005'
 
 ak deployment create --build-id=b:00000000000000000000000000000005 --env=my_project/default --activate
 return code == 0
@@ -22,19 +22,19 @@ wait 5s for session s:00000000000000000000000000000008
 # Check the session's output and final state.
 ak session log -J
 return code == 0
-output contains "print": "1st random int with seed: 5"
-output contains "print": "2nd random int with seed: 2"
-output contains "print": "3rd random int with seed: 1"
-output contains "print": "Store set = OK"
-output contains "print": "Store get = value"
-output contains "Store del = 1"
-output regex "print": "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6} \+0000 UTC"
-output contains "print": "done"
+output contains '"print": "1st random int with seed: 5"'
+output contains '"print": "2nd random int with seed: 2"'
+output contains '"print": "3rd random int with seed: 1"'
+output contains '"print": "Store set = OK"'
+output contains '"print": "Store get = value"'
+output contains '"Store del = 1"'
+output regex '"print": "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6} \+0000 UTC"'
+output contains '"print": "done"'
 
 ak sessions list
 return code == 0
-output contains session_id:"s:00000000000000000000000000000008"
-output contains state:SESSION_STATE_TYPE_COMPLETED
+output 'contains session_id:"s:00000000000000000000000000000008"'
+output 'contains state:SESSION_STATE_TYPE_COMPLETED'
 
 -- project.yaml --
 version: v1


### PR DESCRIPTION
- Output checks (equals/contains/regex) use `''`
- Tip about order of checks for AK commands