### PR TITLE
Remove unnecessary import alias

### DIFF
--- a/cmd/ak/cmd/manifest/apply.go
+++ b/cmd/ak/cmd/manifest/apply.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"go.autokitteh.dev/autokitteh/cmd/ak/common"
-	imanifest "go.autokitteh.dev/autokitteh/internal/manifest"
+	"go.autokitteh.dev/autokitteh/internal/manifest"
 )
 
 var dryRun bool
@@ -33,7 +33,7 @@ var applyCmd = common.StandardCommand(&cobra.Command{
 			ctx, cancel := common.LimitedContext()
 			defer cancel()
 
-			_, err := imanifest.Execute(ctx, actions, common.Client(), func(msg string) {
+			_, err := manifest.Execute(ctx, actions, common.Client(), func(msg string) {
 				fmt.Fprintf(os.Stderr, "[exec] %s\n", msg)
 			})
 			return err

--- a/cmd/ak/cmd/manifest/exec.go
+++ b/cmd/ak/cmd/manifest/exec.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"go.autokitteh.dev/autokitteh/cmd/ak/common"
-	imanifest "go.autokitteh.dev/autokitteh/internal/manifest"
+	"go.autokitteh.dev/autokitteh/internal/manifest"
 )
 
 var execCmd = common.StandardCommand(&cobra.Command{
@@ -23,7 +23,7 @@ var execCmd = common.StandardCommand(&cobra.Command{
 			return err
 		}
 
-		var actions imanifest.Actions
+		var actions manifest.Actions
 
 		if err := json.Unmarshal(data, &actions); err != nil {
 			return fmt.Errorf("invalid plan input: %w", err)
@@ -32,7 +32,7 @@ var execCmd = common.StandardCommand(&cobra.Command{
 		ctx, cancel := common.LimitedContext()
 		defer cancel()
 
-		_, err = imanifest.Execute(ctx, actions, common.Client(), func(msg string) {
+		_, err = manifest.Execute(ctx, actions, common.Client(), func(msg string) {
 			fmt.Fprintf(os.Stderr, "[exec] %s\n", msg)
 		})
 		return err

--- a/cmd/ak/cmd/manifest/plan.go
+++ b/cmd/ak/cmd/manifest/plan.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"go.autokitteh.dev/autokitteh/cmd/ak/common"
-	imanifest "go.autokitteh.dev/autokitteh/internal/manifest"
+	"go.autokitteh.dev/autokitteh/internal/manifest"
 )
 
 var noValidate, fromScratch bool
@@ -40,8 +40,8 @@ func init() {
 	planCmd.Flags().BoolVarP(&fromScratch, "from-scratch", "s", false, "assume no existing setup")
 }
 
-func plan(data []byte, path string) (imanifest.Actions, error) {
-	manifest, err := imanifest.Read(data, path)
+func plan(data []byte, path string) (manifest.Actions, error) {
+	m, err := manifest.Read(data, path)
 	if err != nil {
 		return nil, err
 	}
@@ -49,11 +49,11 @@ func plan(data []byte, path string) (imanifest.Actions, error) {
 	ctx, cancel := common.LimitedContext()
 	defer cancel()
 
-	return imanifest.Plan(
+	return manifest.Plan(
 		ctx,
-		manifest,
+		m,
 		common.Client(),
-		imanifest.WithLogger(func(msg string) { fmt.Fprintf(os.Stderr, "[plan] %s\n", msg) }),
-		imanifest.WithFromScratch(fromScratch),
+		manifest.WithLogger(func(msg string) { fmt.Fprintf(os.Stderr, "[plan] %s\n", msg) }),
+		manifest.WithFromScratch(fromScratch),
 	)
 }

--- a/cmd/ak/cmd/manifest/schema.go
+++ b/cmd/ak/cmd/manifest/schema.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"go.autokitteh.dev/autokitteh/cmd/ak/common"
-	imanifest "go.autokitteh.dev/autokitteh/internal/manifest"
+	"go.autokitteh.dev/autokitteh/internal/manifest"
 )
 
 var schemaCmd = common.StandardCommand(&cobra.Command{
@@ -16,7 +16,7 @@ var schemaCmd = common.StandardCommand(&cobra.Command{
 	Args:    cobra.NoArgs,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Fprintln(cmd.OutOrStdout(), imanifest.JSONSchemaString)
+		fmt.Fprintln(cmd.OutOrStdout(), manifest.JSONSchemaString)
 		return nil
 	},
 })

--- a/cmd/ak/cmd/manifest/validate.go
+++ b/cmd/ak/cmd/manifest/validate.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"go.autokitteh.dev/autokitteh/cmd/ak/common"
-	imanifest "go.autokitteh.dev/autokitteh/internal/manifest"
+	"go.autokitteh.dev/autokitteh/internal/manifest"
 )
 
 var validateCmd = common.StandardCommand(&cobra.Command{
@@ -19,7 +19,7 @@ var validateCmd = common.StandardCommand(&cobra.Command{
 			return err
 		}
 
-		if _, err := imanifest.Read(data, path); err != nil {
+		if _, err := manifest.Read(data, path); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Import aliases are counterintuitive, unless they're required.