### PR TITLE
Shorten command name + add missing build tests

### DIFF
--- a/cmd/ak/cmd/projects/build.go
+++ b/cmd/ak/cmd/projects/build.go
@@ -1,6 +1,7 @@
 package projects
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -30,7 +31,7 @@ var buildCmd = common.StandardCommand(&cobra.Command{
 			return err
 		}
 		if !p.IsValid() {
-			err = fmt.Errorf("project %q not found", args[0])
+			err = errors.New("project not found")
 			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
 

--- a/cmd/ak/cmd/projects/download.go
+++ b/cmd/ak/cmd/projects/download.go
@@ -1,6 +1,7 @@
 package projects
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -14,36 +15,34 @@ import (
 
 var outputDirectory string
 
-var downloadResourcesCmd = common.StandardCommand(&cobra.Command{
-	Use:   "download-resources <project name or ID> [--output-dir=...]",
-	Short: "Download the project's resources",
+var downloadCmd = common.StandardCommand(&cobra.Command{
+	Use:   "download <project name or ID> [--output-dir <path>] [--fail]",
+	Short: "Download project resources",
 	Args:  cobra.ExactArgs(1),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		_, pid, err := r.ProjectNameOrID(args[0])
+		p, pid, err := r.ProjectNameOrID(args[0])
 		if err != nil {
-			return err
+			return common.FailIfError(cmd, err, "project")
 		}
-
-		if !pid.IsValid() {
-			return fmt.Errorf("project %s not found", args[0])
+		if !p.IsValid() {
+			err = errors.New("project not found")
+			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
 
 		ctx, cancel := common.LimitedContext()
 		defer cancel()
 
-		resources, err := projects().DownloadResources(ctx, pid)
+		rs, err := projects().DownloadResources(ctx, pid)
 		if err != nil {
-			return fmt.Errorf("download resources: %w", err)
+			return err
+		}
+		if err := common.FailIfNotFound(cmd, "resources", len(rs) > 0); err != nil {
+			return err
 		}
 
-		if len(resources) == 0 {
-			fmt.Println("no resources found")
-			return nil
-		}
-
-		for filename, data := range resources {
+		for filename, data := range rs {
 			fulllPath := filepath.Join(outputDirectory, filename)
 
 			if err := os.MkdirAll(path.Dir(fulllPath), 0o755); err != nil {
@@ -61,5 +60,7 @@ var downloadResourcesCmd = common.StandardCommand(&cobra.Command{
 
 func init() {
 	// Command-specific flags.
-	downloadResourcesCmd.Flags().StringVarP(&outputDirectory, "output-dir", "o", ".", "path to output directory")
+	downloadCmd.Flags().StringVarP(&outputDirectory, "output-dir", "o", ".", "path to output directory")
+
+	common.AddFailIfNotFoundFlag(downloadCmd)
 }

--- a/cmd/ak/cmd/projects/download.go
+++ b/cmd/ak/cmd/projects/download.go
@@ -34,15 +34,15 @@ var downloadCmd = common.StandardCommand(&cobra.Command{
 		ctx, cancel := common.LimitedContext()
 		defer cancel()
 
-		rs, err := projects().DownloadResources(ctx, pid)
+		resources, err := projects().DownloadResources(ctx, pid)
 		if err != nil {
 			return err
 		}
-		if err := common.FailIfNotFound(cmd, "resources", len(rs) > 0); err != nil {
+		if err := common.FailIfNotFound(cmd, "resources", len(resources) > 0); err != nil {
 			return err
 		}
 
-		for filename, data := range rs {
+		for filename, data := range resources {
 			fulllPath := filepath.Join(outputDirectory, filename)
 
 			if err := os.MkdirAll(path.Dir(fulllPath), 0o755); err != nil {

--- a/cmd/ak/cmd/projects/projects.go
+++ b/cmd/ak/cmd/projects/projects.go
@@ -23,7 +23,7 @@ func init() {
 	// Subcommands.
 	projectsCmd.AddCommand(buildCmd)
 	projectsCmd.AddCommand(createCmd)
-	projectsCmd.AddCommand(downloadResourcesCmd)
+	projectsCmd.AddCommand(downloadCmd)
 	projectsCmd.AddCommand(getCmd)
 	projectsCmd.AddCommand(listCmd)
 }

--- a/tests/cli/projects.txt
+++ b/tests/cli/projects.txt
@@ -18,30 +18,18 @@ $ ${AK} -j p get p1; echo $?
 $ # List projects.
 $ ${AK} -j p ls
 {"project_id":"prj_00000000000000000000000001","name":"p1"}
-$ # Download resources project not found.
-$ ${AK} -j projects download-resources nonexisting -o /tmp
-Error: project nonexisting not found
-$ # Download resources project has no resources.
-$ ${AK} -j projects download-resources p1 -o /tmp
-no resources found
-$ # Set resources project not found
-$ ${AK} projects build nonexisting -f ${tmp}
-Error: project "nonexisting" not found
-$ # Set resources requires --path
-$ ${AK} projects build p1
-Error: required flag(s) "from" not set
 $ # Set resources specific file succeed
 $ ${AK} projects build p1 -f ${data_file_path}; echo $?
 build_id: bld_00000000000000000000000003
 0
 $ # Download resources succeed.
-$ ${AK} -j projects download-resources p1 -o ${tmp2}/; ls ${tmp2}/
+$ ${AK} -j projects download p1 -o ${tmp2}/; ls ${tmp2}/
 data_file
 $ # Set resources directory file succeed
 $ ${AK} projects build p1 -f ${tmp}; echo $?
 build_id: bld_00000000000000000000000004
 0
 $ # Download resources succeed.
-$ ${AK} -j projects download-resources p1 -o ${tmp2}/; ls ${tmp2}/
+$ ${AK} -j projects download p1 -o ${tmp2}/; ls ${tmp2}/
 data_file
 data_file2

--- a/tests/system/testdata/projects/build.txtar
+++ b/tests/system/testdata/projects/build.txtar
@@ -1,0 +1,42 @@
+# Precondition: create project.
+ak project create my_project
+return code == 0
+output equals 'project_id: prj_00000000000000000000000001'
+
+# Negative tests: build nonexistent project.
+ak project build bad_project --from program.star
+output equals 'Error: project not found'
+return code == 10
+
+ak project build prj_deadbeef0deadbeef0deadbeef --from program.star
+output equals 'Error: project not found'
+return code == 10
+
+# Negative test: build project without required flag.
+ak project build my_project
+output equals 'Error: required flag(s) "from" not set'
+return code == 1
+
+# Build project from a single file.
+ak project build my_project --from single_file
+return code == 0
+
+# Build project from a directory tree with multiple files.
+ak project build my_project --from directory
+return code == 0
+
+# Build project from both, alongside each other.
+ak project build my_project --from single_file --from directory
+return code == 0
+
+-- single_file --
+print("single_file")
+
+-- directory/file1.star --
+print("directory/file1.star")
+
+-- directory/subdirectory/file1.star --
+print("directory/subdirectory/file1.star")
+
+-- directory/subdirectory/file2.star --
+print("directory/subdirectory/file2.star")

--- a/tests/system/testdata/projects/download.txtar
+++ b/tests/system/testdata/projects/download.txtar
@@ -1,0 +1,38 @@
+# Precondition: create project.
+ak project create my_project
+return code == 0
+output equals 'project_id: prj_00000000000000000000000001'
+
+# Negative tests: download resources of nonexistent project, with/out --fail flag.
+ak project download bad_project
+output equals 'Error: project not found'
+return code == 10
+
+ak project download prj_deadbeef0deadbeef0deadbeef
+output equals 'Error: project not found'
+return code == 10
+
+ak project download bad_project --fail
+output equals 'Error: project not found'
+return code == 10
+
+ak project download prj_deadbeef0deadbeef0deadbeef --fail
+output equals 'Error: project not found'
+return code == 10
+
+# Negative tests: download nonexistent resources of existing project, with/out --fail flag.
+ak project download my_project
+return code == 0
+output equals ''
+
+ak project download prj_00000000000000000000000001
+return code == 0
+output equals ''
+
+ak project download my_project --fail
+output equals 'Error: resources not found'
+return code == 10
+
+ak project download prj_00000000000000000000000001 --fail
+output equals 'Error: resources not found'
+return code == 10

--- a/tests/system/testdata/workflows/builtin_funcs.txtar
+++ b/tests/system/testdata/workflows/builtin_funcs.txtar
@@ -3,10 +3,7 @@
 ak manifest apply project.yaml
 return code == 0
 
-ak project set-resources my_project --path my_program.star
-return code == 0
-
-ak project build my_project
+ak project build my_project --from my_program.star
 return code == 0
 output equals 'build_id: bld_00000000000000000000000005'
 


### PR DESCRIPTION
This makes sense because resources are a property of projects, as opposed to builds, so this command won't be confused with the "build download" command.

En passant:
- Fix project check (checking the resolver's returned ID is not enough)
- Replace `fmt.Errorf` with `--fail` (commands shouldn't write to stdout/stderr directly anyway)
- Move some tests of `project build` and `project download` to system tests