### PR TITLE
when running from make, always use ak as a proc 

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -30,8 +30,6 @@ jobs:
         run: make build bin
       - name: Test
         run: make test-unit
-        env:
-          AK_SYSTEST_USE_PROC_SVC: 1
 
   static-analysis:
     name: Static analysis

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ endif
 VERSION_PKG_PATH="go.autokitteh.dev/autokitteh/internal/version"
 LDFLAGS+=-X '${VERSION_PKG_PATH}.Version=${VERSION}' -X '${VERSION_PKG_PATH}.Time=${TIMESTAMP}' -X '${VERSION_PKG_PATH}.Commit=${COMMIT}$(shell git diff --quiet || echo '(dirty)')' -X '${VERSION_PKG_PATH}.User=$(shell whoami)' -X '${VERSION_PKG_PATH}.Host=$(shell hostname)'
 
+export AK_SYSTEST_USE_PROC_SVC=1
+
 # 1. Detect unformatted Go files
 # 2. Run golangci-lint (Go linters)
 # 3. Run shellcheck (shell scripts linter)


### PR DESCRIPTION
it's not running in a debugger anyway, so why flake.