### PR TITLE
BUGFIX: pass context appropriately on callbacks to workflow

### DIFF
--- a/runtimes/starlarkrt/internal/tls/tls.go
+++ b/runtimes/starlarkrt/internal/tls/tls.go
@@ -1,0 +1,32 @@
+package tls
+
+import (
+	"context"
+
+	"go.starlark.net/starlark"
+
+	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+type Context struct {
+	GoCtx     context.Context
+	RunID     sdktypes.RunID
+	Callbacks *sdkservices.RunCallbacks
+	Globals   starlark.StringDict
+}
+
+type tlsKeyType string
+
+const tlsKey = tlsKeyType("autokitteh")
+
+func Set(th *starlark.Thread, ctx *Context) {
+	th.SetLocal(string(tlsKey), ctx)
+}
+
+func Get(th *starlark.Thread) *Context {
+	if ctx, ok := th.Local(string(tlsKey)).(*Context); ok {
+		return ctx
+	}
+	return nil
+}

--- a/runtimes/starlarkrt/internal/values/context.go
+++ b/runtimes/starlarkrt/internal/values/context.go
@@ -16,3 +16,17 @@ type Context struct {
 	// Used to deterministically set internal function signatures.
 	funcSeq uint
 }
+
+type tlsKeyType string
+
+const tlsKey = tlsKeyType("autokitteh-vctx")
+
+func (c *Context) SetTLS(th *starlark.Thread) { th.SetLocal(string(tlsKey), c) }
+
+func FromTLS(th *starlark.Thread) *Context {
+	ctx, ok := th.Local(string(tlsKey)).(*Context)
+	if !ok {
+		return nil
+	}
+	return ctx
+}

--- a/runtimes/starlarkrt/internal/values/funcs.go
+++ b/runtimes/starlarkrt/internal/values/funcs.go
@@ -7,6 +7,7 @@ import (
 	"go.starlark.net/starlark"
 
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/runtimes/starlarkrt/internal/tls"
 	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
@@ -61,8 +62,14 @@ func (vctx *Context) functionToStarlark(v sdktypes.Value) (starlark.Value, error
 				}
 			}
 
+			tlsContext := tls.Get(th)
+			ctx := context.Background()
+			if tlsContext != nil && tlsContext.GoCtx != nil {
+				ctx = tlsContext.GoCtx
+			}
+
 			akret, err := vctx.Call(
-				context.Background(), // TODO: extract context from thread. Put context in its tls?
+				ctx,
 				vctx.RunID,
 				v,
 				akargs,


### PR DESCRIPTION
I introduced a bug in https://github.com/autokitteh/autokitteh/pull/89 where the context on a callback to workflow from runtime was not passed correctly, thus callbacks to builtin functions was considered as a nested activity, which cannot be supported. This compounded with another bug in the same PR where builtins were not considered.

This PR also necessitated a change to the way I store starlark TLS data, hence it's not very minimal, but still reasonable.