### PR TITLE
fold sdkvalues into sdktypes

### DIFF
--- a/cmd/ak/cmd/events/events.go
+++ b/cmd/ak/cmd/events/events.go
@@ -10,7 +10,7 @@ import (
 	"go.autokitteh.dev/autokitteh/cmd/ak/common"
 	valuesv1 "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/values/v1"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 // Flags shared by the "create", "dispatch", and "list" subcommands.
@@ -53,7 +53,7 @@ func parseDataKeyValue(kv string) (string, *valuesv1.Value, error) {
 		return "", nil, fmt.Errorf(`invalid data pair %q, expected "key=value"`, kv)
 	}
 
-	vw := sdkvalues.ValueWrapper{}
+	vw := sdktypes.ValueWrapper{}
 	value, err := vw.Wrap(v)
 	if err != nil {
 		return "", nil, fmt.Errorf("invalid data value %q: %w", v, err)

--- a/integrations/aws/import.go
+++ b/integrations/aws/import.go
@@ -15,7 +15,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdklogger"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 func getAWSConfig(cfg []byte) (*aws.Config, error) {
@@ -125,7 +124,7 @@ func importServiceMethods(moduleName string, connect any) ([]sdkmodule.Optfn, er
 				return sdktypes.InvalidValue, fmt.Errorf("invalid error return")
 			}
 
-			out, err := sdkvalues.Wrap(outv.Interface())
+			out, err := sdktypes.WrapValue(outv.Interface())
 			if err != nil {
 				return sdktypes.InvalidValue, fmt.Errorf("return value conversion error: %w", err)
 			}

--- a/integrations/chatgpt/impl.go
+++ b/integrations/chatgpt/impl.go
@@ -8,7 +8,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 const (
@@ -59,7 +58,7 @@ func (i integration) createChatCompletion(ctx context.Context, args []sdktypes.V
 	resp, err := client.CreateChatCompletion(ctx, req)
 	if err != nil {
 		jsonResp := ChatCompletionResponse{Error: err.Error()}
-		return sdkvalues.Wrap(jsonResp)
+		return sdktypes.WrapValue(jsonResp)
 	}
 
 	// Parse and return the response.
@@ -78,7 +77,7 @@ func (i integration) createChatCompletion(ctx context.Context, args []sdktypes.V
 			FinishReason: string(c.FinishReason),
 		})
 	}
-	return sdkvalues.Wrap(jsonResp)
+	return sdktypes.WrapValue(jsonResp)
 }
 
 // Workaround for a JSON conversion issue in the client library,

--- a/integrations/github/actions.go
+++ b/integrations/github/actions.go
@@ -7,7 +7,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository
@@ -43,5 +42,5 @@ func (i integration) listWorkflowRuns(ctx context.Context, args []sdktypes.Value
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(c)
+	return sdktypes.WrapValue(c)
 }

--- a/integrations/github/commits.go
+++ b/integrations/github/commits.go
@@ -7,7 +7,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://docs.github.com/en/rest/commits/commits#list-commits
@@ -37,5 +36,5 @@ func (i integration) listCommits(ctx context.Context, args []sdktypes.Value, kwa
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }

--- a/integrations/github/git_refs.go
+++ b/integrations/github/git_refs.go
@@ -7,7 +7,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://docs.github.com/en/rest/git/refs#create-a-reference
@@ -42,7 +41,7 @@ func (i integration) createRef(ctx context.Context, args []sdktypes.Value, kwarg
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(c)
+	return sdktypes.WrapValue(c)
 }
 
 // https://docs.github.com/en/rest/git/refs#get-a-reference
@@ -69,5 +68,5 @@ func (i integration) getRef(ctx context.Context, args []sdktypes.Value, kwargs m
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(c)
+	return sdktypes.WrapValue(c)
 }

--- a/integrations/github/issue_comments.go
+++ b/integrations/github/issue_comments.go
@@ -7,7 +7,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://docs.github.com/en/rest/issues/comments#create-an-issue-comment
@@ -41,5 +40,5 @@ func (i integration) createIssueComment(ctx context.Context, args []sdktypes.Val
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(c)
+	return sdktypes.WrapValue(c)
 }

--- a/integrations/github/issue_labels.go
+++ b/integrations/github/issue_labels.go
@@ -5,7 +5,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 func (i integration) addIssueLabels(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
@@ -34,7 +33,7 @@ func (i integration) addIssueLabels(ctx context.Context, args []sdktypes.Value, 
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(c)
+	return sdktypes.WrapValue(c)
 }
 
 func (i integration) removeIssueLabel(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
@@ -62,5 +61,5 @@ func (i integration) removeIssueLabel(ctx context.Context, args []sdktypes.Value
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(c)
+	return sdktypes.WrapValue(c)
 }

--- a/integrations/github/issues.go
+++ b/integrations/github/issues.go
@@ -7,7 +7,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://docs.github.com/en/rest/issues/issues#create-an-issue
@@ -40,7 +39,7 @@ func (i integration) createIssue(ctx context.Context, args []sdktypes.Value, kwa
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://docs.github.com/en/rest/issues/issues#get-an-issue
@@ -69,7 +68,7 @@ func (i integration) getIssue(ctx context.Context, args []sdktypes.Value, kwargs
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://docs.github.com/en/rest/issues/issues#update-an-issue
@@ -108,7 +107,7 @@ func (i integration) updateIssue(ctx context.Context, args []sdktypes.Value, kwa
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://docs.github.com/en/rest/issues/issues#list-repository-issues
@@ -147,5 +146,5 @@ func (i integration) listRepositoryIssues(ctx context.Context, args []sdktypes.V
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(is)
+	return sdktypes.WrapValue(is)
 }

--- a/integrations/github/pulls.go
+++ b/integrations/github/pulls.go
@@ -7,7 +7,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
@@ -37,7 +36,7 @@ func (i integration) getPullRequest(ctx context.Context, args []sdktypes.Value, 
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(pr)
+	return sdktypes.WrapValue(pr)
 }
 
 // https://docs.github.com/en/rest/pulls/pulls#list-pull-requests
@@ -86,7 +85,7 @@ func (i integration) listPullRequests(ctx context.Context, args []sdktypes.Value
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(prs)
+	return sdktypes.WrapValue(prs)
 }
 
 // https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
@@ -136,7 +135,7 @@ func (i integration) createPullRequest(ctx context.Context, args []sdktypes.Valu
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(pr)
+	return sdktypes.WrapValue(pr)
 }
 
 // https://docs.github.com/en/rest/pulls/review-requests#request-reviewers-for-a-pull-request
@@ -169,5 +168,5 @@ func (i integration) requestReview(ctx context.Context, args []sdktypes.Value, k
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(pr)
+	return sdktypes.WrapValue(pr)
 }

--- a/integrations/github/pulls_comments.go
+++ b/integrations/github/pulls_comments.go
@@ -8,7 +8,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://docs.github.com/en/rest/pulls/comments#list-review-comments-on-a-pull-request
@@ -59,5 +58,5 @@ func (i integration) listPullRequestReviewComments(ctx context.Context, args []s
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(cs)
+	return sdktypes.WrapValue(cs)
 }

--- a/integrations/github/reactions.go
+++ b/integrations/github/reactions.go
@@ -5,7 +5,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://docs.github.com/en/rest/reactions/reactions#create-reaction-for-a-commit-comment
@@ -35,7 +34,7 @@ func (i integration) createReactionForCommitComment(ctx context.Context, args []
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(r)
+	return sdktypes.WrapValue(r)
 }
 
 // https://docs.github.com/en/rest/reactions/reactions#create-reaction-for-an-issue
@@ -65,7 +64,7 @@ func (i integration) createReactionForIssue(ctx context.Context, args []sdktypes
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(r)
+	return sdktypes.WrapValue(r)
 }
 
 // https://docs.github.com/en/rest/reactions/reactions#create-reaction-for-an-issue-comment
@@ -94,7 +93,7 @@ func (i integration) createReactionForIssueComment(ctx context.Context, args []s
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(r)
+	return sdktypes.WrapValue(r)
 }
 
 // https://docs.github.com/en/rest/reactions/reactions#create-reaction-for-a-pull-request-review-comment
@@ -124,5 +123,5 @@ func (i integration) createReactionForPullRequestReviewComment(ctx context.Conte
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(r)
+	return sdktypes.WrapValue(r)
 }

--- a/integrations/github/repo.go
+++ b/integrations/github/repo.go
@@ -7,7 +7,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://docs.github.com/en/rest/collaborators/collaborators#list-repository-collaborators
@@ -37,5 +36,5 @@ func (i integration) listCollaborators(ctx context.Context, args []sdktypes.Valu
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(c)
+	return sdktypes.WrapValue(c)
 }

--- a/integrations/github/repository_content.go
+++ b/integrations/github/repository_content.go
@@ -7,7 +7,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents
@@ -66,7 +65,7 @@ func (i integration) createOrUpdateFile(ctx context.Context, args []sdktypes.Val
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(c)
+	return sdktypes.WrapValue(c)
 }
 
 // https://docs.github.com/en/rest/repos/contents#get-repository-content
@@ -103,5 +102,5 @@ func (i integration) getContents(ctx context.Context, args []sdktypes.Value, kwa
 		directoryContent = []*github.RepositoryContent{fileContent}
 	}
 
-	return sdkvalues.Wrap(directoryContent)
+	return sdktypes.WrapValue(directoryContent)
 }

--- a/integrations/github/users.go
+++ b/integrations/github/users.go
@@ -5,7 +5,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://docs.github.com/en/rest/users#get-a-user
@@ -28,5 +27,5 @@ func (i integration) getUser(ctx context.Context, args []sdktypes.Value, kwargs 
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }

--- a/integrations/github/webhooks/webhook.go
+++ b/integrations/github/webhooks/webhook.go
@@ -17,7 +17,6 @@ import (
 	valuesv1 "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/values/v1"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 
 	"go.autokitteh.dev/autokitteh/integrations/internal/extrazap"
 )
@@ -180,7 +179,7 @@ func extractInstallationID(l *zap.Logger, event any, eventType string) string {
 
 // transformEvent transforms a received GitHub event into an autokitteh event.
 func transformEvent(l *zap.Logger, w http.ResponseWriter, event any) (map[string]*valuesv1.Value, error) {
-	wrapped, err := sdkvalues.DefaultValueWrapper.Wrap(event)
+	wrapped, err := sdktypes.DefaultValueWrapper.Wrap(event)
 	if err != nil {
 		l.Error("Failed to wrap GitHub event",
 			zap.Error(err),

--- a/integrations/google/gmail/drafts.go
+++ b/integrations/google/gmail/drafts.go
@@ -9,7 +9,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.drafts/create
@@ -48,7 +47,7 @@ func (a api) draftsCreate(ctx context.Context, args []sdktypes.Value, kwargs map
 		draft,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.drafts/delete
@@ -75,7 +74,7 @@ func (a api) draftsDelete(ctx context.Context, args []sdktypes.Value, kwargs map
 	if err == nil {
 		err = errors.New("")
 	}
-	return sdkvalues.Wrap(err)
+	return sdktypes.WrapValue(err)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.drafts/get
@@ -113,7 +112,7 @@ func (a api) draftsGet(ctx context.Context, args []sdktypes.Value, kwargs map[st
 		draft,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.drafts/list
@@ -157,7 +156,7 @@ func (a api) draftsList(ctx context.Context, args []sdktypes.Value, kwargs map[s
 		drafts,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.drafts/send
@@ -196,7 +195,7 @@ func (a api) draftsSend(ctx context.Context, args []sdktypes.Value, kwargs map[s
 		msg,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.drafts/update
@@ -236,5 +235,5 @@ func (a api) draftsUpdate(ctx context.Context, args []sdktypes.Value, kwargs map
 		draft,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }

--- a/integrations/google/gmail/labels.go
+++ b/integrations/google/gmail/labels.go
@@ -8,7 +8,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.labels/create
@@ -45,7 +44,7 @@ func (a api) labelsCreate(ctx context.Context, args []sdktypes.Value, kwargs map
 		label,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.labels/delete
@@ -72,7 +71,7 @@ func (a api) labelsDelete(ctx context.Context, args []sdktypes.Value, kwargs map
 	if err == nil {
 		err = errors.New("")
 	}
-	return sdkvalues.Wrap(err)
+	return sdktypes.WrapValue(err)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.labels/get
@@ -109,7 +108,7 @@ func (a api) labelsGet(ctx context.Context, args []sdktypes.Value, kwargs map[st
 		label,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.labels/list
@@ -140,7 +139,7 @@ func (a api) labelsList(ctx context.Context, args []sdktypes.Value, kwargs map[s
 		labels,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.labels/patch
@@ -179,7 +178,7 @@ func (a api) labelsPatch(ctx context.Context, args []sdktypes.Value, kwargs map[
 		label,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.labels/update
@@ -218,5 +217,5 @@ func (a api) labelsUpdate(ctx context.Context, args []sdktypes.Value, kwargs map
 		label,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }

--- a/integrations/google/gmail/messages.go
+++ b/integrations/google/gmail/messages.go
@@ -9,7 +9,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.messages/batchModify
@@ -42,7 +41,7 @@ func (a api) messagesBatchModify(ctx context.Context, args []sdktypes.Value, kwa
 	if err == nil {
 		err = errors.New("")
 	}
-	return sdkvalues.Wrap(err)
+	return sdktypes.WrapValue(err)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.messages/get
@@ -83,7 +82,7 @@ func (a api) messagesGet(ctx context.Context, args []sdktypes.Value, kwargs map[
 		msg,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.messages/import
@@ -131,7 +130,7 @@ func (a api) messagesImport(ctx context.Context, args []sdktypes.Value, kwargs m
 		msg,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.messages/insert
@@ -175,7 +174,7 @@ func (a api) messagesInsert(ctx context.Context, args []sdktypes.Value, kwargs m
 		msg,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.messages/list
@@ -221,7 +220,7 @@ func (a api) messagesList(ctx context.Context, args []sdktypes.Value, kwargs map
 		msgs,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.messages/modify
@@ -265,7 +264,7 @@ func (a api) messagesModify(ctx context.Context, args []sdktypes.Value, kwargs m
 		msg,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.messages/send
@@ -304,7 +303,7 @@ func (a api) messagesSend(ctx context.Context, args []sdktypes.Value, kwargs map
 		msg,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.messages/trash
@@ -341,7 +340,7 @@ func (a api) messagesTrash(ctx context.Context, args []sdktypes.Value, kwargs ma
 		msg,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.messages/untrash
@@ -378,7 +377,7 @@ func (a api) messagesUntrash(ctx context.Context, args []sdktypes.Value, kwargs 
 		msg,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.messages.attachments/get
@@ -416,5 +415,5 @@ func (a api) messagesAttachmentsGet(ctx context.Context, args []sdktypes.Value, 
 		mpb,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }

--- a/integrations/google/gmail/misc.go
+++ b/integrations/google/gmail/misc.go
@@ -8,7 +8,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users/getProfile
@@ -34,7 +33,7 @@ func (a api) getProfile(ctx context.Context, args []sdktypes.Value, kwargs map[s
 		profile,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // TODO: https://developers.google.com/gmail/api/reference/rest/v1/users/history/list
@@ -82,5 +81,5 @@ func (a api) historyList(ctx context.Context, args []sdktypes.Value, kwargs map[
 		history,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }

--- a/integrations/google/gmail/threads.go
+++ b/integrations/google/gmail/threads.go
@@ -8,7 +8,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.threads/get
@@ -49,7 +48,7 @@ func (a api) threadsGet(ctx context.Context, args []sdktypes.Value, kwargs map[s
 		thread,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.threads/list
@@ -95,7 +94,7 @@ func (a api) threadsList(ctx context.Context, args []sdktypes.Value, kwargs map[
 		threads,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.threads/modify
@@ -139,7 +138,7 @@ func (a api) threadsModify(ctx context.Context, args []sdktypes.Value, kwargs ma
 		thread,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.threads/trash
@@ -176,7 +175,7 @@ func (a api) threadsTrash(ctx context.Context, args []sdktypes.Value, kwargs map
 		thread,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // https://developers.google.com/gmail/api/reference/rest/v1/users.threads/untrash
@@ -213,5 +212,5 @@ func (a api) threadsUntrash(ctx context.Context, args []sdktypes.Value, kwargs m
 		thread,
 		err.Error(),
 	}
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }

--- a/integrations/google/sheets/methods.go
+++ b/integrations/google/sheets/methods.go
@@ -11,7 +11,6 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://developers.google.com/sheets/api/guides/concepts#expandable-1
@@ -41,7 +40,7 @@ func (a api) a1Range(ctx context.Context, args []sdktypes.Value, kwargs map[stri
 		r = fmt.Sprintf("'%s'", sheetName)
 		if from == "" && to == "" {
 			// Example: "Sheet1" - all the cells in "Sheet1".
-			return sdkvalues.Wrap(r)
+			return sdktypes.WrapValue(r)
 		}
 		r += "!" // Possible to specify to/from cells without a sheet name.
 	}
@@ -49,7 +48,7 @@ func (a api) a1Range(ctx context.Context, args []sdktypes.Value, kwargs map[stri
 	if to != "" {
 		r = fmt.Sprintf("%s:%s", r, to)
 	}
-	return sdkvalues.Wrap(r)
+	return sdktypes.WrapValue(r)
 }
 
 // Read a single cell.
@@ -137,7 +136,7 @@ func (a api) readRange(ctx context.Context, args []sdktypes.Value, kwargs map[st
 			resp.Values[i] = append(resp.Values[i], "")
 		}
 	}
-	return sdkvalues.Wrap(resp.Values)
+	return sdktypes.WrapValue(resp.Values)
 }
 
 // Write a single cell.
@@ -173,7 +172,7 @@ func (a api) writeCell(ctx context.Context, args []sdktypes.Value, kwargs map[st
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
-	data, err := sdkvalues.Wrap([][]any{{value}})
+	data, err := sdktypes.WrapValue([][]any{{value}})
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -212,7 +211,7 @@ func (a api) writeRange(ctx context.Context, args []sdktypes.Value, kwargs map[s
 		}
 		cols := row.GetList().Values()
 		return kittehs.TransformError(cols, func(col sdktypes.Value) (any, error) {
-			return sdkvalues.Unwrap(col)
+			return col.Unwrap()
 		})
 	})
 	if err != nil {
@@ -234,7 +233,7 @@ func (a api) writeRange(ctx context.Context, args []sdktypes.Value, kwargs map[s
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // Set the background color in a range of cells.
@@ -295,7 +294,7 @@ func (a api) setBackgroundColor(ctx context.Context, args []sdktypes.Value, kwar
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // Set the text format in a range of cells.
@@ -366,5 +365,5 @@ func (a api) setTextFormat(ctx context.Context, args []sdktypes.Value, kwargs ma
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }

--- a/integrations/grpc/module.go
+++ b/integrations/grpc/module.go
@@ -1,7 +1,7 @@
 package grpc
 
 /*
-var safeForJsonWrapper = sdkvalues.ValueWrapper{SafeForJSON: true}
+var safeForJsonWrapper = sdktypes.ValueWrapper{SafeForJSON: true}
 
 func parsePayload(args []sdktypes.Value, kwargs map[string]sdktypes.Value) (map[string]any, error) {
 	if len(args) > 1 {
@@ -59,7 +59,7 @@ func createGRPCCallWrapper(functionName string) sdkexecutor.Function {
 			return nil, err
 		}
 
-		return sdkvalues.DefaultValueWrapper.Wrap(res)
+		return sdktypes.DefaultValueWrapper.Wrap(res)
 	}
 }
 
@@ -101,7 +101,7 @@ func newGRPCModule(xid sdktypes.ExecutorID) sdkmodule.Module {
 
 	for _, f := range fns {
 		opts = append(opts, kittehs.Transform(f.Constants, func(c string) sdkmodule.Optfn {
-			return sdkmodule.ExportValue(c, sdkmodule.WithValue(kittehs.Must1(sdkvalues.Wrap(c))))
+			return sdkmodule.ExportValue(c, sdkmodule.WithValue(kittehs.Must1(sdktypes.WrapValue(c))))
 		})...)
 	}
 

--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -19,7 +19,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkexecutor"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // TODO(ENG-242): limit outreach ("RequestGuard" at https://github.com/qri-io/starlib/blob/master/http/http.go#L59)
@@ -151,7 +150,7 @@ func setBody(req *http.Request, rawBody string, formBody map[string]string, cont
 
 		req.Header.Set("Content-Type", contentType)
 
-		v, err := sdkvalues.ValueWrapper{SafeForJSON: true}.Unwrap(jsonBody)
+		v, err := sdktypes.ValueWrapper{SafeForJSON: true}.Unwrap(jsonBody)
 		if err != nil {
 			return err
 		}
@@ -230,7 +229,7 @@ func toStruct(r *http.Response) (sdktypes.Value, error) {
 	)
 
 	if err := json.Unmarshal(body, &data); err == nil {
-		jsonValue, _ = sdkvalues.Wrap(data)
+		jsonValue, _ = sdktypes.WrapValue(data)
 	}
 
 	if !jsonValue.IsValid() {

--- a/integrations/redis/utils.go
+++ b/integrations/redis/utils.go
@@ -9,11 +9,10 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 func unwrap(v sdktypes.Value) (any, error) {
-	u, err := sdkvalues.DefaultValueWrapper.Unwrap(v)
+	u, err := sdktypes.DefaultValueWrapper.Unwrap(v)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +54,7 @@ func returnCmd[R any, C resulter[R]](cmd C) (sdktypes.Value, error) {
 		return sdktypes.InvalidValue, err
 	}
 
-	wrapped, err := sdkvalues.DefaultValueWrapper.Wrap(ret)
+	wrapped, err := sdktypes.DefaultValueWrapper.Wrap(ret)
 	if err != nil {
 		return sdktypes.InvalidValue, fmt.Errorf("wrap: %w", err)
 	}

--- a/integrations/scheduler/scheduler.go
+++ b/integrations/scheduler/scheduler.go
@@ -12,7 +12,6 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 const (
@@ -114,7 +113,7 @@ func dispatchEvents(ctx context.Context, l *zap.Logger, d sdkservices.Dispatcher
 			Second: now.Second(),
 		}
 
-		wrapped, err := sdkvalues.DefaultValueWrapper.Wrap(e)
+		wrapped, err := sdktypes.DefaultValueWrapper.Wrap(e)
 		if err != nil {
 			l.Error("Failed to wrap cron event",
 				zap.Any("event", e),

--- a/integrations/slack/api/auth/methods.go
+++ b/integrations/slack/api/auth/methods.go
@@ -5,7 +5,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 
 	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 )
@@ -27,7 +26,7 @@ func (a API) Test(ctx context.Context, args []sdktypes.Value, kwargs map[string]
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // TestWithToken is only used internally, when the context doesn't store a

--- a/integrations/slack/api/bookmarks/methods.go
+++ b/integrations/slack/api/bookmarks/methods.go
@@ -6,7 +6,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 
 	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 )
@@ -46,7 +45,7 @@ func (a API) Add(ctx context.Context, args []sdktypes.Value, kwargs map[string]s
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // Edit a bookmark in a channel.
@@ -77,7 +76,7 @@ func (a API) Edit(ctx context.Context, args []sdktypes.Value, kwargs map[string]
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // List bookmarks for a channel.
@@ -104,7 +103,7 @@ func (a API) List(ctx context.Context, args []sdktypes.Value, kwargs map[string]
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // Remove a bookmark from a channel.
@@ -133,5 +132,5 @@ func (a API) Remove(ctx context.Context, args []sdktypes.Value, kwargs map[strin
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }

--- a/integrations/slack/api/chat/methods.go
+++ b/integrations/slack/api/chat/methods.go
@@ -6,7 +6,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 
 	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 )
@@ -48,7 +47,7 @@ func (a API) Delete(ctx context.Context, args []sdktypes.Value, kwargs map[strin
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // PostEphemeral sends an ephemeral message to a user in a group/channel
@@ -94,7 +93,7 @@ func (a API) PostEphemeral(ctx context.Context, args []sdktypes.Value, kwargs ma
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // PostMessage sends a message to a user/group/channel. For text formatting
@@ -133,7 +132,7 @@ func (a API) PostMessage(ctx context.Context, args []sdktypes.Value, kwargs map[
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // Update an existing message sent by the caller. For text formatting tips,
@@ -172,7 +171,7 @@ func (a API) Update(ctx context.Context, args []sdktypes.Value, kwargs map[strin
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // SendTextMessage sends a message to a user/group/channel. For text formatting
@@ -203,7 +202,7 @@ func (a API) SendTextMessage(ctx context.Context, args []sdktypes.Value, kwargs 
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // SendApprovalMessage sends an interactive message to a user/group/channel,
@@ -296,5 +295,5 @@ func (a API) SendApprovalMessage(ctx context.Context, args []sdktypes.Value, kwa
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }

--- a/integrations/slack/api/conversations/methods.go
+++ b/integrations/slack/api/conversations/methods.go
@@ -8,7 +8,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 
 	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 )
@@ -45,7 +44,7 @@ func (a API) Archive(ctx context.Context, args []sdktypes.Value, kwargs map[stri
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // Close a direct message or multi-person direct message.
@@ -75,7 +74,7 @@ func (a API) Close(ctx context.Context, args []sdktypes.Value, kwargs map[string
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // Create initiates a public or private channel-based conversation.
@@ -110,7 +109,7 @@ func (a API) Create(ctx context.Context, args []sdktypes.Value, kwargs map[strin
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // History returns the history of a conversation's (channel's)
@@ -147,7 +146,7 @@ func (a API) History(ctx context.Context, args []sdktypes.Value, kwargs map[stri
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // Info returns information about a conversation (channel).
@@ -191,7 +190,7 @@ func (a API) Info(ctx context.Context, args []sdktypes.Value, kwargs map[string]
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // Invite invites users to a channel.
@@ -226,7 +225,7 @@ func (a API) Invite(ctx context.Context, args []sdktypes.Value, kwargs map[strin
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // List lists all the channels in a Slack team.
@@ -281,7 +280,7 @@ func (a API) List(ctx context.Context, args []sdktypes.Value, kwargs map[string]
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // Members retrieves all the members of a conversation (channel).
@@ -325,7 +324,7 @@ func (a API) Members(ctx context.Context, args []sdktypes.Value, kwargs map[stri
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // Open opens or resumes a direct message or multi-person direct message.
@@ -357,7 +356,7 @@ func (a API) Open(ctx context.Context, args []sdktypes.Value, kwargs map[string]
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // Rename a conversation (channel).
@@ -391,7 +390,7 @@ func (a API) Rename(ctx context.Context, args []sdktypes.Value, kwargs map[strin
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // Replies retrieves a thread of messages posted to a conversation (channel).
@@ -454,7 +453,7 @@ func (a API) Replies(ctx context.Context, args []sdktypes.Value, kwargs map[stri
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // SetPurpose sets the purpose (description) for a conversation (channel).
@@ -488,7 +487,7 @@ func (a API) SetPurpose(ctx context.Context, args []sdktypes.Value, kwargs map[s
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // SetTopic sets the topic for a conversation (channel).
@@ -522,7 +521,7 @@ func (a API) SetTopic(ctx context.Context, args []sdktypes.Value, kwargs map[str
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // Unarchive reverses conversation (channel) archival.
@@ -552,5 +551,5 @@ func (a API) Unarchive(ctx context.Context, args []sdktypes.Value, kwargs map[st
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }

--- a/integrations/slack/api/reactions/methods.go
+++ b/integrations/slack/api/reactions/methods.go
@@ -6,7 +6,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 
 	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 )
@@ -47,5 +46,5 @@ func (a API) Add(ctx context.Context, args []sdktypes.Value, kwargs map[string]s
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }

--- a/integrations/slack/api/users/methods.go
+++ b/integrations/slack/api/users/methods.go
@@ -8,7 +8,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 
 	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 )
@@ -46,7 +45,7 @@ func (a API) GetPresence(ctx context.Context, args []sdktypes.Value, kwargs map[
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // Info returns information about a user based on their Slack user ID, e.g.
@@ -82,7 +81,7 @@ func (a API) Info(ctx context.Context, args []sdktypes.Value, kwargs map[string]
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // List returns information about all active and inactive users and apps/bots.
@@ -128,7 +127,7 @@ func (a API) List(ctx context.Context, args []sdktypes.Value, kwargs map[string]
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }
 
 // LookupByEmail returns information about a user based on their email address,
@@ -156,5 +155,5 @@ func (a API) LookupByEmail(ctx context.Context, args []sdktypes.Value, kwargs ma
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }

--- a/integrations/slack/webhooks/bot_events.go
+++ b/integrations/slack/webhooks/bot_events.go
@@ -9,7 +9,6 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	valuesv1 "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/values/v1"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 
 	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 	"go.autokitteh.dev/autokitteh/integrations/slack/events"
@@ -130,7 +129,7 @@ func (h handler) HandleBotEvent(w http.ResponseWriter, r *http.Request) {
 
 // transformEvent transforms a received Slack event into an autokitteh event.
 func transformEvent(l *zap.Logger, w http.ResponseWriter, event any) (map[string]*valuesv1.Value, error) {
-	wrapped, err := sdkvalues.DefaultValueWrapper.Wrap(event)
+	wrapped, err := sdktypes.DefaultValueWrapper.Wrap(event)
 	if err != nil {
 		l.Error("Failed to wrap Slack event",
 			zap.Error(err),

--- a/integrations/slack/webhooks/interaction.go
+++ b/integrations/slack/webhooks/interaction.go
@@ -14,7 +14,6 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	valuesv1 "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/values/v1"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 
 	"go.autokitteh.dev/autokitteh/integrations/internal/extrazap"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api"
@@ -184,7 +183,7 @@ func (h handler) HandleInteraction(w http.ResponseWriter, r *http.Request) {
 
 // transformPayload transforms a received Slack event into an autokitteh event.
 func transformPayload(l *zap.Logger, w http.ResponseWriter, payload *BlockActionsPayload) (map[string]*valuesv1.Value, error) {
-	wrapped, err := sdkvalues.DefaultValueWrapper.Wrap(payload)
+	wrapped, err := sdktypes.DefaultValueWrapper.Wrap(payload)
 	if err != nil {
 		l.Error("Failed to wrap Slack event",
 			zap.Error(err),

--- a/integrations/slack/webhooks/slash_command.go
+++ b/integrations/slack/webhooks/slash_command.go
@@ -11,7 +11,6 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	valuesv1 "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/values/v1"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 
 	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 )
@@ -145,7 +144,7 @@ func (h handler) HandleSlashCommand(w http.ResponseWriter, r *http.Request) {
 
 // transformCommand transforms a received Slack event into an autokitteh event.
 func transformCommand(l *zap.Logger, w http.ResponseWriter, cmd SlashCommand) (map[string]*valuesv1.Value, error) {
-	wrapped, err := sdkvalues.DefaultValueWrapper.Wrap(cmd)
+	wrapped, err := sdktypes.DefaultValueWrapper.Wrap(cmd)
 	if err != nil {
 		l.Error("Failed to wrap Slack event",
 			zap.Error(err),

--- a/integrations/twilio/twilio.go
+++ b/integrations/twilio/twilio.go
@@ -9,7 +9,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // https://www.twilio.com/docs/messaging/api/message-resource#create-a-message-resource
@@ -72,5 +71,5 @@ func (i integration) createMessage(ctx context.Context, args []sdktypes.Value, k
 	}
 
 	// Parse and return the response.
-	return sdkvalues.Wrap(resp)
+	return sdktypes.WrapValue(resp)
 }

--- a/internal/backend/akmodules/time/time.go
+++ b/internal/backend/akmodules/time/time.go
@@ -13,7 +13,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkexecutor"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 func New() sdkexecutor.Executor {
@@ -96,7 +95,7 @@ func parseTime(_ context.Context, args []sdktypes.Value, kwargs map[string]sdkty
 	if location == "" && format == "" {
 		var t time.Time
 
-		if err := sdkvalues.DefaultValueWrapper.UnwrapInto(&t, args[0]); err != nil {
+		if err := sdktypes.DefaultValueWrapper.UnwrapInto(&t, args[0]); err != nil {
 			return sdktypes.InvalidValue, err
 		}
 

--- a/internal/backend/sessions/sessionworkflows/syscalls.go
+++ b/internal/backend/sessions/sessionworkflows/syscalls.go
@@ -12,7 +12,6 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 const (
@@ -32,7 +31,7 @@ func (w *sessionWorkflow) syscall(ctx context.Context, args []sdktypes.Value, kw
 
 	var op string
 
-	if err := sdkvalues.DefaultValueWrapper.UnwrapInto(&op, args[0]); err != nil {
+	if err := sdktypes.DefaultValueWrapper.UnwrapInto(&op, args[0]); err != nil {
 		return sdktypes.InvalidValue, err
 	}
 
@@ -186,7 +185,7 @@ func (w *sessionWorkflow) subscribe(ctx context.Context, args []sdktypes.Value, 
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.DefaultValueWrapper.Wrap(signalID)
+	return sdktypes.DefaultValueWrapper.Wrap(signalID)
 }
 
 /*
@@ -220,7 +219,7 @@ func (w *sessionWorkflow) nextEvent(ctx context.Context, args []sdktypes.Value, 
 			return sdktypes.InvalidValue, err
 		}
 		if event != nil {
-			return sdkvalues.DefaultValueWrapper.Wrap(event)
+			return sdktypes.DefaultValueWrapper.Wrap(event)
 		}
 	}
 
@@ -242,7 +241,7 @@ func (w *sessionWorkflow) nextEvent(ctx context.Context, args []sdktypes.Value, 
 		return sdktypes.InvalidValue, fmt.Errorf("no event received")
 	}
 
-	return sdkvalues.DefaultValueWrapper.Wrap(event)
+	return sdktypes.DefaultValueWrapper.Wrap(event)
 }
 
 func (w *sessionWorkflow) unsubscribe(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {

--- a/internal/backend/store/store.go
+++ b/internal/backend/store/store.go
@@ -15,7 +15,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 type Config struct {
@@ -113,7 +112,7 @@ func (s *store) Get(ctx context.Context, envID sdktypes.EnvID, projectID sdktype
 
 	m := make(map[string]sdktypes.Value, len(vs))
 	for i, k := range keys {
-		if m[k], err = sdkvalues.DefaultValueWrapper.Wrap(vs[i]); err != nil {
+		if m[k], err = sdktypes.DefaultValueWrapper.Wrap(vs[i]); err != nil {
 			return nil, fmt.Errorf("wrap #%d: %w", i, err)
 		}
 	}

--- a/runtimes/configrt/parsers/parsers.go
+++ b/runtimes/configrt/parsers/parsers.go
@@ -14,7 +14,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 var (
@@ -45,7 +44,7 @@ func ParseJSON(r io.Reader) (sdktypes.Value, error) {
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.DefaultValueWrapper.Wrap(m)
+	return sdktypes.DefaultValueWrapper.Wrap(m)
 }
 
 func ParseRawJSON(r io.Reader) (sdktypes.Value, error) {
@@ -70,7 +69,7 @@ func ParseYAML(r io.Reader) (sdktypes.Value, error) {
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.DefaultValueWrapper.Wrap(m)
+	return sdktypes.DefaultValueWrapper.Wrap(m)
 }
 
 func ParseRawYAML(r io.Reader) (sdktypes.Value, error) {
@@ -95,7 +94,7 @@ func ParseXML(r io.Reader) (sdktypes.Value, error) {
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdkvalues.DefaultValueWrapper.Wrap(m)
+	return sdktypes.DefaultValueWrapper.Wrap(m)
 }
 
 func ParseText(r io.Reader) (sdktypes.Value, error) {
@@ -115,7 +114,7 @@ func ParseCSV(r io.Reader) (sdktypes.Value, error) {
 		return sdktypes.InvalidValue, err
 	}
 
-	v := kittehs.Must1(sdkvalues.DefaultValueWrapper.Wrap(rs))
+	v := kittehs.Must1(sdktypes.DefaultValueWrapper.Wrap(rs))
 
 	return sdktypes.NewDictValueFromStringMap(map[string]sdktypes.Value{
 		"data": v,

--- a/sdk/sdkmodule/unpack.go
+++ b/sdk/sdkmodule/unpack.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 // UnpackArgs unpacks the positional and keyword arguments into the supplied parameter
@@ -53,14 +52,14 @@ func UnpackArgs(args []sdktypes.Value, kwargs map[string]sdktypes.Value, dsts ..
 		}
 
 		if strings.HasPrefix(name, "**") {
-			if err := sdkvalues.DefaultValueWrapper.UnwrapInto(dst, sdktypes.NewDictValueFromStringMap(kwargs)); err != nil {
+			if err := sdktypes.DefaultValueWrapper.UnwrapInto(dst, sdktypes.NewDictValueFromStringMap(kwargs)); err != nil {
 				return fmt.Errorf("dst %q: %w", name, err)
 			}
 
 			kwargs = nil
 			continue
 		} else if strings.HasPrefix(name, "*") {
-			if err := sdkvalues.DefaultValueWrapper.UnwrapInto(dst, sdktypes.NewListValue(args)); err != nil {
+			if err := sdktypes.DefaultValueWrapper.UnwrapInto(dst, sdktypes.NewListValue(args)); err != nil {
 				return fmt.Errorf("dst %q: %w", name, err)
 			}
 
@@ -87,7 +86,7 @@ func UnpackArgs(args []sdktypes.Value, kwargs map[string]sdktypes.Value, dsts ..
 			}
 		}
 
-		if err := sdkvalues.DefaultValueWrapper.UnwrapInto(dst, v); err != nil {
+		if err := sdktypes.DefaultValueWrapper.UnwrapInto(dst, v); err != nil {
 			return fmt.Errorf("dst %q: %w", name, err)
 		}
 	}

--- a/sdk/sdktypes/value.go
+++ b/sdk/sdktypes/value.go
@@ -160,3 +160,5 @@ func (v Value) ToStringValuesMap() (map[string]Value, error) {
 		return nil, errors.New("not convertible to map")
 	}
 }
+
+func (v Value) Unwrap() (any, error) { return UnwrapValue(v) }

--- a/sdk/sdktypes/value_wrap.go
+++ b/sdk/sdktypes/value_wrap.go
@@ -1,4 +1,4 @@
-package sdkvalues
+package sdktypes
 
 import (
 	"encoding/json"
@@ -7,29 +7,28 @@ import (
 	"time"
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
-	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-func Wrap(v any) (sdktypes.Value, error) { return DefaultValueWrapper.Wrap(v) }
+func WrapValue(v any) (Value, error) { return DefaultValueWrapper.Wrap(v) }
 
 // Wraps a native go type in a Value.
-func (w ValueWrapper) Wrap(v any) (sdktypes.Value, error) {
-	if v, ok := v.(sdktypes.Value); ok {
+func (w ValueWrapper) Wrap(v any) (Value, error) {
+	if v, ok := v.(Value); ok {
 		return v, nil
 	}
 
 	if t, ok := v.(time.Time); ok {
-		return sdktypes.NewTimeValue(t), nil
+		return NewTimeValue(t), nil
 	}
 
 	if d, ok := v.(time.Duration); ok {
-		return sdktypes.NewDurationValue(d), nil
+		return NewDurationValue(d), nil
 	}
 
 	if msg, ok := v.(json.RawMessage); ok {
-		var vv sdktypes.Value
+		var vv Value
 		if err := json.Unmarshal(msg, &vv); err != nil {
-			return sdktypes.InvalidValue, fmt.Errorf("unmarshal value error: %w", err)
+			return InvalidValue, fmt.Errorf("unmarshal value error: %w", err)
 		}
 		return vv, nil
 	}
@@ -41,23 +40,23 @@ func (w ValueWrapper) Wrap(v any) (sdktypes.Value, error) {
 		fallthrough
 
 	case reflect.Invalid:
-		return sdktypes.InvalidValue, sdkerrors.ErrInvalidArgument{}
+		return InvalidValue, sdkerrors.ErrInvalidArgument{}
 
 	case reflect.Ptr:
 		if !vv.IsNil() {
 			return w.Wrap(vv.Elem().Interface())
 		}
 
-		return sdktypes.Nothing, nil
+		return Nothing, nil
 
 	case reflect.Struct:
 		vt := reflect.TypeOf(v)
 
 		if vt.Size() == 0 {
-			return sdktypes.Nothing, nil
+			return Nothing, nil
 		}
 
-		fs := make(map[string]sdktypes.Value)
+		fs := make(map[string]Value)
 
 		for _, vfs := range reflect.VisibleFields(vt) {
 			if !vfs.IsExported() || vfs.Anonymous {
@@ -68,7 +67,7 @@ func (w ValueWrapper) Wrap(v any) (sdktypes.Value, error) {
 
 			wfv, err := w.Wrap(fv.Interface())
 			if err != nil {
-				return sdktypes.InvalidValue, fmt.Errorf("unable to convert struct field: %w", err)
+				return InvalidValue, fmt.Errorf("unable to convert struct field: %w", err)
 			}
 
 			n := w.fromStructCaser(vfs.Name)
@@ -77,73 +76,73 @@ func (w ValueWrapper) Wrap(v any) (sdktypes.Value, error) {
 		}
 
 		if w.WrapStructAsMap {
-			return sdktypes.NewDictValueFromStringMap(fs), nil
+			return NewDictValueFromStringMap(fs), nil
 		} else {
 			n := vt.Name()
 			if len(n) == 0 {
 				n = "struct"
 			}
 
-			sym, err := sdktypes.ParseSymbol(n)
+			sym, err := ParseSymbol(n)
 			if err != nil {
-				return sdktypes.InvalidValue, fmt.Errorf("wrapping invalid name %q: %w", n, err)
+				return InvalidValue, fmt.Errorf("wrapping invalid name %q: %w", n, err)
 			}
 
-			return sdktypes.NewStructValue(sdktypes.NewSymbolValue(sym), fs)
+			return NewStructValue(NewSymbolValue(sym), fs)
 		}
 
 	case reflect.Array, reflect.Slice:
 		if vv.Type().Elem().Kind() == reflect.Uint8 {
-			return sdktypes.NewBytesValue(vv.Interface().([]byte)), nil
+			return NewBytesValue(vv.Interface().([]byte)), nil
 		}
 
-		vs := make([]sdktypes.Value, vv.Len())
+		vs := make([]Value, vv.Len())
 		for i := 0; i < vv.Len(); i++ {
 			var err error
 			if vs[i], err = w.Wrap(vv.Index(i).Interface()); err != nil {
-				return sdktypes.InvalidValue, fmt.Errorf("%d: %w", i, err)
+				return InvalidValue, fmt.Errorf("%d: %w", i, err)
 			}
 		}
 
-		return sdktypes.NewListValue(vs), nil
+		return NewListValue(vs), nil
 
 	case reflect.Map:
-		vs := make([]sdktypes.DictItem, 0, vv.Len())
+		vs := make([]DictItem, 0, vv.Len())
 		for i := vv.MapRange(); i.Next(); {
 			k, v := i.Key(), i.Value()
 
-			var di sdktypes.DictItem
+			var di DictItem
 
 			var err error
 
 			if di.K, err = w.Wrap(k.Interface()); err != nil {
-				return sdktypes.InvalidValue, fmt.Errorf("key %v: %w", k, err)
+				return InvalidValue, fmt.Errorf("key %v: %w", k, err)
 			}
 
 			if di.V, err = w.Wrap(v.Interface()); err != nil {
-				return sdktypes.InvalidValue, fmt.Errorf("key %v: %w", k, err)
+				return InvalidValue, fmt.Errorf("key %v: %w", k, err)
 			}
 
 			vs = append(vs, di)
 		}
 
-		return sdktypes.NewDictValue(vs)
+		return NewDictValue(vs)
 
 	default:
 		if num, ok := v.(json.Number); ok {
 			if i64, err := num.Int64(); err == nil {
-				return sdktypes.NewIntegerValue(i64), nil
+				return NewIntegerValue(i64), nil
 			} else if f64, err := num.Float64(); err == nil {
-				return sdktypes.NewFloatValue(f64), nil
+				return NewFloatValue(f64), nil
 			} else {
-				return sdktypes.NewStringValue(string(num)), nil
+				return NewStringValue(string(num)), nil
 			}
 		}
 
 		// force a float if the type is a float. see comment below
 		// for conversion from float64.
 		if f64, ok := v.(float64); ok {
-			return sdktypes.NewFloatValue(f64), nil
+			return NewFloatValue(f64), nil
 		}
 
 		// Checking using CanConvert in case of a custom type that
@@ -152,7 +151,7 @@ func (w ValueWrapper) Wrap(v any) (sdktypes.Value, error) {
 
 		boolType := reflect.TypeOf(true)
 		if vv.CanConvert(boolType) {
-			return sdktypes.NewBooleanValue(vv.Convert(boolType).Interface().(bool)), nil
+			return NewBooleanValue(vv.Convert(boolType).Interface().(bool)), nil
 		}
 
 		float64Type := reflect.TypeOf(float64(9.0))
@@ -163,17 +162,17 @@ func (w ValueWrapper) Wrap(v any) (sdktypes.Value, error) {
 			f64 := vv.Convert(float64Type).Interface().(float64)
 			i64 := int64(f64)
 			if f64 == float64(i64) {
-				return sdktypes.NewIntegerValue(i64), nil
+				return NewIntegerValue(i64), nil
 			}
 
-			return sdktypes.NewFloatValue(f64), nil
+			return NewFloatValue(f64), nil
 		}
 
 		strType := reflect.TypeOf("meow")
 		if vv.CanConvert(strType) {
-			return sdktypes.NewStringValue(vv.Convert(strType).Interface().(string)), nil
+			return NewStringValue(vv.Convert(strType).Interface().(string)), nil
 		}
 
-		return sdktypes.InvalidValue, fmt.Errorf("unhandled type: %q/%q", vk, reflect.TypeOf(v))
+		return InvalidValue, fmt.Errorf("unhandled type: %q/%q", vk, reflect.TypeOf(v))
 	}
 }

--- a/sdk/sdktypes/value_wrap_test.go
+++ b/sdk/sdktypes/value_wrap_test.go
@@ -1,4 +1,4 @@
-package sdkvalues_test
+package sdktypes_test
 
 import (
 	"fmt"
@@ -9,11 +9,10 @@ import (
 
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.autokitteh.dev/autokitteh/sdk/sdkvalues"
 )
 
 var (
-	w = sdkvalues.DefaultValueWrapper
+	w = sdktypes.DefaultValueWrapper
 
 	iv           = sdktypes.NewIntegerValue(42)
 	nothing      = sdktypes.Nothing
@@ -123,7 +122,7 @@ func TestValueWrapper(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%v", test.in), func(t *testing.T) {
-			var w sdkvalues.ValueWrapper
+			var w sdktypes.ValueWrapper
 			v, err := w.Wrap(test.in)
 			if !assert.NoError(t, err) {
 				return
@@ -343,7 +342,7 @@ func TestUnwrapIntoKitchenSink(t *testing.T) {
 		InS:   struct{ T time.Time }{T: time.Date(2023, time.January, 1, 18, 32, 0, 0, time.UTC)},
 	}
 
-	w := sdkvalues.DefaultValueWrapper
+	w := sdktypes.DefaultValueWrapper
 
 	var x X
 

--- a/sdk/sdktypes/value_wrapper.go
+++ b/sdk/sdktypes/value_wrapper.go
@@ -1,9 +1,7 @@
-package sdkvalues
+package sdktypes
 
 import (
 	"github.com/iancoleman/strcase"
-
-	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 // CAVEATS:
@@ -21,7 +19,7 @@ type ValueWrapper struct {
 	SafeForJSON bool
 
 	// Wrap: Used for functions that are wrapped using this wrapper.
-	ExecutorID sdktypes.ExecutorID
+	ExecutorID ExecutorID
 
 	FromStructFieldNameCaser func(string) string
 	ToStructFieldNameCaser   func(string) string
@@ -33,10 +31,10 @@ type ValueWrapper struct {
 	RawDuration bool
 
 	// Unwrap: Tranform value before unwrapping. If returns nil, ignore value.
-	Preunwrap func(sdktypes.Value) (sdktypes.Value, error)
+	Preunwrap func(Value) (Value, error)
 
 	// Unwrap: if not handled, use this unwrapper.
-	UnwrapUnknown func(sdktypes.Value) (any, error)
+	UnwrapUnknown func(Value) (any, error)
 }
 
 var DefaultValueWrapper ValueWrapper


### PR DESCRIPTION
simplifies structure and prevents future cyclic dependency