### PR TITLE
db tests cleanup

### DIFF
--- a/internal/backend/db/dbgorm/builds.go
+++ b/internal/backend/db/dbgorm/builds.go
@@ -10,8 +10,8 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-func (db *gormdb) saveBuild(ctx context.Context, build scheme.Build) error {
-	return db.db.WithContext(ctx).Create(&build).Error
+func (db *gormdb) saveBuild(ctx context.Context, build *scheme.Build) error {
+	return db.db.WithContext(ctx).Create(build).Error
 }
 
 func (db *gormdb) SaveBuild(ctx context.Context, build sdktypes.Build, data []byte) error {
@@ -21,7 +21,7 @@ func (db *gormdb) SaveBuild(ctx context.Context, build sdktypes.Build, data []by
 		Data:      data,
 		CreatedAt: build.CreatedAt(),
 	}
-	return translateError(db.saveBuild(ctx, b))
+	return translateError(db.saveBuild(ctx, &b))
 }
 
 func (db *gormdb) GetBuild(ctx context.Context, buildID sdktypes.BuildID) (sdktypes.Build, error) {

--- a/internal/backend/db/dbgorm/builds_test.go
+++ b/internal/backend/db/dbgorm/builds_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func saveBuildAndAssert(t *testing.T, f *dbFixture, build scheme.Build) {
-	assert.NoError(t, f.gormdb.saveBuild(f.ctx, build))
+	assert.NoError(t, f.gormdb.saveBuild(f.ctx, &build))
 	findAndAssertOne(t, f, build, "build_id = ?", build.BuildID)
 }
 

--- a/internal/backend/db/dbgorm/builds_test.go
+++ b/internal/backend/db/dbgorm/builds_test.go
@@ -9,9 +9,11 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 )
 
-func saveBuildAndAssert(t *testing.T, f *dbFixture, build scheme.Build) {
-	assert.NoError(t, f.gormdb.saveBuild(f.ctx, &build))
-	findAndAssertOne(t, f, build, "build_id = ?", build.BuildID)
+func saveBuildsAndAssert(t *testing.T, f *dbFixture, builds ...scheme.Build) {
+	for _, build := range builds {
+		assert.NoError(t, f.gormdb.saveBuild(f.ctx, &build))
+		findAndAssertOne(t, f, build, "build_id = ?", build.BuildID)
+	}
 }
 
 func assertBuildDeleted(t *testing.T, f *dbFixture, buildID string) {
@@ -21,14 +23,14 @@ func assertBuildDeleted(t *testing.T, f *dbFixture, buildID string) {
 func TestSaveBuild(t *testing.T) {
 	f := newDBFixture(true)
 	build := newBuild()
-	saveBuildAndAssert(t, f, build)
+	saveBuildsAndAssert(t, f, build)
 	findAndAssertOne(t, f, build, "") // check there is only single build in DB
 }
 
 func TestDeleteBuild(t *testing.T) {
 	f := newDBFixture(true)
 	build := newBuild()
-	saveBuildAndAssert(t, f, build)
+	saveBuildsAndAssert(t, f, build)
 
 	assert.NoError(t, f.gormdb.deleteBuild(f.ctx, build.BuildID))
 	assertBuildDeleted(t, f, build.BuildID)
@@ -45,7 +47,7 @@ func TestListBuild(t *testing.T) {
 
 	// create build and obtain it via list
 	build := newBuild()
-	saveBuildAndAssert(t, f, build)
+	saveBuildsAndAssert(t, f, build)
 
 	// check listBuilds API
 	builds, err = f.gormdb.listBuilds(f.ctx, flt)

--- a/internal/backend/db/dbgorm/builds_test.go
+++ b/internal/backend/db/dbgorm/builds_test.go
@@ -9,7 +9,7 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 )
 
-func saveBuildsAndAssert(t *testing.T, f *dbFixture, builds ...scheme.Build) {
+func (f *dbFixture) saveBuildsAndAssert(t *testing.T, builds ...scheme.Build) {
 	for _, build := range builds {
 		assert.NoError(t, f.gormdb.saveBuild(f.ctx, &build))
 		findAndAssertOne(t, f, build, "build_id = ?", build.BuildID)
@@ -23,14 +23,14 @@ func assertBuildDeleted(t *testing.T, f *dbFixture, buildID string) {
 func TestSaveBuild(t *testing.T) {
 	f := newDBFixture(true)
 	b := newBuild()
-	saveBuildsAndAssert(t, f, b)
+	f.saveBuildsAndAssert(t, b)
 	findAndAssertOne(t, f, b, "") // check there is only single build in DB
 }
 
 func TestDeleteBuild(t *testing.T) {
 	f := newDBFixture(true)
 	b := newBuild()
-	saveBuildsAndAssert(t, f, b)
+	f.saveBuildsAndAssert(t, b)
 
 	assert.NoError(t, f.gormdb.deleteBuild(f.ctx, b.BuildID))
 	assertBuildDeleted(t, f, b.BuildID)
@@ -47,7 +47,7 @@ func TestListBuild(t *testing.T) {
 
 	// create build and obtain it via list
 	b := newBuild()
-	saveBuildsAndAssert(t, f, b)
+	f.saveBuildsAndAssert(t, b)
 
 	// check listBuilds API
 	builds, err = f.gormdb.listBuilds(f.ctx, flt)

--- a/internal/backend/db/dbgorm/builds_test.go
+++ b/internal/backend/db/dbgorm/builds_test.go
@@ -22,14 +22,14 @@ func assertBuildDeleted(t *testing.T, f *dbFixture, buildID string) {
 
 func TestSaveBuild(t *testing.T) {
 	f := newDBFixture(true)
-	b := newBuild()
+	b := f.newBuild()
 	f.saveBuildsAndAssert(t, b)
 	findAndAssertOne(t, f, b, "") // check there is only single build in DB
 }
 
 func TestDeleteBuild(t *testing.T) {
 	f := newDBFixture(true)
-	b := newBuild()
+	b := f.newBuild()
 	f.saveBuildsAndAssert(t, b)
 
 	assert.NoError(t, f.gormdb.deleteBuild(f.ctx, b.BuildID))
@@ -46,7 +46,7 @@ func TestListBuild(t *testing.T) {
 	assert.Equal(t, 0, len(builds))
 
 	// create build and obtain it via list
-	b := newBuild()
+	b := f.newBuild()
 	f.saveBuildsAndAssert(t, b)
 
 	// check listBuilds API

--- a/internal/backend/db/dbgorm/builds_test.go
+++ b/internal/backend/db/dbgorm/builds_test.go
@@ -22,18 +22,18 @@ func assertBuildDeleted(t *testing.T, f *dbFixture, buildID string) {
 
 func TestSaveBuild(t *testing.T) {
 	f := newDBFixture(true)
-	build := newBuild()
-	saveBuildsAndAssert(t, f, build)
-	findAndAssertOne(t, f, build, "") // check there is only single build in DB
+	b := newBuild()
+	saveBuildsAndAssert(t, f, b)
+	findAndAssertOne(t, f, b, "") // check there is only single build in DB
 }
 
 func TestDeleteBuild(t *testing.T) {
 	f := newDBFixture(true)
-	build := newBuild()
-	saveBuildsAndAssert(t, f, build)
+	b := newBuild()
+	saveBuildsAndAssert(t, f, b)
 
-	assert.NoError(t, f.gormdb.deleteBuild(f.ctx, build.BuildID))
-	assertBuildDeleted(t, f, build.BuildID)
+	assert.NoError(t, f.gormdb.deleteBuild(f.ctx, b.BuildID))
+	assertBuildDeleted(t, f, b.BuildID)
 }
 
 func TestListBuild(t *testing.T) {
@@ -46,17 +46,17 @@ func TestListBuild(t *testing.T) {
 	assert.Equal(t, 0, len(builds))
 
 	// create build and obtain it via list
-	build := newBuild()
-	saveBuildsAndAssert(t, f, build)
+	b := newBuild()
+	saveBuildsAndAssert(t, f, b)
 
 	// check listBuilds API
 	builds, err = f.gormdb.listBuilds(f.ctx, flt)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(builds))
-	assert.Equal(t, build, builds[0])
+	assert.Equal(t, b, builds[0])
 
 	// delete build
-	assert.NoError(t, f.gormdb.deleteBuild(f.ctx, build.BuildID))
+	assert.NoError(t, f.gormdb.deleteBuild(f.ctx, b.BuildID))
 
 	// check listBuilds API - ensure no builds are found
 	builds, err = f.gormdb.listBuilds(f.ctx, flt)

--- a/internal/backend/db/dbgorm/connections.go
+++ b/internal/backend/db/dbgorm/connections.go
@@ -9,8 +9,8 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-func (db *gormdb) createConnection(ctx context.Context, conn scheme.Connection) error {
-	return db.db.WithContext(ctx).Create(&conn).Error
+func (db *gormdb) createConnection(ctx context.Context, conn *scheme.Connection) error {
+	return db.db.WithContext(ctx).Create(conn).Error
 }
 
 func (db *gormdb) CreateConnection(ctx context.Context, conn sdktypes.Connection) error {
@@ -22,7 +22,7 @@ func (db *gormdb) CreateConnection(ctx context.Context, conn sdktypes.Connection
 		Name:             conn.Name().String(),
 	}
 
-	return translateError(db.createConnection(ctx, c))
+	return translateError(db.createConnection(ctx, &c))
 }
 
 func (db *gormdb) UpdateConnection(ctx context.Context, conn sdktypes.Connection) error {

--- a/internal/backend/db/dbgorm/connections_test.go
+++ b/internal/backend/db/dbgorm/connections_test.go
@@ -10,7 +10,7 @@ import (
 
 func createConnectionsAndAssert(t *testing.T, f *dbFixture, connections ...scheme.Connection) {
 	for _, conn := range connections {
-		assert.NoError(t, f.gormdb.createConnection(f.ctx, conn))
+		assert.NoError(t, f.gormdb.createConnection(f.ctx, &conn))
 		findAndAssertOne(t, f, conn, "connection_id = ?", conn.ConnectionID)
 	}
 }

--- a/internal/backend/db/dbgorm/connections_test.go
+++ b/internal/backend/db/dbgorm/connections_test.go
@@ -8,7 +8,7 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/backend/db/dbgorm/scheme"
 )
 
-func createConnectionsAndAssert(t *testing.T, f *dbFixture, connections ...scheme.Connection) {
+func (f *dbFixture) createConnectionsAndAssert(t *testing.T, connections ...scheme.Connection) {
 	for _, conn := range connections {
 		assert.NoError(t, f.gormdb.createConnection(f.ctx, &conn))
 		findAndAssertOne(t, f, conn, "connection_id = ?", conn.ConnectionID)
@@ -21,5 +21,5 @@ func TestCreateConnection(t *testing.T) {
 
 	tr := newConnection()
 	// test createConnection
-	createConnectionsAndAssert(t, f, tr)
+	f.createConnectionsAndAssert(t, tr)
 }

--- a/internal/backend/db/dbgorm/connections_test.go
+++ b/internal/backend/db/dbgorm/connections_test.go
@@ -19,7 +19,7 @@ func TestCreateConnection(t *testing.T) {
 	f := newDBFixture(true)                              // no foreign keys
 	findAndAssertCount(t, f, scheme.Connection{}, 0, "") // no connections
 
-	tr := newConnection()
+	tr := f.newConnection()
 	// test createConnection
 	f.createConnectionsAndAssert(t, tr)
 }

--- a/internal/backend/db/dbgorm/deployments.go
+++ b/internal/backend/db/dbgorm/deployments.go
@@ -13,8 +13,8 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-func (db *gormdb) createDeployment(ctx context.Context, deployment scheme.Deployment) error {
-	return db.db.WithContext(ctx).Create(&deployment).Error
+func (db *gormdb) createDeployment(ctx context.Context, deployment *scheme.Deployment) error {
+	return db.db.WithContext(ctx).Create(deployment).Error
 }
 
 func (db *gormdb) CreateDeployment(ctx context.Context, deployment sdktypes.Deployment) error {
@@ -30,7 +30,7 @@ func (db *gormdb) CreateDeployment(ctx context.Context, deployment sdktypes.Depl
 	}
 
 	return db.locked(func(db *gormdb) error {
-		return translateError(db.createDeployment(ctx, d))
+		return translateError(db.createDeployment(ctx, &d))
 	})
 }
 

--- a/internal/backend/db/dbgorm/deployments_test.go
+++ b/internal/backend/db/dbgorm/deployments_test.go
@@ -13,7 +13,7 @@ import (
 
 func createDeploymentsAndAssert(t *testing.T, f *dbFixture, deployments ...scheme.Deployment) {
 	for _, deployment := range deployments {
-		assert.NoError(t, f.gormdb.createDeployment(f.ctx, deployment))
+		assert.NoError(t, f.gormdb.createDeployment(f.ctx, &deployment))
 		findAndAssertOne(t, f, deployment, "deployment_id = ?", deployment.DeploymentID)
 	}
 }
@@ -63,7 +63,7 @@ func TestCreateDeploymentsForeignKeys(t *testing.T) {
 	d.BuildID = "unexistingBuildID"
 	d.EnvID = "unexistingEnvID"
 
-	err := f.gormdb.createDeployment(f.ctx, d)
+	err := f.gormdb.createDeployment(f.ctx, &d)
 	assert.ErrorContains(t, err, "FOREIGN KEY")
 
 	p := newProject(f)

--- a/internal/backend/db/dbgorm/deployments_test.go
+++ b/internal/backend/db/dbgorm/deployments_test.go
@@ -44,8 +44,10 @@ func listDeploymentsWithStatsAndAssert(t *testing.T, f *dbFixture, expected int)
 	return deployments
 }
 
-func assertDeploymentDeleted(t *testing.T, f *dbFixture, deploymentID string) {
-	assertSoftDeleted(t, f, scheme.Deployment{DeploymentID: deploymentID})
+func assertDeploymentsDeleted(t *testing.T, f *dbFixture, deployments ...scheme.Deployment) {
+	for _, deployment := range deployments {
+		assertSoftDeleted(t, f, scheme.Deployment{DeploymentID: deployment.DeploymentID})
+	}
 }
 
 func TestCreateDeployment(t *testing.T) {
@@ -128,7 +130,7 @@ func TestListDeploymentsWithStats(t *testing.T) {
 
 	// delete session
 	assert.NoError(t, f.gormdb.deleteSession(f.ctx, s.SessionID))
-	assertSessionDeleted(t, f, s.SessionID)
+	assertSessionsDeleted(t, f, s)
 
 	// check that deployment stats are updated
 	deployments = listDeploymentsWithStatsAndAssert(t, f, 1)
@@ -157,11 +159,10 @@ func TestDeleteDeployment(t *testing.T) {
 
 	// delete deployment. Ensure deployment sessions are marked as deleted as well
 	assert.NoError(t, f.gormdb.deleteDeployment(f.ctx, d.DeploymentID))
-	assertDeploymentDeleted(t, f, d.DeploymentID)
+	assertDeploymentsDeleted(t, f, d)
 
 	listDeploymentsWithStatsAndAssert(t, f, 0)
-	assertSessionDeleted(t, f, s1.SessionID)
-	assertSessionDeleted(t, f, s2.SessionID)
+	assertSessionsDeleted(t, f, s1, s2)
 
 	// TODO: meanwhile builds are not deleted when deployment is deleted
 	// assertBuildDeleted(t, f, b.BuildID)

--- a/internal/backend/db/dbgorm/deployments_test.go
+++ b/internal/backend/db/dbgorm/deployments_test.go
@@ -141,16 +141,15 @@ func TestDeleteDeployment(t *testing.T) {
 	listDeploymentsAndAssert(t, f, 0) // ensure no deployments
 
 	b := newBuild()
-	saveBuildsAndAssert(t, f, b)
 	d := newDeployment(f)
 	d.BuildID = b.BuildID
+	saveBuildsAndAssert(t, f, b)
 	createDeploymentsAndAssert(t, f, d)
 
 	// add sessions and check that deployment stats are updated
-	session1 := newSession(f, sdktypes.SessionStateTypeCompleted)
-	createSessionsAndAssert(t, f, session1)
-	session2 := newSession(f, sdktypes.SessionStateTypeError)
-	createSessionsAndAssert(t, f, session2)
+	s1 := newSession(f, sdktypes.SessionStateTypeCompleted)
+	s2 := newSession(f, sdktypes.SessionStateTypeError)
+	createSessionsAndAssert(t, f, s1, s2)
 
 	dWS := scheme.DeploymentWithStats{Deployment: d, Completed: 1, Error: 1}
 	deployments := listDeploymentsWithStatsAndAssert(t, f, 1)
@@ -161,8 +160,8 @@ func TestDeleteDeployment(t *testing.T) {
 	assertDeploymentDeleted(t, f, d.DeploymentID)
 
 	listDeploymentsWithStatsAndAssert(t, f, 0)
-	assertSessionDeleted(t, f, session1.SessionID)
-	assertSessionDeleted(t, f, session2.SessionID)
+	assertSessionDeleted(t, f, s1.SessionID)
+	assertSessionDeleted(t, f, s2.SessionID)
 
 	// TODO: meanwhile builds are not deleted when deployment is deleted
 	// assertBuildDeleted(t, f, b.BuildID)

--- a/internal/backend/db/dbgorm/deployments_test.go
+++ b/internal/backend/db/dbgorm/deployments_test.go
@@ -44,7 +44,7 @@ func listDeploymentsWithStatsAndAssert(t *testing.T, f *dbFixture, expected int)
 	return deployments
 }
 
-func assertDeploymentsDeleted(t *testing.T, f *dbFixture, deployments ...scheme.Deployment) {
+func (f *dbFixture) assertDeploymentsDeleted(t *testing.T, deployments ...scheme.Deployment) {
 	for _, deployment := range deployments {
 		assertSoftDeleted(t, f, scheme.Deployment{DeploymentID: deployment.DeploymentID})
 	}
@@ -130,7 +130,7 @@ func TestListDeploymentsWithStats(t *testing.T) {
 
 	// delete session
 	assert.NoError(t, f.gormdb.deleteSession(f.ctx, s.SessionID))
-	assertSessionsDeleted(t, f, s)
+	f.assertSessionsDeleted(t, s)
 
 	// check that deployment stats are updated
 	deployments = listDeploymentsWithStatsAndAssert(t, f, 1)
@@ -159,10 +159,10 @@ func TestDeleteDeployment(t *testing.T) {
 
 	// delete deployment. Ensure deployment sessions are marked as deleted as well
 	assert.NoError(t, f.gormdb.deleteDeployment(f.ctx, d.DeploymentID))
-	assertDeploymentsDeleted(t, f, d)
+	f.assertDeploymentsDeleted(t, d)
 
 	listDeploymentsWithStatsAndAssert(t, f, 0)
-	assertSessionsDeleted(t, f, s1, s2)
+	f.assertSessionsDeleted(t, s1, s2)
 
 	// TODO: meanwhile builds are not deleted when deployment is deleted
 	// assertBuildDeleted(t, f, b.BuildID)

--- a/internal/backend/db/dbgorm/deployments_test.go
+++ b/internal/backend/db/dbgorm/deployments_test.go
@@ -11,7 +11,7 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-func createDeploymentsAndAssert(t *testing.T, f *dbFixture, deployments ...scheme.Deployment) {
+func (f *dbFixture) createDeploymentsAndAssert(t *testing.T, deployments ...scheme.Deployment) {
 	for _, deployment := range deployments {
 		assert.NoError(t, f.gormdb.createDeployment(f.ctx, &deployment))
 		findAndAssertOne(t, f, deployment, "deployment_id = ?", deployment.DeploymentID)
@@ -56,7 +56,7 @@ func TestCreateDeployment(t *testing.T) {
 
 	d := newDeployment(f)
 	// test createDeployment
-	createDeploymentsAndAssert(t, f, d)
+	f.createDeploymentsAndAssert(t, d)
 }
 
 func TestCreateDeploymentsForeignKeys(t *testing.T) {
@@ -71,12 +71,12 @@ func TestCreateDeploymentsForeignKeys(t *testing.T) {
 	p := newProject(f)
 	e := newEnv(f)
 	b := newBuild()
-	createProjectsAndAssert(t, f, p)
-	createEnvsAndAssert(t, f, e)
-	saveBuildsAndAssert(t, f, b)
+	f.createProjectsAndAssert(t, p)
+	f.createEnvsAndAssert(t, e)
+	f.saveBuildsAndAssert(t, b)
 
 	d = newDeployment(f)
-	createDeploymentsAndAssert(t, f, d)
+	f.createDeploymentsAndAssert(t, d)
 }
 
 func TestGetDeployment(t *testing.T) {
@@ -84,7 +84,7 @@ func TestGetDeployment(t *testing.T) {
 	listDeploymentsAndAssert(t, f, 0) // no deployments
 
 	d := newDeployment(f)
-	createDeploymentsAndAssert(t, f, d)
+	f.createDeploymentsAndAssert(t, d)
 
 	// check getDeployment
 	deployment, err := f.gormdb.getDeployment(f.ctx, d.DeploymentID)
@@ -101,7 +101,7 @@ func TestListDeployments(t *testing.T) {
 	listDeploymentsAndAssert(t, f, 0) // no deployments
 
 	d := newDeployment(f)
-	createDeploymentsAndAssert(t, f, d)
+	f.createDeploymentsAndAssert(t, d)
 
 	deployments := listDeploymentsAndAssert(t, f, 1)
 	assert.Equal(t, d, deployments[0])
@@ -113,7 +113,7 @@ func TestListDeploymentsWithStats(t *testing.T) {
 
 	// create deployment and ensure there are no stats
 	d := newDeployment(f)
-	createDeploymentsAndAssert(t, f, d)
+	f.createDeploymentsAndAssert(t, d)
 
 	dWS := scheme.DeploymentWithStats{Deployment: d} // no stats, all zeros
 	deployments := listDeploymentsWithStatsAndAssert(t, f, 1)
@@ -121,7 +121,7 @@ func TestListDeploymentsWithStats(t *testing.T) {
 
 	// add session for the stats
 	s := newSession(f, sdktypes.SessionStateTypeCompleted)
-	createSessionsAndAssert(t, f, s)
+	f.createSessionsAndAssert(t, s)
 
 	// ensure that new session is included in stats
 	dWS.Completed = 1
@@ -145,13 +145,13 @@ func TestDeleteDeployment(t *testing.T) {
 	b := newBuild()
 	d := newDeployment(f)
 	d.BuildID = b.BuildID
-	saveBuildsAndAssert(t, f, b)
-	createDeploymentsAndAssert(t, f, d)
+	f.saveBuildsAndAssert(t, b)
+	f.createDeploymentsAndAssert(t, d)
 
 	// add sessions and check that deployment stats are updated
 	s1 := newSession(f, sdktypes.SessionStateTypeCompleted)
 	s2 := newSession(f, sdktypes.SessionStateTypeError)
-	createSessionsAndAssert(t, f, s1, s2)
+	f.createSessionsAndAssert(t, s1, s2)
 
 	dWS := scheme.DeploymentWithStats{Deployment: d, Completed: 1, Error: 1}
 	deployments := listDeploymentsWithStatsAndAssert(t, f, 1)

--- a/internal/backend/db/dbgorm/deployments_test.go
+++ b/internal/backend/db/dbgorm/deployments_test.go
@@ -18,7 +18,7 @@ func (f *dbFixture) createDeploymentsAndAssert(t *testing.T, deployments ...sche
 	}
 }
 
-func listDeploymentsAndAssert(t *testing.T, f *dbFixture, expected int) []scheme.Deployment {
+func (f *dbFixture) listDeploymentsAndAssert(t *testing.T, expected int) []scheme.Deployment {
 	flt := sdkservices.ListDeploymentsFilter{
 		State:               sdktypes.DeploymentStateUnspecified,
 		Limit:               0,
@@ -51,8 +51,8 @@ func (f *dbFixture) assertDeploymentsDeleted(t *testing.T, deployments ...scheme
 }
 
 func TestCreateDeployment(t *testing.T) {
-	f := newDBFixture(true)           // no foreign keys
-	listDeploymentsAndAssert(t, f, 0) // no deployments
+	f := newDBFixture(true)          // no foreign keys
+	f.listDeploymentsAndAssert(t, 0) // no deployments
 
 	d := newDeployment(f)
 	// test createDeployment
@@ -80,8 +80,8 @@ func TestCreateDeploymentsForeignKeys(t *testing.T) {
 }
 
 func TestGetDeployment(t *testing.T) {
-	f := newDBFixture(true)           // no foreign keys
-	listDeploymentsAndAssert(t, f, 0) // no deployments
+	f := newDBFixture(true)          // no foreign keys
+	f.listDeploymentsAndAssert(t, 0) // no deployments
 
 	d := newDeployment(f)
 	f.createDeploymentsAndAssert(t, d)
@@ -97,19 +97,19 @@ func TestGetDeployment(t *testing.T) {
 }
 
 func TestListDeployments(t *testing.T) {
-	f := newDBFixture(true)           // no foreign keys
-	listDeploymentsAndAssert(t, f, 0) // no deployments
+	f := newDBFixture(true)          // no foreign keys
+	f.listDeploymentsAndAssert(t, 0) // no deployments
 
 	d := newDeployment(f)
 	f.createDeploymentsAndAssert(t, d)
 
-	deployments := listDeploymentsAndAssert(t, f, 1)
+	deployments := f.listDeploymentsAndAssert(t, 1)
 	assert.Equal(t, d, deployments[0])
 }
 
 func TestListDeploymentsWithStats(t *testing.T) {
-	f := newDBFixture(true)           // no foreign keys
-	listDeploymentsAndAssert(t, f, 0) // ensure no deployments
+	f := newDBFixture(true)          // no foreign keys
+	f.listDeploymentsAndAssert(t, 0) // ensure no deployments
 
 	// create deployment and ensure there are no stats
 	d := newDeployment(f)
@@ -139,8 +139,8 @@ func TestListDeploymentsWithStats(t *testing.T) {
 }
 
 func TestDeleteDeployment(t *testing.T) {
-	f := newDBFixture(true)           // no foreign keys
-	listDeploymentsAndAssert(t, f, 0) // ensure no deployments
+	f := newDBFixture(true)          // no foreign keys
+	f.listDeploymentsAndAssert(t, 0) // ensure no deployments
 
 	b := newBuild()
 	d := newDeployment(f)

--- a/internal/backend/db/dbgorm/deployments_test.go
+++ b/internal/backend/db/dbgorm/deployments_test.go
@@ -54,28 +54,28 @@ func TestCreateDeployment(t *testing.T) {
 	f := newDBFixture(true)          // no foreign keys
 	f.listDeploymentsAndAssert(t, 0) // no deployments
 
-	d := newDeployment(f)
+	d := f.newDeployment()
 	// test createDeployment
 	f.createDeploymentsAndAssert(t, d)
 }
 
 func TestCreateDeploymentsForeignKeys(t *testing.T) {
 	f := newDBFixture(false) // with foreign keys
-	d := newDeployment(f)
+	d := f.newDeployment()
 	d.BuildID = "unexistingBuildID"
 	d.EnvID = "unexistingEnvID"
 
 	err := f.gormdb.createDeployment(f.ctx, &d)
 	assert.ErrorContains(t, err, "FOREIGN KEY")
 
-	p := newProject(f)
-	e := newEnv(f)
-	b := newBuild()
+	p := f.newProject()
+	e := f.newEnv()
+	b := f.newBuild()
 	f.createProjectsAndAssert(t, p)
 	f.createEnvsAndAssert(t, e)
 	f.saveBuildsAndAssert(t, b)
 
-	d = newDeployment(f)
+	d = f.newDeployment()
 	f.createDeploymentsAndAssert(t, d)
 }
 
@@ -83,7 +83,7 @@ func TestGetDeployment(t *testing.T) {
 	f := newDBFixture(true)          // no foreign keys
 	f.listDeploymentsAndAssert(t, 0) // no deployments
 
-	d := newDeployment(f)
+	d := f.newDeployment()
 	f.createDeploymentsAndAssert(t, d)
 
 	// check getDeployment
@@ -100,7 +100,7 @@ func TestListDeployments(t *testing.T) {
 	f := newDBFixture(true)          // no foreign keys
 	f.listDeploymentsAndAssert(t, 0) // no deployments
 
-	d := newDeployment(f)
+	d := f.newDeployment()
 	f.createDeploymentsAndAssert(t, d)
 
 	deployments := f.listDeploymentsAndAssert(t, 1)
@@ -112,7 +112,7 @@ func TestListDeploymentsWithStats(t *testing.T) {
 	f.listDeploymentsAndAssert(t, 0) // ensure no deployments
 
 	// create deployment and ensure there are no stats
-	d := newDeployment(f)
+	d := f.newDeployment()
 	f.createDeploymentsAndAssert(t, d)
 
 	dWS := scheme.DeploymentWithStats{Deployment: d} // no stats, all zeros
@@ -120,7 +120,7 @@ func TestListDeploymentsWithStats(t *testing.T) {
 	assert.Equal(t, dWS, deployments[0])
 
 	// add session for the stats
-	s := newSession(f, sdktypes.SessionStateTypeCompleted)
+	s := f.newSession(sdktypes.SessionStateTypeCompleted)
 	f.createSessionsAndAssert(t, s)
 
 	// ensure that new session is included in stats
@@ -142,15 +142,15 @@ func TestDeleteDeployment(t *testing.T) {
 	f := newDBFixture(true)          // no foreign keys
 	f.listDeploymentsAndAssert(t, 0) // ensure no deployments
 
-	b := newBuild()
-	d := newDeployment(f)
+	b := f.newBuild()
+	d := f.newDeployment()
 	d.BuildID = b.BuildID
 	f.saveBuildsAndAssert(t, b)
 	f.createDeploymentsAndAssert(t, d)
 
 	// add sessions and check that deployment stats are updated
-	s1 := newSession(f, sdktypes.SessionStateTypeCompleted)
-	s2 := newSession(f, sdktypes.SessionStateTypeError)
+	s1 := f.newSession(sdktypes.SessionStateTypeCompleted)
+	s2 := f.newSession(sdktypes.SessionStateTypeError)
 	f.createSessionsAndAssert(t, s1, s2)
 
 	dWS := scheme.DeploymentWithStats{Deployment: d, Completed: 1, Error: 1}

--- a/internal/backend/db/dbgorm/deployments_test.go
+++ b/internal/backend/db/dbgorm/deployments_test.go
@@ -71,7 +71,7 @@ func TestCreateDeploymentsForeignKeys(t *testing.T) {
 	b := newBuild()
 	createProjectsAndAssert(t, f, p)
 	createEnvsAndAssert(t, f, e)
-	saveBuildAndAssert(t, f, b)
+	saveBuildsAndAssert(t, f, b)
 
 	d = newDeployment(f)
 	createDeploymentsAndAssert(t, f, d)
@@ -119,7 +119,7 @@ func TestListDeploymentsWithStats(t *testing.T) {
 
 	// add session for the stats
 	s := newSession(f, sdktypes.SessionStateTypeCompleted)
-	createSessionAndAssert(t, f, s)
+	createSessionsAndAssert(t, f, s)
 
 	// ensure that new session is included in stats
 	dWS.Completed = 1
@@ -141,16 +141,16 @@ func TestDeleteDeployment(t *testing.T) {
 	listDeploymentsAndAssert(t, f, 0) // ensure no deployments
 
 	b := newBuild()
-	saveBuildAndAssert(t, f, b)
+	saveBuildsAndAssert(t, f, b)
 	d := newDeployment(f)
 	d.BuildID = b.BuildID
 	createDeploymentsAndAssert(t, f, d)
 
 	// add sessions and check that deployment stats are updated
 	session1 := newSession(f, sdktypes.SessionStateTypeCompleted)
-	createSessionAndAssert(t, f, session1)
+	createSessionsAndAssert(t, f, session1)
 	session2 := newSession(f, sdktypes.SessionStateTypeError)
-	createSessionAndAssert(t, f, session2)
+	createSessionsAndAssert(t, f, session2)
 
 	dWS := scheme.DeploymentWithStats{Deployment: d, Completed: 1, Error: 1}
 	deployments := listDeploymentsWithStatsAndAssert(t, f, 1)

--- a/internal/backend/db/dbgorm/envs.go
+++ b/internal/backend/db/dbgorm/envs.go
@@ -21,8 +21,8 @@ func envVarMembershipID(ev sdktypes.EnvVar) string {
 	return fmt.Sprintf("%s/%s", ev.EnvID().Value(), ev.Symbol().String())
 }
 
-func (db *gormdb) createEnv(ctx context.Context, env scheme.Env) error {
-	return db.db.WithContext(ctx).Create(&env).Error
+func (db *gormdb) createEnv(ctx context.Context, env *scheme.Env) error {
+	return db.db.WithContext(ctx).Create(env).Error
 }
 
 func (db *gormdb) CreateEnv(ctx context.Context, env sdktypes.Env) error {
@@ -37,7 +37,7 @@ func (db *gormdb) CreateEnv(ctx context.Context, env sdktypes.Env) error {
 		Name:         env.Name().String(),
 		MembershipID: envMembershipID(env),
 	}
-	return translateError(db.createEnv(ctx, e))
+	return translateError(db.createEnv(ctx, &e))
 }
 
 func (db *gormdb) deleteEnvs(ctx context.Context, ids []string) error {

--- a/internal/backend/db/dbgorm/envs_test.go
+++ b/internal/backend/db/dbgorm/envs_test.go
@@ -10,7 +10,7 @@ import (
 
 func createEnvsAndAssert(t *testing.T, f *dbFixture, envs ...scheme.Env) {
 	for _, env := range envs {
-		assert.NoError(t, f.gormdb.createEnv(f.ctx, env))
+		assert.NoError(t, f.gormdb.createEnv(f.ctx, &env))
 		findAndAssertOne(t, f, env, "env_id = ?", env.EnvID)
 	}
 }

--- a/internal/backend/db/dbgorm/envs_test.go
+++ b/internal/backend/db/dbgorm/envs_test.go
@@ -15,7 +15,7 @@ func (f *dbFixture) createEnvsAndAssert(t *testing.T, envs ...scheme.Env) {
 	}
 }
 
-func assertEnvDeleted(t *testing.T, f *dbFixture, envs ...scheme.Env) {
+func (f *dbFixture) assertEnvDeleted(t *testing.T, envs ...scheme.Env) {
 	for _, env := range envs {
 		assertSoftDeleted(t, f, scheme.Env{EnvID: env.EnvID})
 	}
@@ -39,7 +39,7 @@ func TestDeleteEnv(t *testing.T) {
 
 	// test deleteEnv
 	assert.NoError(t, f.gormdb.deleteEnv(f.ctx, e.EnvID))
-	assertEnvDeleted(t, f, e)
+	f.assertEnvDeleted(t, e)
 }
 
 func TestDeleteEnvs(t *testing.T) {
@@ -51,7 +51,7 @@ func TestDeleteEnvs(t *testing.T) {
 
 	// test deleteEnvs
 	assert.NoError(t, f.gormdb.deleteEnvs(f.ctx, []string{e1.EnvID, e2.EnvID}))
-	assertEnvDeleted(t, f, e1, e2)
+	f.assertEnvDeleted(t, e1, e2)
 }
 
 func TestDeleteEnvForeignKeys(t *testing.T) {
@@ -78,5 +78,5 @@ func TestDeleteEnvForeignKeys(t *testing.T) {
 	// delete deployment (referencing build), then env
 	assert.NoError(t, f.gormdb.deleteDeployment(f.ctx, d.DeploymentID))
 	assert.NoError(t, f.gormdb.deleteEnv(f.ctx, e.EnvID))
-	assertEnvDeleted(t, f, e)
+	f.assertEnvDeleted(t, e)
 }

--- a/internal/backend/db/dbgorm/envs_test.go
+++ b/internal/backend/db/dbgorm/envs_test.go
@@ -25,7 +25,7 @@ func TestCreateEnv(t *testing.T) {
 	f := newDBFixture(true)                       // no foreign keys
 	findAndAssertCount(t, f, scheme.Env{}, 0, "") // no envs
 
-	e := newEnv(f)
+	e := f.newEnv()
 	// test createEnv
 	f.createEnvsAndAssert(t, e)
 }
@@ -34,7 +34,7 @@ func TestDeleteEnv(t *testing.T) {
 	f := newDBFixture(true)                       // no foreign keys
 	findAndAssertCount(t, f, scheme.Env{}, 0, "") // no envs
 
-	e := newEnv(f)
+	e := f.newEnv()
 	f.createEnvsAndAssert(t, e)
 
 	// test deleteEnv
@@ -46,7 +46,7 @@ func TestDeleteEnvs(t *testing.T) {
 	f := newDBFixture(true)                       // no foreign keys
 	findAndAssertCount(t, f, scheme.Env{}, 0, "") // no envs
 
-	e1, e2 := newEnv(f), newEnv(f)
+	e1, e2 := f.newEnv(), f.newEnv()
 	f.createEnvsAndAssert(t, e1, e2)
 
 	// test deleteEnvs
@@ -58,11 +58,11 @@ func TestDeleteEnvForeignKeys(t *testing.T) {
 	f := newDBFixture(false)
 	findAndAssertCount(t, f, scheme.Env{}, 0, "") // no envs
 
-	b := newBuild()
-	p := newProject(f)
-	e := newEnv(f)
+	b := f.newBuild()
+	p := f.newProject()
+	e := f.newEnv()
 	e.ProjectID = p.ProjectID
-	d := newDeployment(f)
+	d := f.newDeployment()
 	d.BuildID = b.BuildID
 	d.EnvID = e.EnvID
 

--- a/internal/backend/db/dbgorm/envs_test.go
+++ b/internal/backend/db/dbgorm/envs_test.go
@@ -45,8 +45,7 @@ func TestDeleteEnvs(t *testing.T) {
 	findAndAssertCount(t, f, scheme.Env{}, 0, "") // no envs
 
 	e1, e2 := newEnv(f), newEnv(f)
-	createEnvsAndAssert(t, f, e1)
-	createEnvsAndAssert(t, f, e2)
+	createEnvsAndAssert(t, f, e1, e2)
 
 	// test deleteEnvs
 	assert.NoError(t, f.gormdb.deleteEnvs(f.ctx, []string{e1.EnvID, e2.EnvID}))

--- a/internal/backend/db/dbgorm/envs_test.go
+++ b/internal/backend/db/dbgorm/envs_test.go
@@ -15,8 +15,10 @@ func createEnvsAndAssert(t *testing.T, f *dbFixture, envs ...scheme.Env) {
 	}
 }
 
-func assertEnvDeleted(t *testing.T, f *dbFixture, envID string) {
-	assertSoftDeleted(t, f, scheme.Env{EnvID: envID})
+func assertEnvDeleted(t *testing.T, f *dbFixture, envs ...scheme.Env) {
+	for _, env := range envs {
+		assertSoftDeleted(t, f, scheme.Env{EnvID: env.EnvID})
+	}
 }
 
 func TestCreateEnv(t *testing.T) {
@@ -37,7 +39,7 @@ func TestDeleteEnv(t *testing.T) {
 
 	// test deleteEnv
 	assert.NoError(t, f.gormdb.deleteEnv(f.ctx, e.EnvID))
-	assertEnvDeleted(t, f, e.EnvID)
+	assertEnvDeleted(t, f, e)
 }
 
 func TestDeleteEnvs(t *testing.T) {
@@ -49,8 +51,7 @@ func TestDeleteEnvs(t *testing.T) {
 
 	// test deleteEnvs
 	assert.NoError(t, f.gormdb.deleteEnvs(f.ctx, []string{e1.EnvID, e2.EnvID}))
-	assertEnvDeleted(t, f, e1.EnvID)
-	assertEnvDeleted(t, f, e2.EnvID)
+	assertEnvDeleted(t, f, e1, e2)
 }
 
 func TestDeleteEnvForeignKeys(t *testing.T) {
@@ -77,5 +78,5 @@ func TestDeleteEnvForeignKeys(t *testing.T) {
 	// delete deployment (referencing build), then env
 	assert.NoError(t, f.gormdb.deleteDeployment(f.ctx, d.DeploymentID))
 	assert.NoError(t, f.gormdb.deleteEnv(f.ctx, e.EnvID))
-	assertEnvDeleted(t, f, e.EnvID)
+	assertEnvDeleted(t, f, e)
 }

--- a/internal/backend/db/dbgorm/envs_test.go
+++ b/internal/backend/db/dbgorm/envs_test.go
@@ -8,7 +8,7 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/backend/db/dbgorm/scheme"
 )
 
-func createEnvsAndAssert(t *testing.T, f *dbFixture, envs ...scheme.Env) {
+func (f *dbFixture) createEnvsAndAssert(t *testing.T, envs ...scheme.Env) {
 	for _, env := range envs {
 		assert.NoError(t, f.gormdb.createEnv(f.ctx, &env))
 		findAndAssertOne(t, f, env, "env_id = ?", env.EnvID)
@@ -27,7 +27,7 @@ func TestCreateEnv(t *testing.T) {
 
 	e := newEnv(f)
 	// test createEnv
-	createEnvsAndAssert(t, f, e)
+	f.createEnvsAndAssert(t, e)
 }
 
 func TestDeleteEnv(t *testing.T) {
@@ -35,7 +35,7 @@ func TestDeleteEnv(t *testing.T) {
 	findAndAssertCount(t, f, scheme.Env{}, 0, "") // no envs
 
 	e := newEnv(f)
-	createEnvsAndAssert(t, f, e)
+	f.createEnvsAndAssert(t, e)
 
 	// test deleteEnv
 	assert.NoError(t, f.gormdb.deleteEnv(f.ctx, e.EnvID))
@@ -47,7 +47,7 @@ func TestDeleteEnvs(t *testing.T) {
 	findAndAssertCount(t, f, scheme.Env{}, 0, "") // no envs
 
 	e1, e2 := newEnv(f), newEnv(f)
-	createEnvsAndAssert(t, f, e1, e2)
+	f.createEnvsAndAssert(t, e1, e2)
 
 	// test deleteEnvs
 	assert.NoError(t, f.gormdb.deleteEnvs(f.ctx, []string{e1.EnvID, e2.EnvID}))
@@ -66,10 +66,10 @@ func TestDeleteEnvForeignKeys(t *testing.T) {
 	d.BuildID = b.BuildID
 	d.EnvID = e.EnvID
 
-	saveBuildsAndAssert(t, f, b)
-	createProjectsAndAssert(t, f, p)
-	createEnvsAndAssert(t, f, e)
-	createDeploymentsAndAssert(t, f, d)
+	f.saveBuildsAndAssert(t, b)
+	f.createProjectsAndAssert(t, p)
+	f.createEnvsAndAssert(t, e)
+	f.createDeploymentsAndAssert(t, d)
 
 	// cannot delete env, since deployment referencing it
 	err := f.gormdb.deleteEnv(f.ctx, e.EnvID)

--- a/internal/backend/db/dbgorm/envs_test.go
+++ b/internal/backend/db/dbgorm/envs_test.go
@@ -66,7 +66,7 @@ func TestDeleteEnvForeignKeys(t *testing.T) {
 	d.BuildID = b.BuildID
 	d.EnvID = e.EnvID
 
-	saveBuildAndAssert(t, f, b)
+	saveBuildsAndAssert(t, f, b)
 	createProjectsAndAssert(t, f, p)
 	createEnvsAndAssert(t, f, e)
 	createDeploymentsAndAssert(t, f, d)

--- a/internal/backend/db/dbgorm/gorm_test.go
+++ b/internal/backend/db/dbgorm/gorm_test.go
@@ -141,7 +141,7 @@ var (
 	testIntegrationID = "int_00000000000000000000000001"
 )
 
-func newSession(f *dbFixture, st sdktypes.SessionStateType) scheme.Session {
+func (f *dbFixture) newSession(st sdktypes.SessionStateType) scheme.Session {
 	f.sessionID += 1
 	sessionID := fmt.Sprintf("ses_%026d", f.sessionID)
 
@@ -157,7 +157,7 @@ func newSession(f *dbFixture, st sdktypes.SessionStateType) scheme.Session {
 	}
 }
 
-func newBuild() scheme.Build {
+func (f *dbFixture) newBuild() scheme.Build {
 	return scheme.Build{
 		BuildID:   testBuildID,
 		Data:      []byte{},
@@ -165,7 +165,7 @@ func newBuild() scheme.Build {
 	}
 }
 
-func newDeployment(f *dbFixture) scheme.Deployment {
+func (f *dbFixture) newDeployment() scheme.Deployment {
 	f.deploymentID += 1
 	deploymentID := fmt.Sprintf("dep_%026d", f.deploymentID)
 
@@ -179,7 +179,7 @@ func newDeployment(f *dbFixture) scheme.Deployment {
 	}
 }
 
-func newProject(f *dbFixture) scheme.Project {
+func (f *dbFixture) newProject() scheme.Project {
 	f.projectID += 1
 	projectID := fmt.Sprintf("prj_%026d", f.projectID)
 
@@ -191,7 +191,7 @@ func newProject(f *dbFixture) scheme.Project {
 	}
 }
 
-func newEnv(f *dbFixture) scheme.Env {
+func (f *dbFixture) newEnv() scheme.Env {
 	f.envID += 1
 	envID := fmt.Sprintf("env_%026d", f.envID)
 
@@ -203,7 +203,7 @@ func newEnv(f *dbFixture) scheme.Env {
 	}
 }
 
-func newTrigger(f *dbFixture) scheme.Trigger {
+func (f *dbFixture) newTrigger() scheme.Trigger {
 	f.triggerID += 1
 	triggerID := fmt.Sprintf("trg_%026d", f.triggerID)
 
@@ -216,7 +216,7 @@ func newTrigger(f *dbFixture) scheme.Trigger {
 	}
 }
 
-func newConnection() scheme.Connection {
+func (f *dbFixture) newConnection() scheme.Connection {
 	return scheme.Connection{
 		ConnectionID:     testConnectionID,
 		IntegrationID:    testIntegrationID,
@@ -226,7 +226,7 @@ func newConnection() scheme.Connection {
 	}
 }
 
-func newIntegration() scheme.Integration {
+func (f *dbFixture) newIntegration() scheme.Integration {
 	return scheme.Integration{
 		IntegrationID: testIntegrationID,
 		UniqueName:    "",

--- a/internal/backend/db/dbgorm/integrations_test.go
+++ b/internal/backend/db/dbgorm/integrations_test.go
@@ -19,7 +19,7 @@ func TestCreateIntegration(t *testing.T) {
 	f := newDBFixture(true)                               // no foreign keys
 	findAndAssertCount(t, f, scheme.Integration{}, 0, "") // no integrations
 
-	i := newIntegration()
+	i := f.newIntegration()
 	// test createIntegration
 	f.createIntegrationsAndAssert(t, i)
 }

--- a/internal/backend/db/dbgorm/integrations_test.go
+++ b/internal/backend/db/dbgorm/integrations_test.go
@@ -8,7 +8,7 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/backend/db/dbgorm/scheme"
 )
 
-func createIntegrationsAndAssert(t *testing.T, f *dbFixture, integrations ...scheme.Integration) {
+func (f *dbFixture) createIntegrationsAndAssert(t *testing.T, integrations ...scheme.Integration) {
 	for _, i := range integrations {
 		assert.NoError(t, f.gormdb.createIntegration(f.ctx, &i))
 		findAndAssertOne(t, f, i, "integration_id = ?", i.IntegrationID)
@@ -21,5 +21,5 @@ func TestCreateIntegration(t *testing.T) {
 
 	i := newIntegration()
 	// test createIntegration
-	createIntegrationsAndAssert(t, f, i)
+	f.createIntegrationsAndAssert(t, i)
 }

--- a/internal/backend/db/dbgorm/projects.go
+++ b/internal/backend/db/dbgorm/projects.go
@@ -13,8 +13,8 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-func (db *gormdb) createProject(ctx context.Context, p scheme.Project) error {
-	return db.db.WithContext(ctx).Create(&p).Error
+func (db *gormdb) createProject(ctx context.Context, p *scheme.Project) error {
+	return db.db.WithContext(ctx).Create(p).Error
 }
 
 func (db *gormdb) CreateProject(ctx context.Context, p sdktypes.Project) error {
@@ -27,7 +27,7 @@ func (db *gormdb) CreateProject(ctx context.Context, p sdktypes.Project) error {
 		ProjectID: p.ID().String(),
 		Name:      p.Name().String(),
 	}
-	return translateError(db.createProject(ctx, project))
+	return translateError(db.createProject(ctx, &project))
 }
 
 func (db *gormdb) deleteProject(ctx context.Context, projectID string) error {

--- a/internal/backend/db/dbgorm/projects_test.go
+++ b/internal/backend/db/dbgorm/projects_test.go
@@ -26,8 +26,10 @@ func listProjectsAndAssert(t *testing.T, f *dbFixture, expected int) []scheme.Pr
 	return projects
 }
 
-func assertProjectDeleted(t *testing.T, f *dbFixture, projectID string) {
-	assertSoftDeleted(t, f, scheme.Project{ProjectID: projectID})
+func assertProjectDeleted(t *testing.T, f *dbFixture, projects ...scheme.Project) {
+	for _, project := range projects {
+		assertSoftDeleted(t, f, scheme.Project{ProjectID: project.ProjectID})
+	}
 }
 
 func TestCreateProject(t *testing.T) {
@@ -220,16 +222,11 @@ func TestDeleteProjectAndDependents(t *testing.T) {
 	err = f.gormdb.deleteProjectAndDependents(f.ctx, p1.ProjectID)
 	assert.NoError(t, err)
 
-	assertDeploymentDeleted(t, f, d1e1p1.DeploymentID)
-	assertDeploymentDeleted(t, f, d2e1p1.DeploymentID)
-	assertDeploymentDeleted(t, f, d1e2p1.DeploymentID)
+	assertDeploymentsDeleted(t, f, d1e1p1, d2e1p1, d1e2p1)
 
-	assertEnvDeleted(t, f, e1p1.EnvID)
-	assertEnvDeleted(t, f, e2p1.EnvID)
-	assertProjectDeleted(t, f, p1.ProjectID)
+	assertEnvDeleted(t, f, e1p1, e2p1)
+	assertProjectDeleted(t, f, p1)
 
-	assertSessionDeleted(t, f, s1d1e1p1.SessionID)
-	assertSessionDeleted(t, f, s2d1e2p1.SessionID)
-
+	assertSessionsDeleted(t, f, s1d1e1p1, s2d1e2p1)
 	assertTriggersDeleted(t, f, t1, t2)
 }

--- a/internal/backend/db/dbgorm/projects_test.go
+++ b/internal/backend/db/dbgorm/projects_test.go
@@ -19,7 +19,7 @@ func (f *dbFixture) createProjectsAndAssert(t *testing.T, projects ...scheme.Pro
 	}
 }
 
-func listProjectsAndAssert(t *testing.T, f *dbFixture, expected int) []scheme.Project {
+func (f *dbFixture) listProjectsAndAssert(t *testing.T, expected int) []scheme.Project {
 	projects, err := f.gormdb.listProjects(f.ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, len(projects))
@@ -78,12 +78,12 @@ func TestListProjects(t *testing.T) {
 	f.createProjectsAndAssert(t, p)
 
 	// test listProjects
-	projects := listProjectsAndAssert(t, f, 1)
+	projects := f.listProjectsAndAssert(t, 1)
 	assert.Equal(t, p, projects[0])
 
 	// test listProjects after delete
 	assert.NoError(t, f.gormdb.deleteProject(f.ctx, p.ProjectID))
-	listProjectsAndAssert(t, f, 0)
+	f.listProjectsAndAssert(t, 0)
 }
 
 func TestGetProjectDeployments(t *testing.T) {

--- a/internal/backend/db/dbgorm/projects_test.go
+++ b/internal/backend/db/dbgorm/projects_test.go
@@ -14,7 +14,7 @@ import (
 
 func createProjectsAndAssert(t *testing.T, f *dbFixture, projects ...scheme.Project) {
 	for _, project := range projects {
-		assert.NoError(t, f.gormdb.createProject(f.ctx, project))
+		assert.NoError(t, f.gormdb.createProject(f.ctx, &project))
 		findAndAssertOne(t, f, project, "project_id = ?", project.ProjectID)
 	}
 }

--- a/internal/backend/db/dbgorm/projects_test.go
+++ b/internal/backend/db/dbgorm/projects_test.go
@@ -26,7 +26,7 @@ func listProjectsAndAssert(t *testing.T, f *dbFixture, expected int) []scheme.Pr
 	return projects
 }
 
-func assertProjectDeleted(t *testing.T, f *dbFixture, projects ...scheme.Project) {
+func (f *dbFixture) assertProjectDeleted(t *testing.T, projects ...scheme.Project) {
 	for _, project := range projects {
 		assertSoftDeleted(t, f, scheme.Project{ProjectID: project.ProjectID})
 	}
@@ -222,11 +222,9 @@ func TestDeleteProjectAndDependents(t *testing.T) {
 	err = f.gormdb.deleteProjectAndDependents(f.ctx, p1.ProjectID)
 	assert.NoError(t, err)
 
-	assertDeploymentsDeleted(t, f, d1e1p1, d2e1p1, d1e2p1)
-
-	assertEnvDeleted(t, f, e1p1, e2p1)
-	assertProjectDeleted(t, f, p1)
-
-	assertSessionsDeleted(t, f, s1d1e1p1, s2d1e2p1)
-	assertTriggersDeleted(t, f, t1, t2)
+	f.assertDeploymentsDeleted(t, d1e1p1, d2e1p1, d1e2p1)
+	f.assertEnvDeleted(t, e1p1, e2p1)
+	f.assertProjectDeleted(t, p1)
+	f.assertSessionsDeleted(t, s1d1e1p1, s2d1e2p1)
+	f.assertTriggersDeleted(t, t1, t2)
 }

--- a/internal/backend/db/dbgorm/projects_test.go
+++ b/internal/backend/db/dbgorm/projects_test.go
@@ -12,7 +12,7 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-func createProjectsAndAssert(t *testing.T, f *dbFixture, projects ...scheme.Project) {
+func (f *dbFixture) createProjectsAndAssert(t *testing.T, projects ...scheme.Project) {
 	for _, project := range projects {
 		assert.NoError(t, f.gormdb.createProject(f.ctx, &project))
 		findAndAssertOne(t, f, project, "project_id = ?", project.ProjectID)
@@ -38,7 +38,7 @@ func TestCreateProject(t *testing.T) {
 
 	p := newProject(f)
 	// test createProject
-	createProjectsAndAssert(t, f, p)
+	f.createProjectsAndAssert(t, p)
 }
 
 func TestGetProjects(t *testing.T) {
@@ -46,7 +46,7 @@ func TestGetProjects(t *testing.T) {
 	findAndAssertCount(t, f, scheme.Project{}, 0, "") // no projects
 
 	p := newProject(f)
-	createProjectsAndAssert(t, f, p)
+	f.createProjectsAndAssert(t, p)
 
 	// test getProjectByID
 	project, err := f.gormdb.getProject(f.ctx, p.ProjectID)
@@ -75,7 +75,7 @@ func TestListProjects(t *testing.T) {
 	findAndAssertCount(t, f, scheme.Project{}, 0, "") // no projects
 
 	p := newProject(f)
-	createProjectsAndAssert(t, f, p)
+	f.createProjectsAndAssert(t, p)
 
 	// test listProjects
 	projects := listProjectsAndAssert(t, f, 1)
@@ -112,9 +112,9 @@ func TestGetProjectDeployments(t *testing.T) {
 	d3.EnvID = e2.EnvID
 	d4.EnvID = e4.EnvID
 
-	createProjectsAndAssert(t, f, p1, p2)
-	createEnvsAndAssert(t, f, e1, e2, e3, e4)
-	createDeploymentsAndAssert(t, f, d1, d2, d3, d4)
+	f.createProjectsAndAssert(t, p1, p2)
+	f.createEnvsAndAssert(t, e1, e2, e3, e4)
+	f.createDeploymentsAndAssert(t, d1, d2, d3, d4)
 
 	ds, err := f.gormdb.getProjectDeployments(f.ctx, p1.ProjectID)
 	assert.NoError(t, err)
@@ -135,9 +135,9 @@ func TestGetProjectEnvs(t *testing.T) {
 	e2.ProjectID = p.ProjectID
 	d.EnvID = e1.EnvID
 
-	createProjectsAndAssert(t, f, p)
-	createEnvsAndAssert(t, f, e1, e2)
-	createDeploymentsAndAssert(t, f, d)
+	f.createProjectsAndAssert(t, p)
+	f.createEnvsAndAssert(t, e1, e2)
+	f.createDeploymentsAndAssert(t, d)
 
 	envIDs, err := f.gormdb.getProjectEnvs(f.ctx, p.ProjectID)
 	assert.NoError(t, err)
@@ -201,14 +201,14 @@ func TestDeleteProjectAndDependents(t *testing.T) {
 	s2d1e2p1.DeploymentID = d1e2p1.DeploymentID
 	s3d1e1p2.DeploymentID = d1e1p2.DeploymentID
 
-	createProjectsAndAssert(t, f, p1, p2)
-	createIntegrationsAndAssert(t, f, i)
-	createConnectionsAndAssert(t, f, c)
-	createEnvsAndAssert(t, f, e1p1, e2p1, e1p2)
-	createTriggersAndAssert(t, f, t1, t2)
-	saveBuildsAndAssert(t, f, b)
-	createDeploymentsAndAssert(t, f, d1e1p1, d2e1p1, d1e2p1, d1e1p2)
-	createSessionsAndAssert(t, f, s1d1e1p1, s2d1e2p1, s3d1e1p2)
+	f.createProjectsAndAssert(t, p1, p2)
+	f.createIntegrationsAndAssert(t, i)
+	f.createConnectionsAndAssert(t, c)
+	f.createEnvsAndAssert(t, e1p1, e2p1, e1p2)
+	f.createTriggersAndAssert(t, t1, t2)
+	f.saveBuildsAndAssert(t, b)
+	f.createDeploymentsAndAssert(t, d1e1p1, d2e1p1, d1e2p1, d1e1p2)
+	f.createSessionsAndAssert(t, s1d1e1p1, s2d1e2p1, s3d1e1p2)
 
 	// ensure failure if deployments are not inactive
 	err := f.gormdb.deleteProjectAndDependents(f.ctx, p1.ProjectID)

--- a/internal/backend/db/dbgorm/projects_test.go
+++ b/internal/backend/db/dbgorm/projects_test.go
@@ -209,15 +209,15 @@ func TestDeleteProjectAndDependents(t *testing.T) {
 	createEnvsAndAssert(t, f, e1p2)
 	createTriggersAndAssert(t, f, t1, t2)
 
-	saveBuildAndAssert(t, f, b)
+	saveBuildsAndAssert(t, f, b)
 	createDeploymentsAndAssert(t, f, d1e1p1)
 	createDeploymentsAndAssert(t, f, d2e1p1)
 	createDeploymentsAndAssert(t, f, d1e2p1)
 	createDeploymentsAndAssert(t, f, d1e1p2)
 
-	createSessionAndAssert(t, f, s1d1e1p1)
-	createSessionAndAssert(t, f, s2d1e2p1)
-	createSessionAndAssert(t, f, s3d1e1p2)
+	createSessionsAndAssert(t, f, s1d1e1p1)
+	createSessionsAndAssert(t, f, s2d1e2p1)
+	createSessionsAndAssert(t, f, s3d1e1p2)
 
 	// ensure failure if deployments are not inactive
 	err := f.gormdb.deleteProjectAndDependents(f.ctx, p1.ProjectID)

--- a/internal/backend/db/dbgorm/projects_test.go
+++ b/internal/backend/db/dbgorm/projects_test.go
@@ -36,7 +36,7 @@ func TestCreateProject(t *testing.T) {
 	f := newDBFixture(true)                           // no foreign keys
 	findAndAssertCount(t, f, scheme.Project{}, 0, "") // no projects
 
-	p := newProject(f)
+	p := f.newProject()
 	// test createProject
 	f.createProjectsAndAssert(t, p)
 }
@@ -45,7 +45,7 @@ func TestGetProjects(t *testing.T) {
 	f := newDBFixture(true)                           // no foreign keys
 	findAndAssertCount(t, f, scheme.Project{}, 0, "") // no projects
 
-	p := newProject(f)
+	p := f.newProject()
 	f.createProjectsAndAssert(t, p)
 
 	// test getProjectByID
@@ -74,7 +74,7 @@ func TestListProjects(t *testing.T) {
 	f := newDBFixture(true)                           // no foreign keys
 	findAndAssertCount(t, f, scheme.Project{}, 0, "") // no projects
 
-	p := newProject(f)
+	p := f.newProject()
 	f.createProjectsAndAssert(t, p)
 
 	// test listProjects
@@ -98,9 +98,9 @@ func TestGetProjectDeployments(t *testing.T) {
 	//
 	// p2:
 	// - e4: (d4)
-	p1, p2 := newProject(f), newProject(f)
-	e1, e2, e3, e4 := newEnv(f), newEnv(f), newEnv(f), newEnv(f)
-	d1, d2, d3, d4 := newDeployment(f), newDeployment(f), newDeployment(f), newDeployment(f)
+	p1, p2 := f.newProject(), f.newProject()
+	e1, e2, e3, e4 := f.newEnv(), f.newEnv(), f.newEnv(), f.newEnv()
+	d1, d2, d3, d4 := f.newDeployment(), f.newDeployment(), f.newDeployment(), f.newDeployment()
 
 	e1.ProjectID = p1.ProjectID
 	e2.ProjectID = p1.ProjectID
@@ -127,9 +127,9 @@ func TestGetProjectEnvs(t *testing.T) {
 	findAndAssertCount(t, f, scheme.Project{}, 0, "") // no projects
 
 	// create two envs - one with deployment and second without
-	p := newProject(f)
-	e1, e2 := newEnv(f), newEnv(f)
-	d := newDeployment(f)
+	p := f.newProject()
+	e1, e2 := f.newEnv(), f.newEnv()
+	d := f.newDeployment()
 
 	e1.ProjectID = p.ProjectID
 	e2.ProjectID = p.ProjectID
@@ -159,19 +159,19 @@ func TestDeleteProjectAndDependents(t *testing.T) {
 	// - p2
 	//   - e1
 	//     - d1 (s3)
-	p1, p2 := newProject(f), newProject(f)
+	p1, p2 := f.newProject(), f.newProject()
 
-	i := newIntegration()
-	c := newConnection()
+	i := f.newIntegration()
+	c := f.newConnection()
 	c.IntegrationID = i.IntegrationID
 	c.ProjectID = p1.ProjectID
 
-	e1p1, e2p1, e1p2 := newEnv(f), newEnv(f), newEnv(f)
+	e1p1, e2p1, e1p2 := f.newEnv(), f.newEnv(), f.newEnv()
 	e1p1.ProjectID = p1.ProjectID
 	e2p1.ProjectID = p1.ProjectID
 	e1p2.ProjectID = p2.ProjectID
 
-	t1, t2 := newTrigger(f), newTrigger(f)
+	t1, t2 := f.newTrigger(), f.newTrigger()
 	t1.ProjectID = p1.ProjectID
 	t1.EnvID = e1p1.EnvID
 	t1.ConnectionID = c.ConnectionID
@@ -179,12 +179,9 @@ func TestDeleteProjectAndDependents(t *testing.T) {
 	t2.EnvID = e2p1.EnvID
 	t1.ConnectionID = c.ConnectionID
 
-	b := newBuild()
+	b := f.newBuild()
 
-	d1e1p1 := newDeployment(f)
-	d2e1p1 := newDeployment(f)
-	d1e2p1 := newDeployment(f)
-	d1e1p2 := newDeployment(f)
+	d1e1p1, d2e1p1, d1e2p1, d1e1p2 := f.newDeployment(), f.newDeployment(), f.newDeployment(), f.newDeployment()
 	d1e1p1.EnvID = e1p1.EnvID
 	d2e1p1.EnvID = e1p1.EnvID
 	d1e2p1.EnvID = e2p1.EnvID
@@ -194,9 +191,9 @@ func TestDeleteProjectAndDependents(t *testing.T) {
 	d1e2p1.BuildID = b.BuildID
 	d1e1p2.BuildID = b.BuildID
 
-	s1d1e1p1 := newSession(f, sdktypes.SessionStateTypeCompleted)
-	s2d1e2p1 := newSession(f, sdktypes.SessionStateTypeError)
-	s3d1e1p2 := newSession(f, sdktypes.SessionStateTypeCompleted)
+	s1d1e1p1 := f.newSession(sdktypes.SessionStateTypeCompleted)
+	s2d1e2p1 := f.newSession(sdktypes.SessionStateTypeError)
+	s3d1e1p2 := f.newSession(sdktypes.SessionStateTypeCompleted)
 	s1d1e1p1.DeploymentID = d1e1p1.DeploymentID
 	s2d1e2p1.DeploymentID = d1e2p1.DeploymentID
 	s3d1e1p2.DeploymentID = d1e1p2.DeploymentID

--- a/internal/backend/db/dbgorm/projects_test.go
+++ b/internal/backend/db/dbgorm/projects_test.go
@@ -199,25 +199,14 @@ func TestDeleteProjectAndDependents(t *testing.T) {
 	s2d1e2p1.DeploymentID = d1e2p1.DeploymentID
 	s3d1e1p2.DeploymentID = d1e1p2.DeploymentID
 
-	createProjectsAndAssert(t, f, p1)
-	createProjectsAndAssert(t, f, p2)
+	createProjectsAndAssert(t, f, p1, p2)
 	createIntegrationsAndAssert(t, f, i)
 	createConnectionsAndAssert(t, f, c)
-
-	createEnvsAndAssert(t, f, e1p1)
-	createEnvsAndAssert(t, f, e2p1)
-	createEnvsAndAssert(t, f, e1p2)
+	createEnvsAndAssert(t, f, e1p1, e2p1, e1p2)
 	createTriggersAndAssert(t, f, t1, t2)
-
 	saveBuildsAndAssert(t, f, b)
-	createDeploymentsAndAssert(t, f, d1e1p1)
-	createDeploymentsAndAssert(t, f, d2e1p1)
-	createDeploymentsAndAssert(t, f, d1e2p1)
-	createDeploymentsAndAssert(t, f, d1e1p2)
-
-	createSessionsAndAssert(t, f, s1d1e1p1)
-	createSessionsAndAssert(t, f, s2d1e2p1)
-	createSessionsAndAssert(t, f, s3d1e1p2)
+	createDeploymentsAndAssert(t, f, d1e1p1, d2e1p1, d1e2p1, d1e1p2)
+	createSessionsAndAssert(t, f, s1d1e1p1, s2d1e2p1, s3d1e1p2)
 
 	// ensure failure if deployments are not inactive
 	err := f.gormdb.deleteProjectAndDependents(f.ctx, p1.ProjectID)

--- a/internal/backend/db/dbgorm/secrets_test.go
+++ b/internal/backend/db/dbgorm/secrets_test.go
@@ -8,51 +8,51 @@ import (
 )
 
 func TestSetGetSecret(t *testing.T) {
-	db := newDBFixture(true) // No foreign keys.
+	f := newDBFixture(true) // No foreign keys.
 
 	want := map[string]string{"key": "value"}
-	err := db.gormdb.SetSecret(db.ctx, "name", want)
+	err := f.gormdb.SetSecret(f.ctx, "name", want)
 	assert.NoError(t, err)
 
-	got, err := db.gormdb.GetSecret(db.ctx, "name")
+	got, err := f.gormdb.GetSecret(f.ctx, "name")
 	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 }
 
 func TestGetSecretError(t *testing.T) {
-	db := newDBFixture(true) // No foreign keys.
+	f := newDBFixture(true) // No foreign keys.
 
-	got, err := db.gormdb.GetSecret(db.ctx, "name")
+	got, err := f.gormdb.GetSecret(f.ctx, "name")
 	assert.ErrorIs(t, err, sdkerrors.ErrNotFound)
 	assert.Nil(t, got)
 }
 
 func TestSetAppendGetSecret(t *testing.T) {
-	db := newDBFixture(true) // No foreign keys.
+	f := newDBFixture(true) // No foreign keys.
 
 	data := map[string]string{"key1": "value1"}
-	err := db.gormdb.SetSecret(db.ctx, "name", data)
+	err := f.gormdb.SetSecret(f.ctx, "name", data)
 	assert.NoError(t, err)
 
-	err = db.gormdb.AppendSecret(db.ctx, "name", "key2")
+	err = f.gormdb.AppendSecret(f.ctx, "name", "key2")
 	assert.NoError(t, err)
 
-	got, err := db.gormdb.GetSecret(db.ctx, "name")
+	got, err := f.gormdb.GetSecret(f.ctx, "name")
 	assert.NoError(t, err)
 	assert.NotEqual(t, "", got["key2"])
 }
 
 func TestSetDeleteGetSecret(t *testing.T) {
-	db := newDBFixture(true) // No foreign keys.
+	f := newDBFixture(true) // No foreign keys.
 
 	data := map[string]string{"key": "value"}
-	err := db.gormdb.SetSecret(db.ctx, "name", data)
+	err := f.gormdb.SetSecret(f.ctx, "name", data)
 	assert.NoError(t, err)
 
-	err = db.gormdb.DeleteSecret(db.ctx, "name")
+	err = f.gormdb.DeleteSecret(f.ctx, "name")
 	assert.NoError(t, err)
 
-	got, err := db.gormdb.GetSecret(db.ctx, "name")
+	got, err := f.gormdb.GetSecret(f.ctx, "name")
 	assert.ErrorIs(t, err, sdkerrors.ErrNotFound)
 	assert.Nil(t, got)
 }

--- a/internal/backend/db/dbgorm/sessions.go
+++ b/internal/backend/db/dbgorm/sessions.go
@@ -49,9 +49,9 @@ func (db *gormdb) GetSessionLog(ctx context.Context, sessionID sdktypes.SessionI
 	return sdktypes.NewSessionLog(prs), err
 }
 
-func (db *gormdb) createSession(ctx context.Context, session scheme.Session) error {
+func (db *gormdb) createSession(ctx context.Context, session *scheme.Session) error {
 	return db.transaction(ctx, func(tx *tx) error {
-		if err := tx.db.Create(&session).Error; err != nil {
+		if err := tx.db.Create(session).Error; err != nil {
 			return err
 		}
 		return addSessionLogRecord(
@@ -75,7 +75,7 @@ func (db *gormdb) CreateSession(ctx context.Context, session sdktypes.Session) e
 		CreatedAt:        now,
 		UpdatedAt:        now,
 	}
-	return translateError(db.createSession(ctx, s))
+	return translateError(db.createSession(ctx, &s))
 }
 
 func (db *gormdb) UpdateSessionState(ctx context.Context, sessionID sdktypes.SessionID, state sdktypes.SessionState) error {

--- a/internal/backend/db/dbgorm/sessions_test.go
+++ b/internal/backend/db/dbgorm/sessions_test.go
@@ -12,7 +12,7 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-func createSessionsAndAssert(t *testing.T, f *dbFixture, sessions ...scheme.Session) {
+func (f *dbFixture) createSessionsAndAssert(t *testing.T, sessions ...scheme.Session) {
 	for _, session := range sessions {
 		assert.NoError(t, f.gormdb.createSession(f.ctx, &session))
 		findAndAssertOne(t, f, session, "session_id = ?", session.SessionID)
@@ -45,7 +45,7 @@ func TestCreateSession(t *testing.T) {
 
 	s := newSession(f, sdktypes.SessionStateTypeCompleted)
 	// test createSession
-	createSessionsAndAssert(t, f, s)
+	f.createSessionsAndAssert(t, s)
 
 	logs := findAndAssertCount(t, f, scheme.SessionLogRecord{}, 1, "session_id = ?", s.SessionID)
 	assert.Equal(t, s.SessionID, logs[0].SessionID) // compare only ids, since actual log isn't empty
@@ -65,7 +65,7 @@ func TestGetSession(t *testing.T) {
 	listSessionsAndAssert(t, f, 0) // no sessions
 
 	s := newSession(f, sdktypes.SessionStateTypeCompleted)
-	createSessionsAndAssert(t, f, s)
+	f.createSessionsAndAssert(t, s)
 
 	// check getSession
 	session, err := f.gormdb.getSession(f.ctx, s.SessionID)
@@ -83,7 +83,7 @@ func TestListSessions(t *testing.T) {
 	listSessionsAndAssert(t, f, 0) // no sessions
 
 	s := newSession(f, sdktypes.SessionStateTypeCompleted)
-	createSessionsAndAssert(t, f, s)
+	f.createSessionsAndAssert(t, s)
 
 	sessions := listSessionsAndAssert(t, f, 1)
 	assert.Equal(t, s, sessions[0])
@@ -98,7 +98,7 @@ func TestDeleteSession(t *testing.T) {
 	listSessionsAndAssert(t, f, 0) // no sessions
 
 	s := newSession(f, sdktypes.SessionStateTypeCompleted)
-	createSessionsAndAssert(t, f, s)
+	f.createSessionsAndAssert(t, s)
 
 	assert.NoError(t, f.gormdb.deleteSession(f.ctx, s.SessionID))
 	assertSessionsDeleted(t, f, s)

--- a/internal/backend/db/dbgorm/sessions_test.go
+++ b/internal/backend/db/dbgorm/sessions_test.go
@@ -33,8 +33,10 @@ func listSessionsAndAssert(t *testing.T, f *dbFixture, expected int) []scheme.Se
 	return sessions
 }
 
-func assertSessionDeleted(t *testing.T, f *dbFixture, sessionID string) {
-	assertSoftDeleted(t, f, scheme.Session{SessionID: sessionID})
+func assertSessionsDeleted(t *testing.T, f *dbFixture, sessions ...scheme.Session) {
+	for _, session := range sessions {
+		assertSoftDeleted(t, f, scheme.Session{SessionID: session.SessionID})
+	}
 }
 
 func TestCreateSession(t *testing.T) {
@@ -99,5 +101,5 @@ func TestDeleteSession(t *testing.T) {
 	createSessionsAndAssert(t, f, s)
 
 	assert.NoError(t, f.gormdb.deleteSession(f.ctx, s.SessionID))
-	assertSessionDeleted(t, f, s.SessionID)
+	assertSessionsDeleted(t, f, s)
 }

--- a/internal/backend/db/dbgorm/sessions_test.go
+++ b/internal/backend/db/dbgorm/sessions_test.go
@@ -19,7 +19,7 @@ func (f *dbFixture) createSessionsAndAssert(t *testing.T, sessions ...scheme.Ses
 	}
 }
 
-func listSessionsAndAssert(t *testing.T, f *dbFixture, expected int) []scheme.Session {
+func (f *dbFixture) listSessionsAndAssert(t *testing.T, expected int) []scheme.Session {
 	flt := sdkservices.ListSessionsFilter{
 		CountOnly: false,
 		StateType: sdktypes.SessionStateTypeUnspecified, // fetch all sesssions
@@ -40,8 +40,8 @@ func (f *dbFixture) assertSessionsDeleted(t *testing.T, sessions ...scheme.Sessi
 }
 
 func TestCreateSession(t *testing.T) {
-	f := newDBFixture(true)        // no foreign keys
-	listSessionsAndAssert(t, f, 0) // no sessions
+	f := newDBFixture(true)       // no foreign keys
+	f.listSessionsAndAssert(t, 0) // no sessions
 
 	s := newSession(f, sdktypes.SessionStateTypeCompleted)
 	// test createSession
@@ -52,8 +52,8 @@ func TestCreateSession(t *testing.T) {
 }
 
 func TestCreateSessionForeignKeys(t *testing.T) {
-	f := newDBFixture(false)       // with foreign keys
-	listSessionsAndAssert(t, f, 0) // no sessions
+	f := newDBFixture(false)      // with foreign keys
+	f.listSessionsAndAssert(t, 0) // no sessions
 
 	s := newSession(f, sdktypes.SessionStateTypeCompleted)
 	err := f.gormdb.createSession(f.ctx, &s) // should fail since there is no deployment
@@ -61,8 +61,8 @@ func TestCreateSessionForeignKeys(t *testing.T) {
 }
 
 func TestGetSession(t *testing.T) {
-	f := newDBFixture(true)        // no foreign keys
-	listSessionsAndAssert(t, f, 0) // no sessions
+	f := newDBFixture(true)       // no foreign keys
+	f.listSessionsAndAssert(t, 0) // no sessions
 
 	s := newSession(f, sdktypes.SessionStateTypeCompleted)
 	f.createSessionsAndAssert(t, s)
@@ -79,23 +79,23 @@ func TestGetSession(t *testing.T) {
 }
 
 func TestListSessions(t *testing.T) {
-	f := newDBFixture(true)        // no foreign keys
-	listSessionsAndAssert(t, f, 0) // no sessions
+	f := newDBFixture(true)       // no foreign keys
+	f.listSessionsAndAssert(t, 0) // no sessions
 
 	s := newSession(f, sdktypes.SessionStateTypeCompleted)
 	f.createSessionsAndAssert(t, s)
 
-	sessions := listSessionsAndAssert(t, f, 1)
+	sessions := f.listSessionsAndAssert(t, 1)
 	assert.Equal(t, s, sessions[0])
 
 	// deleteSession and ensure that listSessions is empty
 	assert.NoError(t, f.gormdb.deleteSession(f.ctx, s.SessionID))
-	listSessionsAndAssert(t, f, 0)
+	f.listSessionsAndAssert(t, 0)
 }
 
 func TestDeleteSession(t *testing.T) {
-	f := newDBFixture(true)        // no foreign keys
-	listSessionsAndAssert(t, f, 0) // no sessions
+	f := newDBFixture(true)       // no foreign keys
+	f.listSessionsAndAssert(t, 0) // no sessions
 
 	s := newSession(f, sdktypes.SessionStateTypeCompleted)
 	f.createSessionsAndAssert(t, s)

--- a/internal/backend/db/dbgorm/sessions_test.go
+++ b/internal/backend/db/dbgorm/sessions_test.go
@@ -33,7 +33,7 @@ func listSessionsAndAssert(t *testing.T, f *dbFixture, expected int) []scheme.Se
 	return sessions
 }
 
-func assertSessionsDeleted(t *testing.T, f *dbFixture, sessions ...scheme.Session) {
+func (f *dbFixture) assertSessionsDeleted(t *testing.T, sessions ...scheme.Session) {
 	for _, session := range sessions {
 		assertSoftDeleted(t, f, scheme.Session{SessionID: session.SessionID})
 	}
@@ -101,5 +101,5 @@ func TestDeleteSession(t *testing.T) {
 	f.createSessionsAndAssert(t, s)
 
 	assert.NoError(t, f.gormdb.deleteSession(f.ctx, s.SessionID))
-	assertSessionsDeleted(t, f, s)
+	f.assertSessionsDeleted(t, s)
 }

--- a/internal/backend/db/dbgorm/sessions_test.go
+++ b/internal/backend/db/dbgorm/sessions_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func createSessionAndAssert(t *testing.T, f *dbFixture, session scheme.Session) {
-	assert.NoError(t, f.gormdb.createSession(f.ctx, session))
+	assert.NoError(t, f.gormdb.createSession(f.ctx, &session))
 	findAndAssertOne(t, f, session, "session_id = ?", session.SessionID)
 }
 
@@ -52,7 +52,7 @@ func TestCreateSessionForeignKeys(t *testing.T) {
 	listSessionsAndAssert(t, f, 0) // no sessions
 
 	s := newSession(f, sdktypes.SessionStateTypeCompleted)
-	err := f.gormdb.createSession(f.ctx, s) // should fail since there is no deployment
+	err := f.gormdb.createSession(f.ctx, &s) // should fail since there is no deployment
 	assert.ErrorContains(t, err, "FOREIGN KEY")
 }
 

--- a/internal/backend/db/dbgorm/sessions_test.go
+++ b/internal/backend/db/dbgorm/sessions_test.go
@@ -43,7 +43,7 @@ func TestCreateSession(t *testing.T) {
 	f := newDBFixture(true)       // no foreign keys
 	f.listSessionsAndAssert(t, 0) // no sessions
 
-	s := newSession(f, sdktypes.SessionStateTypeCompleted)
+	s := f.newSession(sdktypes.SessionStateTypeCompleted)
 	// test createSession
 	f.createSessionsAndAssert(t, s)
 
@@ -55,7 +55,7 @@ func TestCreateSessionForeignKeys(t *testing.T) {
 	f := newDBFixture(false)      // with foreign keys
 	f.listSessionsAndAssert(t, 0) // no sessions
 
-	s := newSession(f, sdktypes.SessionStateTypeCompleted)
+	s := f.newSession(sdktypes.SessionStateTypeCompleted)
 	err := f.gormdb.createSession(f.ctx, &s) // should fail since there is no deployment
 	assert.ErrorContains(t, err, "FOREIGN KEY")
 }
@@ -64,7 +64,7 @@ func TestGetSession(t *testing.T) {
 	f := newDBFixture(true)       // no foreign keys
 	f.listSessionsAndAssert(t, 0) // no sessions
 
-	s := newSession(f, sdktypes.SessionStateTypeCompleted)
+	s := f.newSession(sdktypes.SessionStateTypeCompleted)
 	f.createSessionsAndAssert(t, s)
 
 	// check getSession
@@ -82,7 +82,7 @@ func TestListSessions(t *testing.T) {
 	f := newDBFixture(true)       // no foreign keys
 	f.listSessionsAndAssert(t, 0) // no sessions
 
-	s := newSession(f, sdktypes.SessionStateTypeCompleted)
+	s := f.newSession(sdktypes.SessionStateTypeCompleted)
 	f.createSessionsAndAssert(t, s)
 
 	sessions := f.listSessionsAndAssert(t, 1)
@@ -97,7 +97,7 @@ func TestDeleteSession(t *testing.T) {
 	f := newDBFixture(true)       // no foreign keys
 	f.listSessionsAndAssert(t, 0) // no sessions
 
-	s := newSession(f, sdktypes.SessionStateTypeCompleted)
+	s := f.newSession(sdktypes.SessionStateTypeCompleted)
 	f.createSessionsAndAssert(t, s)
 
 	assert.NoError(t, f.gormdb.deleteSession(f.ctx, s.SessionID))

--- a/internal/backend/db/dbgorm/sessions_test.go
+++ b/internal/backend/db/dbgorm/sessions_test.go
@@ -12,9 +12,11 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-func createSessionAndAssert(t *testing.T, f *dbFixture, session scheme.Session) {
-	assert.NoError(t, f.gormdb.createSession(f.ctx, &session))
-	findAndAssertOne(t, f, session, "session_id = ?", session.SessionID)
+func createSessionsAndAssert(t *testing.T, f *dbFixture, sessions ...scheme.Session) {
+	for _, session := range sessions {
+		assert.NoError(t, f.gormdb.createSession(f.ctx, &session))
+		findAndAssertOne(t, f, session, "session_id = ?", session.SessionID)
+	}
 }
 
 func listSessionsAndAssert(t *testing.T, f *dbFixture, expected int) []scheme.Session {
@@ -41,7 +43,7 @@ func TestCreateSession(t *testing.T) {
 
 	s := newSession(f, sdktypes.SessionStateTypeCompleted)
 	// test createSession
-	createSessionAndAssert(t, f, s)
+	createSessionsAndAssert(t, f, s)
 
 	logs := findAndAssertCount(t, f, scheme.SessionLogRecord{}, 1, "session_id = ?", s.SessionID)
 	assert.Equal(t, s.SessionID, logs[0].SessionID) // compare only ids, since actual log isn't empty
@@ -61,7 +63,7 @@ func TestGetSession(t *testing.T) {
 	listSessionsAndAssert(t, f, 0) // no sessions
 
 	s := newSession(f, sdktypes.SessionStateTypeCompleted)
-	createSessionAndAssert(t, f, s)
+	createSessionsAndAssert(t, f, s)
 
 	// check getSession
 	session, err := f.gormdb.getSession(f.ctx, s.SessionID)
@@ -79,7 +81,7 @@ func TestListSessions(t *testing.T) {
 	listSessionsAndAssert(t, f, 0) // no sessions
 
 	s := newSession(f, sdktypes.SessionStateTypeCompleted)
-	createSessionAndAssert(t, f, s)
+	createSessionsAndAssert(t, f, s)
 
 	sessions := listSessionsAndAssert(t, f, 1)
 	assert.Equal(t, s, sessions[0])
@@ -94,7 +96,7 @@ func TestDeleteSession(t *testing.T) {
 	listSessionsAndAssert(t, f, 0) // no sessions
 
 	s := newSession(f, sdktypes.SessionStateTypeCompleted)
-	createSessionAndAssert(t, f, s)
+	createSessionsAndAssert(t, f, s)
 
 	assert.NoError(t, f.gormdb.deleteSession(f.ctx, s.SessionID))
 	assertSessionDeleted(t, f, s.SessionID)

--- a/internal/backend/db/dbgorm/triggers.go
+++ b/internal/backend/db/dbgorm/triggers.go
@@ -43,8 +43,8 @@ func triggerToRecord(ctx context.Context, tx *tx, trigger sdktypes.Trigger) (*sc
 	}, nil
 }
 
-func (db *gormdb) createTrigger(ctx context.Context, trigger scheme.Trigger) error {
-	return db.db.WithContext(ctx).Create(&trigger).Error
+func (db *gormdb) createTrigger(ctx context.Context, trigger *scheme.Trigger) error {
+	return db.db.WithContext(ctx).Create(trigger).Error
 }
 
 func (db *gormdb) CreateTrigger(ctx context.Context, trigger sdktypes.Trigger) error {
@@ -54,7 +54,7 @@ func (db *gormdb) CreateTrigger(ctx context.Context, trigger sdktypes.Trigger) e
 			return err
 		}
 
-		return translateError(tx.createTrigger(ctx, *t))
+		return translateError(tx.createTrigger(ctx, t))
 	})
 }
 

--- a/internal/backend/db/dbgorm/triggers_test.go
+++ b/internal/backend/db/dbgorm/triggers_test.go
@@ -8,7 +8,7 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/backend/db/dbgorm/scheme"
 )
 
-func createTriggersAndAssert(t *testing.T, f *dbFixture, triggers ...scheme.Trigger) {
+func (f *dbFixture) createTriggersAndAssert(t *testing.T, triggers ...scheme.Trigger) {
 	for _, trigger := range triggers {
 		assert.NoError(t, f.gormdb.createTrigger(f.ctx, &trigger))
 		findAndAssertOne(t, f, trigger, "trigger_id = ?", trigger.TriggerID)
@@ -27,7 +27,7 @@ func TestCreateTrigger(t *testing.T) {
 
 	tr := newTrigger(f)
 	// test createTrigger
-	createTriggersAndAssert(t, f, tr)
+	f.createTriggersAndAssert(t, tr)
 }
 
 func TestDeleteTrigger(t *testing.T) {
@@ -35,7 +35,7 @@ func TestDeleteTrigger(t *testing.T) {
 	findAndAssertCount(t, f, scheme.Trigger{}, 0, "") // no trigger
 
 	tr := newTrigger(f)
-	createTriggersAndAssert(t, f, tr)
+	f.createTriggersAndAssert(t, tr)
 
 	// test deleteTrigger
 	assert.NoError(t, f.gormdb.deleteTrigger(f.ctx, tr.TriggerID))

--- a/internal/backend/db/dbgorm/triggers_test.go
+++ b/internal/backend/db/dbgorm/triggers_test.go
@@ -10,7 +10,7 @@ import (
 
 func createTriggersAndAssert(t *testing.T, f *dbFixture, triggers ...scheme.Trigger) {
 	for _, trigger := range triggers {
-		assert.NoError(t, f.gormdb.createTrigger(f.ctx, trigger))
+		assert.NoError(t, f.gormdb.createTrigger(f.ctx, &trigger))
 		findAndAssertOne(t, f, trigger, "trigger_id = ?", trigger.TriggerID)
 	}
 }

--- a/internal/backend/db/dbgorm/triggers_test.go
+++ b/internal/backend/db/dbgorm/triggers_test.go
@@ -15,7 +15,7 @@ func (f *dbFixture) createTriggersAndAssert(t *testing.T, triggers ...scheme.Tri
 	}
 }
 
-func assertTriggersDeleted(t *testing.T, f *dbFixture, triggers ...scheme.Trigger) {
+func (f *dbFixture) assertTriggersDeleted(t *testing.T, triggers ...scheme.Trigger) {
 	for _, trigger := range triggers {
 		assertDeleted(t, f, scheme.Trigger{TriggerID: trigger.TriggerID})
 	}
@@ -39,5 +39,5 @@ func TestDeleteTrigger(t *testing.T) {
 
 	// test deleteTrigger
 	assert.NoError(t, f.gormdb.deleteTrigger(f.ctx, tr.TriggerID))
-	assertTriggersDeleted(t, f, tr)
+	f.assertTriggersDeleted(t, tr)
 }

--- a/internal/backend/db/dbgorm/triggers_test.go
+++ b/internal/backend/db/dbgorm/triggers_test.go
@@ -25,7 +25,7 @@ func TestCreateTrigger(t *testing.T) {
 	f := newDBFixture(true)                           // no foreign keys
 	findAndAssertCount(t, f, scheme.Trigger{}, 0, "") // no trigger
 
-	tr := newTrigger(f)
+	tr := f.newTrigger()
 	// test createTrigger
 	f.createTriggersAndAssert(t, tr)
 }
@@ -34,7 +34,7 @@ func TestDeleteTrigger(t *testing.T) {
 	f := newDBFixture(true)                           // no foreign keys
 	findAndAssertCount(t, f, scheme.Trigger{}, 0, "") // no trigger
 
-	tr := newTrigger(f)
+	tr := f.newTrigger()
 	f.createTriggersAndAssert(t, tr)
 
 	// test deleteTrigger


### PR DESCRIPTION
1. cleanup of testing functions.
   - convert param to receiver (dbFixture)
   - variadic create/delete
 2. pass scheme as ref  
