### PR TITLE
fix paths manipulation in reader to work on cross-platforms

### DIFF
--- a/sdk/sdkbuildfile/reader.go
+++ b/sdk/sdkbuildfile/reader.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -132,7 +133,7 @@ func Read(r io.Reader) (*BuildFile, error) {
 			// example: runtimes/name/compiled/examples/teststarlark/cats.star
 			//   name = "name"
 			//   rest = "compiled/examples/teststarlark/cats.star"
-			parts := strings.SplitN(path, "/", 3)
+			parts := strings.SplitN(path, string(os.PathSeparator), 3)
 			if len(parts) < 3 || parts[0] != filenames.runtimes {
 				return nil, fmt.Errorf("unexpected path %q", path)
 			}
@@ -187,7 +188,7 @@ func readRuntimeFile(bf *BuildFile, name sdktypes.Symbol, path string, data *byt
 		}
 		rt.Artifact = rt.Artifact.WithExports(exports)
 	default:
-		kind, rest, ok := strings.Cut(path, "/")
+		kind, rest, ok := strings.Cut(path, string(os.PathSeparator))
 		if !ok {
 			return fmt.Errorf("unexpected path %q", path)
 		}


### PR DESCRIPTION
To support server implementation on Windows, we have to implement a path separator adjusted to each OS.

Using this fix, we'll be able to work with the same OS for the server and the client, e.g. 
windows client -> windows server
linux client -> linux server, etc...

The next step is to allow full cross-platform support, to make the server OS agnostic.