### PR TITLE
systest: gracefuly stop ak + temporal

### DIFF
--- a/systest/ak_test.go
+++ b/systest/ak_test.go
@@ -25,6 +25,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"go.autokitteh.dev/autokitteh/cmd/ak/cmd"
 )
 
 const (
@@ -89,12 +91,13 @@ func setUpTest(t *testing.T) string {
 	// Start the AK server, but in a goroutine rather than as a separate
 	// subprocess: to support breakpoint debugging, and measure test coverage.
 	ctx, cancel := context.WithCancel(context.Background())
-	go startAKServer(ctx)
-	t.Cleanup(cancel) // Stop the AK server's goroutine.
+	go startAKServer(ctx, t)
 
-	akAddr := waitForAKServer(t, combinedOutput)
+	defer cmd.App.Stop(context.Background())
 
-	return akAddr
+	t.Cleanup(cancel)
+
+	return waitForAKServer(t, combinedOutput)
 }
 
 func runTestSteps(t *testing.T, steps []string, akPath, akAddr string) {

--- a/systest/server.go
+++ b/systest/server.go
@@ -16,11 +16,15 @@ const (
 
 // Start the AK server, but in a goroutine rather than as a separate
 // subprocess: to support breakpoint debugging, and measure test coverage.
-func startAKServer(ctx context.Context) {
+func startAKServer(ctx context.Context, t *testing.T) {
 	cmd.RootCmd.SetArgs([]string{"up", "--config", "http.addr=:0", "--mode", "test"})
 
-	// We don't care about execution errors here, the test will check this.
-	cmd.RootCmd.ExecuteContext(ctx) //nolint:errcheck
+	if err := cmd.RootCmd.ExecuteContext(ctx); err != nil {
+		t.Logf("ak server error: %v", err)
+	}
+}
+
+func stopAKServer(ctx context.Context, t *testing.T) {
 }
 
 func waitForAKServer(t *testing.T, combinedOutput *mutexBuffer) string {

--- a/systest/testdata/completion.txtar
+++ b/systest/testdata/completion.txtar
@@ -1,7 +1,7 @@
 # The completion command exists.
 ak completion bash
 return code == 0
-output contains 'bash completion for ak'
+output contains 'bash completion for axk'
 
 ak completion zsh
 return code == 0


### PR DESCRIPTION
not sure that's the prettiest thing that can be done. this is more of a poc to show that it can be stopped from a test.

made sure temporal is thoroughly killed at end of run - no lingering processes on either success or failure.