### PR TITLE
Disable racy & flaky test (temporarily)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ endif
 .PHONY: test
 test: test-race test-cli test-runs
 
+# TODO(ENG-427): Fix E2E test's data race.
 # TODO(ENG-447): Fix HTTP trigger flakiness.
 .PHONY: test-unit
 test-unit:
@@ -120,9 +121,11 @@ test-cover:
 	$(GOTEST) -covermode=atomic -coverprofile=tmp/cover.out ./...
 	go tool cover -html=tmp/cover.out
 
+# TODO(ENG-427): Fix E2E test's data race.
+# TODO(ENG-447): Fix HTTP trigger flakiness.
 .PHONY: test-race
 test-race:
-	$(GOTEST) -race ./...
+	$(GOTEST) -race ./... -skip /workflows/builtin_funcs
 
 .PHONY: test-cli
 # We don't want test-cli to explicitly depend on bin since


### PR DESCRIPTION
This was already done in the GitHub CI's make target (`test-unit`).

Adding the same skip in the `test-race` target too, which is used by the full local invocation of `make`.

Not adding it in other targets (e.g. `test-system`) because they're not used automatically so there's value in test failures there even now.