### PR TITLE
New CLI command: project deploy

### DIFF
--- a/cmd/ak/cmd/projects/build.go
+++ b/cmd/ak/cmd/projects/build.go
@@ -1,7 +1,6 @@
 package projects
 
 import (
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -14,6 +13,7 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/resolver"
 )
 
+// Flags shared by the "build" and "deploy" subcommands.
 var (
 	paths   []string
 	uploads map[string][]byte
@@ -21,59 +21,12 @@ var (
 
 var buildCmd = common.StandardCommand(&cobra.Command{
 	Use:   "build <project name or ID> --from <file or directory> [--from ...]",
-	Short: `Build project (see also the "build" subcommands)`,
+	Short: `Build project (see also the "build" commands)`,
 	Args:  cobra.ExactArgs(1),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		r := resolver.Resolver{Client: common.Client()}
-		p, pid, err := r.ProjectNameOrID(args[0])
-		if err != nil {
-			return err
-		}
-		if !p.IsValid() {
-			err = errors.New("project not found")
-			return common.NewExitCodeError(common.NotFoundExitCode, err)
-		}
-
-		uploads = make(map[string][]byte)
-		for _, path := range paths {
-			fi, err := os.Stat(path)
-			if err != nil {
-				return err
-			}
-
-			// Upload an entire directory tree.
-			if fi.IsDir() {
-				err := filepath.WalkDir(path, walk(path))
-				if err != nil {
-					return err
-				}
-				continue
-			}
-
-			// Upload a single file.
-			contents, err := os.ReadFile(path)
-			if err != nil {
-				return err
-			}
-			uploads[fi.Name()] = contents
-		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
-
-		// Communicate with the server in 2 steps.
-		if err := projects().SetResources(ctx, pid, uploads); err != nil {
-			return fmt.Errorf("set resources: %w", err)
-		}
-
-		bid, err := projects().Build(ctx, pid)
-		if err != nil {
-			return fmt.Errorf("build project: %w", err)
-		}
-
-		common.RenderKVIfV("build_id", bid)
-		return nil
+		_, err := buildProject(args)
+		return err
 	},
 })
 
@@ -81,6 +34,59 @@ func init() {
 	// Command-specific flags.
 	buildCmd.Flags().StringArrayVarP(&paths, "from", "f", []string{}, "1 or more file or directory paths")
 	kittehs.Must0(buildCmd.MarkFlagRequired("from"))
+}
+
+// Helper function shared by the "build" and "deploy" subcommands.
+func buildProject(args []string) (string, error) {
+	r := resolver.Resolver{Client: common.Client()}
+	p, pid, err := r.ProjectNameOrID(args[0])
+	if err != nil {
+		return "", err
+	}
+	if !p.IsValid() {
+		err := fmt.Errorf("project %q not found", args[0])
+		return "", common.NewExitCodeError(common.NotFoundExitCode, err)
+	}
+
+	uploads = make(map[string][]byte)
+	for _, path := range paths {
+		fi, err := os.Stat(path)
+		if err != nil {
+			return "", common.NewExitCodeError(common.NotFoundExitCode, err)
+		}
+
+		// Upload an entire directory tree.
+		if fi.IsDir() {
+			err := filepath.WalkDir(path, walk(path))
+			if err != nil {
+				return "", err
+			}
+			continue
+		}
+
+		// Upload a single file.
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return "", err
+		}
+		uploads[fi.Name()] = contents
+	}
+
+	ctx, cancel := common.LimitedContext()
+	defer cancel()
+
+	// Communicate with the server in 2 steps.
+	if err := projects().SetResources(ctx, pid, uploads); err != nil {
+		return "", fmt.Errorf("set resources: %w", err)
+	}
+
+	bid, err := projects().Build(ctx, pid)
+	if err != nil {
+		return "", fmt.Errorf("build project: %w", err)
+	}
+
+	common.RenderKVIfV("build_id", bid)
+	return bid.String(), nil
 }
 
 func walk(basePath string) fs.WalkDirFunc {

--- a/cmd/ak/cmd/projects/build.go
+++ b/cmd/ak/cmd/projects/build.go
@@ -21,7 +21,8 @@ var (
 
 var buildCmd = common.StandardCommand(&cobra.Command{
 	Use:   "build <project name or ID> --from <file or directory> [--from ...]",
-	Short: `Build project (see also the "build" commands)`,
+	Short: "Build project",
+	Long:  `Build project - see also the "build" sibling command`,
 	Args:  cobra.ExactArgs(1),
 
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/ak/cmd/projects/deploy.go
+++ b/cmd/ak/cmd/projects/deploy.go
@@ -16,13 +16,14 @@ var env string
 
 var deployCmd = common.StandardCommand(&cobra.Command{
 	Use:   "deploy <project name or ID> --from <file or directory> [--from ...] [--env <name or ID>]",
-	Short: `Build and deploy project (see also "build" and "deploy" commands)`,
+	Short: "Build, deploy, and activate project",
+	Long:  `Build, deploy, and activate project - see also the "build" and "deployment" parent commands`,
 	Args:  cobra.ExactArgs(1),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
 
-		// First, build the project (see the "build" command).
+		// First, build the project (see the "build" sibling command).
 		buildID, err := buildProject(args)
 		if err != nil {
 			return err
@@ -38,7 +39,7 @@ var deployCmd = common.StandardCommand(&cobra.Command{
 			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
 
-		// Finally, deploy and activate it (see the "deploy" commands).
+		// Finally, deploy and activate it (see the "deployment" parent command).
 		deployment, err := sdktypes.DeploymentFromProto(&sdktypes.DeploymentPB{
 			EnvId:   eid.String(),
 			BuildId: buildID,

--- a/cmd/ak/cmd/projects/deploy.go
+++ b/cmd/ak/cmd/projects/deploy.go
@@ -1,0 +1,78 @@
+package projects
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"go.autokitteh.dev/autokitteh/cmd/ak/common"
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/internal/resolver"
+	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+var env string
+
+var deployCmd = common.StandardCommand(&cobra.Command{
+	Use:   "deploy <project name or ID> --from <file or directory> [--from ...] [--env <name or ID>]",
+	Short: `Build and deploy project (see also "build" and "deploy" commands)`,
+	Args:  cobra.ExactArgs(1),
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		r := resolver.Resolver{Client: common.Client()}
+
+		// First, build the project (see the "build" command).
+		buildID, err := buildProject(args)
+		if err != nil {
+			return err
+		}
+
+		// Then, parse the optional environment argument.
+		e, eid, err := r.EnvNameOrID(env, args[0])
+		if err != nil {
+			return err
+		}
+		if !e.IsValid() {
+			err = fmt.Errorf("environment %q not found", env)
+			return common.NewExitCodeError(common.NotFoundExitCode, err)
+		}
+
+		// Finally, deploy and activate it (see the "deploy" commands).
+		deployment, err := sdktypes.DeploymentFromProto(&sdktypes.DeploymentPB{
+			EnvId:   eid.String(),
+			BuildId: buildID,
+		})
+		if err != nil {
+			return fmt.Errorf("invalid deployment: %w", err)
+		}
+
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		did, err := deployments().Create(ctx, deployment)
+		if err != nil {
+			return fmt.Errorf("create deployment: %w", err)
+		}
+
+		common.RenderKV("deployment_id", did)
+
+		if err := deployments().Activate(ctx, did); err != nil {
+			return fmt.Errorf("activate deployment: %w", err)
+		}
+
+		return nil
+	},
+})
+
+func init() {
+	// Command-specific flags.
+	deployCmd.Flags().StringArrayVarP(&paths, "from", "f", []string{}, "1 or more file or directory paths")
+	kittehs.Must0(deployCmd.MarkFlagRequired("from"))
+
+	deployCmd.Flags().StringVarP(&env, "env", "e", "", "environment name or ID")
+}
+
+func deployments() sdkservices.Deployments {
+	return common.Client().Deployments()
+}

--- a/cmd/ak/cmd/projects/projects.go
+++ b/cmd/ak/cmd/projects/projects.go
@@ -23,6 +23,7 @@ func init() {
 	// Subcommands.
 	projectsCmd.AddCommand(buildCmd)
 	projectsCmd.AddCommand(createCmd)
+	projectsCmd.AddCommand(deployCmd)
 	projectsCmd.AddCommand(downloadCmd)
 	projectsCmd.AddCommand(getCmd)
 	projectsCmd.AddCommand(listCmd)

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -168,6 +168,8 @@ func (r Resolver) DeploymentID(id string) (d sdktypes.Deployment, did sdktypes.D
 // and project names or IDs.
 //
 //   - If the input is empty, we return nil but not an error
+//   - If the environment is empty but the project isn't, we try to
+//     resolve the environment as the default one for the project
 //   - If the environment is specified as a name, the project is required
 //   - If the environment is specified as a *full* name, the project is
 //     optional, but if specified it must concur with the project prefix
@@ -180,7 +182,11 @@ func (r Resolver) DeploymentID(id string) (d sdktypes.Deployment, did sdktypes.D
 // but it doesn't actually exist, we return (nil, ID, nil).
 func (r Resolver) EnvNameOrID(envNameOrID, projNameOrID string) (sdktypes.Env, sdktypes.EnvID, error) {
 	if envNameOrID == "" {
-		return sdktypes.InvalidEnv, sdktypes.InvalidEnvID, nil
+		if projNameOrID == "" {
+			return sdktypes.InvalidEnv, sdktypes.InvalidEnvID, nil
+		} else {
+			envNameOrID = "default"
+		}
 	}
 
 	// Project.
@@ -259,7 +265,7 @@ func (r Resolver) envByFullName(parts []string, projNameOrID string, pid sdktype
 
 	// Sanity check: the original project must match the prefix.
 	if pid.IsValid() && pid != e.ProjectID() {
-		err = fmt.Errorf("env %q doesn't belong to project %q", prefix, projNameOrID)
+		err = fmt.Errorf("env %q doesn't belong to project %q", envName, projNameOrID)
 		return
 	}
 

--- a/sdk/sdkclients/sdkprojectsclient/client.go
+++ b/sdk/sdkclients/sdkprojectsclient/client.go
@@ -73,7 +73,11 @@ func (c *client) GetByID(ctx context.Context, pid sdktypes.ProjectID) (sdktypes.
 
 	project, err := sdktypes.StrictProjectFromProto(resp.Msg.Project)
 	if err != nil {
-		return sdktypes.InvalidProject, fmt.Errorf("invalid project: %w", err)
+		// TODO: "errors.Is(err, sdkerrors.ErrInvalidArgument)" doesn't work.
+		if err.Error() == "invalid argument: zero object" {
+			return sdktypes.InvalidProject, nil
+		}
+		return sdktypes.InvalidProject, err
 	}
 
 	return project, nil

--- a/tests/system/testdata/projects/build.txtar
+++ b/tests/system/testdata/projects/build.txtar
@@ -1,24 +1,29 @@
+# Negative tests: build nonexistent project, by name/ID.
+ak project build bad_project --from program.star
+output equals 'Error: project "bad_project" not found'
+return code == 10
+
+ak project build prj_000000000000000n0nex1stent --from program.star
+output equals 'Error: project "prj_000000000000000n0nex1stent" not found'
+return code == 10
+
 # Precondition: create project.
 ak project create my_project
 return code == 0
 output equals 'project_id: prj_00000000000000000000000001'
-
-# Negative tests: build nonexistent project.
-ak project build bad_project --from program.star
-output equals 'Error: project not found'
-return code == 10
-
-ak project build prj_deadbeef0deadbeef0deadbeef --from program.star
-output equals 'Error: project not found'
-return code == 10
 
 # Negative test: build project without required flag.
 ak project build my_project
 output equals 'Error: required flag(s) "from" not set'
 return code == 1
 
+# Negative test: build project with nonexistent file.
+ak project build my_project --from bad_filename
+output equals 'Error: stat bad_filename: no such file or directory'
+return code == 10
+
 # Build project from a single file.
-ak project build my_project --from single_file
+ak project build my_project --from single_file.star
 return code == 0
 
 # Build project from a directory tree with multiple files.
@@ -26,11 +31,11 @@ ak project build my_project --from directory
 return code == 0
 
 # Build project from both, alongside each other.
-ak project build my_project --from single_file --from directory
+ak project build my_project --from single_file.star --from directory
 return code == 0
 
--- single_file --
-print("single_file")
+-- single_file.star --
+print("single_file.star")
 
 -- directory/file1.star --
 print("directory/file1.star")

--- a/tests/system/testdata/projects/deploy.txtar
+++ b/tests/system/testdata/projects/deploy.txtar
@@ -1,0 +1,73 @@
+# Negative tests: deploy nonexistent project, by name/ID.
+ak project deploy bad_project --from program.star
+output equals 'Error: project "bad_project" not found'
+return code == 10
+
+ak project deploy prj_000000000000000n0nex1stent --from program.star
+output equals 'Error: project "prj_000000000000000n0nex1stent" not found'
+return code == 10
+
+# Preconditions: create project and environment.
+ak project create my_project
+return code == 0
+output equals 'project_id: prj_00000000000000000000000001'
+
+ak env create default --project my_project
+return code == 0
+output equals 'env_id: env_00000000000000000000000002'
+
+# Negative test: deploy project without required flag.
+ak project deploy my_project
+output equals 'Error: required flag(s) "from" not set'
+return code == 1
+
+# Negative test: deploy project with nonexistent file.
+ak project deploy my_project --from bad_filename
+output equals 'Error: stat bad_filename: no such file or directory'
+return code == 10
+
+# Deploy project from a single file.
+ak project deploy my_project --from single_file.star
+return code == 0
+output contains 'build_id: bld_00000000000000000000000003'
+output contains 'deployment_id: dep_00000000000000000000000004'
+
+# Deploy project from a directory tree with multiple files.
+ak project deploy my_project --from directory
+return code == 0
+output contains 'build_id: bld_00000000000000000000000005'
+output contains 'deployment_id: dep_00000000000000000000000006'
+
+# Deploy project from both, alongside each other.
+ak project deploy my_project --from single_file.star --from directory
+return code == 0
+output contains 'build_id: bld_00000000000000000000000007'
+output contains 'deployment_id: dep_00000000000000000000000008'
+
+# Deploy project to default environment, by name/ID.
+ak project deploy my_project --from single_file.star --env default
+return code == 0
+output contains 'build_id: bld_00000000000000000000000009'
+output contains 'deployment_id: dep_0000000000000000000000000a'
+
+ak project deploy my_project --from single_file.star --env my_project/default
+return code == 0
+output contains 'build_id: bld_0000000000000000000000000b'
+output contains 'deployment_id: dep_0000000000000000000000000c'
+
+ak project deploy my_project --from single_file.star --env env_00000000000000000000000002
+return code == 0
+output contains 'build_id: bld_0000000000000000000000000d'
+output contains 'deployment_id: dep_0000000000000000000000000e'
+
+-- single_file.star --
+print("single_file.star")
+
+-- directory/file1.star --
+print("directory/file1.star")
+
+-- directory/subdirectory/file1.star --
+print("directory/subdirectory/file1.star")
+
+-- directory/subdirectory/file2.star --
+print("directory/subdirectory/file2.star")

--- a/tests/system/testdata/projects/deploy_non_default_env.txtar
+++ b/tests/system/testdata/projects/deploy_non_default_env.txtar
@@ -1,0 +1,33 @@
+# Preconditions: create project and environment.
+ak project create my_project
+return code == 0
+output equals 'project_id: prj_00000000000000000000000001'
+
+ak env create my_env --project my_project
+return code == 0
+output equals 'env_id: env_00000000000000000000000002'
+
+# Negative test: deploy project without required flag.
+ak project deploy my_project --from program.star
+output contains 'build_id: bld_00000000000000000000000003'
+output contains 'Error: environment "" not found'
+return code == 10
+
+# Deploy project to non-default environment, by name/ID.
+ak project deploy my_project --from program.star --env my_env
+return code == 0
+output contains 'build_id: bld_00000000000000000000000004'
+output contains 'deployment_id: dep_00000000000000000000000005'
+
+ak project deploy my_project --from program.star --env my_project/my_env
+return code == 0
+output contains 'build_id: bld_00000000000000000000000006'
+output contains 'deployment_id: dep_00000000000000000000000007'
+
+ak project deploy my_project --from program.star --env env_00000000000000000000000002
+return code == 0
+output contains 'build_id: bld_00000000000000000000000008'
+output contains 'deployment_id: dep_00000000000000000000000009'
+
+-- program.star --
+print("program.star")


### PR DESCRIPTION
Syntax:

```
ak projects deploy <project name or ID> --from <file or directory> [--from ...] [--env <name or ID>]
```

Beyond the command itself, this PR also includes a refactoring of the `project build` command (in order to reuse it in `project deploy`), and system tests for building and deploying.