### PR TITLE
ENG-519: custom temporal client

### DIFF
--- a/backend/svc/configset.go
+++ b/backend/svc/configset.go
@@ -5,6 +5,12 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/backend/configset"
 )
 
+const (
+	Default = configset.Default
+	Dev     = configset.Dev
+	Test    = configset.Test
+)
+
 var ParseMode = configset.ParseMode
 
 const ConfigDelim = basesvc.Delim

--- a/internal/backend/temporalclient/client.go
+++ b/internal/backend/temporalclient/client.go
@@ -29,6 +29,13 @@ type impl struct {
 	done   chan struct{}
 }
 
+func NewFromClient(cfg *MonitorConfig, z *zap.Logger, tclient client.Client) (Client, error) {
+	if cfg == nil {
+		cfg = &MonitorConfig{}
+	}
+	return &impl{z: z, cfg: &Config{Monitor: *cfg}, client: tclient, done: make(chan struct{})}, nil
+}
+
 func New(cfg *Config, z *zap.Logger) (Client, error) {
 	var tlsConfig *tls.Config
 	if cfg.TLS.Enabled {
@@ -43,7 +50,7 @@ func New(cfg *Config, z *zap.Logger) (Client, error) {
 	opts := client.Options{
 		HostPort:  cfg.HostPort,
 		Namespace: cfg.Namespace,
-		Logger:    logur.LoggerToKV(zapadapter.New(z.WithOptions(zap.IncreaseLevel(cfg.LogLevel)))),
+		Logger:    logur.LoggerToKV(zapadapter.New(z.WithOptions(zap.IncreaseLevel(cfg.Monitor.LogLevel)))),
 		ConnectionOptions: client.ConnectionOptions{
 			TLS: tlsConfig,
 		},
@@ -117,7 +124,7 @@ func (c *impl) Stop(context.Context) error {
 func (c *impl) healthcheck(ctx context.Context) error {
 	c.z.Debug("checking health")
 
-	if c.cfg.CheckHealthTimeout != 0 {
+	if c.cfg.Monitor.CheckHealthTimeout != 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
@@ -133,7 +140,7 @@ func (c *impl) healthcheck(ctx context.Context) error {
 }
 
 func (c *impl) Start(context.Context) error {
-	if c.cfg.CheckHealthInterval == 0 {
+	if c.cfg.Monitor.CheckHealthInterval == 0 {
 		c.z.Warn("periodical check health is disabled")
 		return nil
 	}
@@ -152,7 +159,7 @@ func (c *impl) Start(context.Context) error {
 			}
 
 			select {
-			case <-time.After(c.cfg.CheckHealthInterval):
+			case <-time.After(c.cfg.Monitor.CheckHealthInterval):
 				// nop
 			case <-c.done:
 				return

--- a/internal/backend/temporalclient/config.go
+++ b/internal/backend/temporalclient/config.go
@@ -16,44 +16,49 @@ type tlsConfig struct {
 	KeyFilePath  string `koanf:"key_file_path"`
 }
 
+type MonitorConfig struct {
+	CheckHealthInterval time.Duration   `koanf:"check_health_interval"`
+	CheckHealthTimeout  time.Duration   `koanf:"check_health_timeout"`
+	LogLevel            zap.AtomicLevel `koanf:"log_level"`
+}
+
 type Config struct {
-	AlwaysStartDevServer  bool            `koanf:"always_start_dev_server"`
-	StartDevServerIfNotUp bool            `koanf:"start_dev_server_if_not_up"`
-	HostPort              string          `koanf:"hostport"`
-	Namespace             string          `koanf:"namespace"`
-	CheckHealthInterval   time.Duration   `koanf:"check_health_interval"`
-	CheckHealthTimeout    time.Duration   `koanf:"check_health_timeout"`
-	LogLevel              zap.AtomicLevel `koanf:"log_level"`
+	Monitor MonitorConfig `koanf:"monitor"`
+
+	AlwaysStartDevServer  bool   `koanf:"always_start_dev_server"`
+	StartDevServerIfNotUp bool   `koanf:"start_dev_server_if_not_up"`
+	HostPort              string `koanf:"hostport"`
+	Namespace             string `koanf:"namespace"`
 
 	// DevServer.ClientOptions is not used.
 	DevServer testsuite.DevServerOptions `koanf:"dev_server"`
 	TLS       tlsConfig                  `koanf:"tls"`
 }
 
-var Configs = configset.Set[Config]{
-	Default: &Config{
+var (
+	defaultMonitorConfig = MonitorConfig{
 		CheckHealthInterval: time.Minute,
 		CheckHealthTimeout:  10 * time.Second,
 		LogLevel:            zap.NewAtomicLevelAt(zapcore.WarnLevel),
-	},
-	Dev: &Config{
-		CheckHealthInterval: time.Minute,
-		CheckHealthTimeout:  10 * time.Second,
-		LogLevel:            zap.NewAtomicLevelAt(zapcore.WarnLevel),
+	}
 
-		StartDevServerIfNotUp: true,
-		DevServer: testsuite.DevServerOptions{
-			LogLevel: zapcore.WarnLevel.String(),
+	Configs = configset.Set[Config]{
+		Default: &Config{
+			Monitor: defaultMonitorConfig,
 		},
-	},
-	Test: &Config{
-		CheckHealthInterval: time.Minute,
-		CheckHealthTimeout:  10 * time.Second,
-		LogLevel:            zap.NewAtomicLevelAt(zapcore.WarnLevel),
-
-		AlwaysStartDevServer: true,
-		DevServer: testsuite.DevServerOptions{
-			LogLevel: zapcore.WarnLevel.String(),
+		Dev: &Config{
+			Monitor:               defaultMonitorConfig,
+			StartDevServerIfNotUp: true,
+			DevServer: testsuite.DevServerOptions{
+				LogLevel: zapcore.WarnLevel.String(),
+			},
 		},
-	},
-}
+		Test: &Config{
+			Monitor:              defaultMonitorConfig,
+			AlwaysStartDevServer: true,
+			DevServer: testsuite.DevServerOptions{
+				LogLevel: zapcore.WarnLevel.String(),
+			},
+		},
+	}
+)


### PR DESCRIPTION
Allow to pass a custom temporal client to backend, and use it instead of creating a new client.