### PR TITLE
give builtin integrations readable name

### DIFF
--- a/sdk/sdktypes/integration_id.go
+++ b/sdk/sdktypes/integration_id.go
@@ -2,6 +2,7 @@ package sdktypes
 
 import (
 	"fmt"
+	"strings"
 
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 )
@@ -23,7 +24,16 @@ func StrictParseIntegrationID(s string) (IntegrationID, error) { return Strict(P
 func IsIntegrationID(s string) bool { return IsIDOf[integrationIDTraits](s) }
 
 func IntegrationIDFromName(name string) IntegrationID {
-	txt := fmt.Sprintf("%s_%026x", integrationIDKind, kittehs.HashString64(name))
+	const chars = "0123456789abcdefghjkmnpqrstvwxyz"
+
+	name = strings.Map(func(r rune) rune {
+		if strings.ContainsRune(chars, r) {
+			return r
+		}
+		return 'x'
+	}, name)
+
+	txt := fmt.Sprintf("%s_3kth%s%s", integrationIDKind, strings.Repeat("0", 26-4-len(name)), name)
 
 	return kittehs.Must1(ParseIntegrationID(txt))
 }

--- a/tests/system/testdata/connections/get.txtar
+++ b/tests/system/testdata/connections/get.txtar
@@ -34,7 +34,7 @@ ak connection get my_project/my_connection
 return code == 0
 output contains 'connection_id:"con_00000000000000000000000002"'
 output contains 'project_id:"prj_00000000000000000000000001"'
-output contains 'integration_id:"int_0000000000f1201a7ed83f7cd5"'
+output contains 'integration_id:"int_3kth000000000000000000http"'
 output contains 'integration_token:"my_url_path"'
 output contains 'name:"my_connection"'
 
@@ -46,7 +46,7 @@ output equals file expected_connection.json
 {
   "connection": {
     "connection_id": "con_00000000000000000000000002",
-    "integration_id": "int_0000000000f1201a7ed83f7cd5",
+    "integration_id": "int_3kth000000000000000000http",
     "integration_token": "my_url_path",
     "project_id": "prj_00000000000000000000000001",
     "name": "my_connection"

--- a/tests/system/testdata/connections/list.txtar
+++ b/tests/system/testdata/connections/list.txtar
@@ -47,20 +47,20 @@ return code == 0
 output equals ''
 
 -- expected_all_unformatted.json --
-{"connection_id":"con_00000000000000000000000002","integration_id":"int_0000000000f1201a7ed83f7cd5","integration_token":"my_url_path_1","project_id":"prj_00000000000000000000000001","name":"my_connection_1"}
-{"connection_id":"con_00000000000000000000000003","integration_id":"int_0000000000f1201a7ed83f7cd5","integration_token":"my_url_path_2","project_id":"prj_00000000000000000000000001","name":"my_connection_2"}
+{"connection_id":"con_00000000000000000000000002","integration_id":"int_3kth000000000000000000http","integration_token":"my_url_path_1","project_id":"prj_00000000000000000000000001","name":"my_connection_1"}
+{"connection_id":"con_00000000000000000000000003","integration_id":"int_3kth000000000000000000http","integration_token":"my_url_path_2","project_id":"prj_00000000000000000000000001","name":"my_connection_2"}
 
 -- expected_all_formatted.json --
 {
   "connection_id": "con_00000000000000000000000002",
-  "integration_id": "int_0000000000f1201a7ed83f7cd5",
+  "integration_id": "int_3kth000000000000000000http",
   "integration_token": "my_url_path_1",
   "project_id": "prj_00000000000000000000000001",
   "name": "my_connection_1"
 }
 {
   "connection_id": "con_00000000000000000000000003",
-  "integration_id": "int_0000000000f1201a7ed83f7cd5",
+  "integration_id": "int_3kth000000000000000000http",
   "integration_token": "my_url_path_2",
   "project_id": "prj_00000000000000000000000001",
   "name": "my_connection_2"
@@ -69,7 +69,7 @@ output equals ''
 -- expected_some.json --
 {
   "connection_id": "con_00000000000000000000000003",
-  "integration_id": "int_0000000000f1201a7ed83f7cd5",
+  "integration_id": "int_3kth000000000000000000http",
   "integration_token": "my_url_path_2",
   "project_id": "prj_00000000000000000000000001",
   "name": "my_connection_2"

--- a/tests/system/testdata/integrations/get.txtar
+++ b/tests/system/testdata/integrations/get.txtar
@@ -22,7 +22,7 @@ output contains 'key:"get"'
 output contains 'key:"post"'
 
 # Get integration by ID.
-ak integration get int_0000000000f1201a7ed83f7cd5
+ak integration get int_3kth000000000000000000http
 return code == 0
 output contains 'unique_name:"http"'
 output contains 'display_name:"HTTP"'

--- a/tests/system/testdata/manifest/apply.txtar
+++ b/tests/system/testdata/manifest/apply.txtar
@@ -111,7 +111,7 @@ project:
 {
   "connection": {
     "connection_id": "con_00000000000000000000000003",
-    "integration_id": "int_0000000000f1201a7ed83f7cd5",
+    "integration_id": "int_3kth000000000000000000http",
     "integration_token": "my_path",
     "project_id": "prj_00000000000000000000000001",
     "name": "my_connection"


### PR DESCRIPTION
this helped me debugging #91 , it gives builtin integrations/modules an id where we can easily deduce from site which is it.