### PR TITLE
run service as an external process for system tests in CI

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -30,6 +30,8 @@ jobs:
         run: make build bin
       - name: Test
         run: make test-unit
+        env:
+          AK_SYSTEST_USE_PROC_SVC: 1
 
   static-analysis:
     name: Static analysis

--- a/backend/svc/svcproc.go
+++ b/backend/svc/svcproc.go
@@ -2,30 +2,118 @@ package svc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"go.uber.org/fx"
+
+	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 )
 
 type svcProc struct {
-	cfg *Config
+	binPath string
+	ropts   RunOptions
+	cfg     *Config
+	addr    string
+	cmd     *exec.Cmd
+	wait    chan ShutdownSignal
 }
 
 func (s *svcProc) Start(ctx context.Context) error {
-	cmd := exec.Command("bin/ak" /*args...*/)
-	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	tmpDir, err := os.MkdirTemp("", "ak-svcproc-*")
+	if err != nil {
+		return fmt.Errorf("mkdirtemp: %w", err)
+	}
+
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			fmt.Fprintf(os.Stderr, "rm(%q): %v\n", tmpDir, err)
+		}
+	}()
+
+	addrFilePath := filepath.Join(tmpDir, "addr")
+	readyFilePath := filepath.Join(tmpDir, "ready")
+
+	// TODO: pass user configuration to executable.
+	cmd := exec.Command(
+		s.binPath,
+		"--config", "http.addr=:0",
+		"--config", fmt.Sprintf("http.addr_filename=%s", addrFilePath),
+		"up",
+		"-m", string(s.ropts.Mode),
+		"-r", readyFilePath,
+	)
 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start: %w", err)
 	}
 
+	wait := make(chan fx.ShutdownSignal, 1)
+	go func() {
+		var rc int
+
+		if err := cmd.Wait(); err != nil {
+			var exitError *exec.ExitError
+			if errors.As(err, &exitError) {
+				rc = exitError.ExitCode()
+			} else {
+				rc = 1010 // indicates some kind of IO error.
+			}
+		}
+
+		// TODO: pass which signal killed it somehow?
+		wait <- ShutdownSignal{ExitCode: rc}
+	}()
+
+	timeout := time.After(5 * time.Second)
+
+	for ready := false; !ready; {
+		select {
+		case <-wait:
+			return errors.New("service stopped before being ready")
+		case <-time.After(100 * time.Millisecond):
+			if _, err := os.Stat(addrFilePath); err == nil {
+				ready = true
+			}
+		case <-timeout:
+			return errors.New("timeout waiting for service to start")
+		}
+	}
+
+	addr, err := os.ReadFile(addrFilePath)
+	if err != nil {
+		return fmt.Errorf("read addr: %w", err)
+	}
+
+	s.addr = strings.TrimSpace(string(addr))
+	s.wait = wait
+	s.cmd = cmd
+
 	return nil
 }
 
-func (s *svcProc) Stop(ctx context.Context) error { return nil }
-func (s *svcProc) Wait() <-chan ShutdownSignal    { return nil }
-func (s *svcProc) Addr() string                   { return "" }
+func (s *svcProc) Stop(ctx context.Context) error {
+	// TODO: wait until verified stopped?
+	return s.cmd.Process.Kill()
+}
 
-func NewSvcProc(cfg *Config, ropts RunOptions) (Service, error) {
-	return &svcProc{}, nil
+func (s *svcProc) Wait() <-chan ShutdownSignal { return s.wait }
+
+func (s *svcProc) Addr() string { return s.addr }
+
+func NewSvcProc(binPath string, cfg *Config, ropts RunOptions) (Service, error) {
+	if ropts.TemporalClient != nil {
+		return nil, sdkerrors.ErrNotImplemented
+	}
+
+	return &svcProc{
+		binPath: binPath,
+		cfg:     cfg,
+		ropts:   ropts,
+	}, nil
 }

--- a/backend/svc/svcproc.go
+++ b/backend/svc/svcproc.go
@@ -1,0 +1,31 @@
+package svc
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+type svcProc struct {
+	cfg *Config
+}
+
+func (s *svcProc) Start(ctx context.Context) error {
+	cmd := exec.Command("bin/ak" /*args...*/)
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start: %w", err)
+	}
+
+	return nil
+}
+
+func (s *svcProc) Stop(ctx context.Context) error { return nil }
+func (s *svcProc) Wait() <-chan ShutdownSignal    { return nil }
+func (s *svcProc) Addr() string                   { return "" }
+
+func NewSvcProc(cfg *Config, ropts RunOptions) (Service, error) {
+	return &svcProc{}, nil
+}

--- a/cmd/ak/cmd/up.go
+++ b/cmd/ak/cmd/up.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -9,10 +10,13 @@ import (
 	"go.autokitteh.dev/autokitteh/cmd/ak/common"
 )
 
-var mode string
+var (
+	mode      string
+	readyFile string
+)
 
 var upCmd = common.StandardCommand(&cobra.Command{
-	Use:     "up [--mode={default|dev|test}]",
+	Use:     "up [--mode={default|dev|test}] [--ready-file=FILE]",
 	Short:   "Start local server",
 	Aliases: []string{"u"},
 	Args:    cobra.NoArgs,
@@ -33,6 +37,12 @@ var upCmd = common.StandardCommand(&cobra.Command{
 			return fmt.Errorf("fx app start: %w", err)
 		}
 
+		if readyFile != "" {
+			if err := os.WriteFile(readyFile, []byte("ready"), 0o644); err != nil {
+				fmt.Fprintf(os.Stderr, "write ready file: %v\n", err)
+			}
+		}
+
 		<-app.Wait()
 
 		fmt.Println() // End the output with "\n".
@@ -44,4 +54,5 @@ var upCmd = common.StandardCommand(&cobra.Command{
 func init() {
 	// Command-specific flags.
 	upCmd.Flags().StringVarP(&mode, "mode", "m", "", "run mode: {default|dev|test}")
+	upCmd.Flags().StringVarP(&readyFile, "ready-file", "r", "", "write a file when the server is ready")
 }

--- a/cmd/ak/cmd/up.go
+++ b/cmd/ak/cmd/up.go
@@ -8,6 +8,7 @@ import (
 
 	"go.autokitteh.dev/autokitteh/backend/svc"
 	"go.autokitteh.dev/autokitteh/cmd/ak/common"
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
 )
 
 var (
@@ -39,7 +40,7 @@ var upCmd = common.StandardCommand(&cobra.Command{
 
 		if readyFile != "" {
 			if err := os.WriteFile(readyFile, []byte("ready"), 0o644); err != nil {
-				fmt.Fprintf(os.Stderr, "write ready file: %v\n", err)
+				fmt.Fprintf(cmd.ErrOrStderr(), "write ready file: %v\n", err)
 			}
 		}
 
@@ -54,5 +55,7 @@ var upCmd = common.StandardCommand(&cobra.Command{
 func init() {
 	// Command-specific flags.
 	upCmd.Flags().StringVarP(&mode, "mode", "m", "", "run mode: {default|dev|test}")
+
 	upCmd.Flags().StringVarP(&readyFile, "ready-file", "r", "", "write a file when the server is ready")
+	kittehs.Must0(upCmd.MarkFlagFilename("ready-file"))
 }

--- a/tests/system/ak_test.go
+++ b/tests/system/ak_test.go
@@ -50,7 +50,7 @@ func TestSuite(t *testing.T) {
 		// multiple actions, checks, and embedded files.
 		t.Run(strings.TrimPrefix(path, rootDir), func(t *testing.T) {
 			steps := readTestFile(t, path)
-			akAddr := setUpTest(t)
+			akAddr := setUpTest(t, akPath)
 			runTestSteps(t, steps, akPath, akAddr)
 		})
 
@@ -70,7 +70,7 @@ func setUpSuite(t *testing.T) string {
 	return akPath
 }
 
-func setUpTest(t *testing.T) string {
+func setUpTest(t *testing.T, akPath string) string {
 	// TODO: Replace "/backend/internal/temporalclient/client.go"?
 
 	// Redirect the OS's stdout and stderr through a pipe, to
@@ -92,7 +92,7 @@ func setUpTest(t *testing.T) string {
 
 	// Start the AK server, but in-process rather than as a separate
 	// subprocess: to support breakpoint debugging, and measure test coverage.
-	svc, err := startAKServer(context.Background())
+	svc, err := startAKServer(context.Background(), akPath)
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}

--- a/tests/system/server.go
+++ b/tests/system/server.go
@@ -3,27 +3,43 @@ package systest
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 
 	"go.autokitteh.dev/autokitteh/backend/svc"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 )
 
+var useProcSvc, _ = strconv.ParseBool(os.Getenv("AK_SYSTEST_USE_PROC_SVC"))
+
 // Start the AK server, but in a goroutine rather than as a separate
 // subprocess: to support breakpoint debugging, and measure test coverage.
-func startAKServer(ctx context.Context) (svc.Service, error) {
+func startAKServer(ctx context.Context, akPath string) (svc.Service, error) {
 	cfg := kittehs.Must1(svc.LoadConfig("", map[string]any{
 		"db.dsn":    "sqlite:test.sqlite",
 		"http.addr": ":0",
 	}, ""))
 
-	svc, err := svc.New(cfg, svc.RunOptions{Mode: "test"})
+	runOpts := svc.RunOptions{Mode: "test"}
+
+	var (
+		service svc.Service
+		err     error
+	)
+
+	if useProcSvc {
+		service, err = svc.NewSvcProc(akPath, cfg, runOpts)
+	} else {
+		service, err = svc.New(cfg, runOpts)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("svc.New: %w", err)
 	}
 
-	if err := svc.Start(ctx); err != nil {
+	if err := service.Start(ctx); err != nil {
 		panic(fmt.Errorf("fx app start: %w", err))
 	}
 
-	return svc, nil
+	return service, nil
 }


### PR DESCRIPTION
this should keep the tests deterministic until we solve the underlying in-process issue and still allow debugging tests easily locally