### PR TITLE
starlark: partial

### DIFF
--- a/runtimes/starlarkrt/internal/bootstrap/bootstrap.star
+++ b/runtimes/starlarkrt/internal/bootstrap/bootstrap.star
@@ -69,3 +69,10 @@ def activity(fn):
     return struct(
         run=lambda *args, **kwargs: run_activity(fn, *args, **kwargs),
     )
+
+# EXPORT: withargs
+def withargs(f, *args, **kwargs):
+    def wrapper(*args2, **kwargs2):
+        kwargs.update(kwargs2)
+        return f(*(args + args2), **kwargs)
+    return wrapper

--- a/runtimes/starlarkrt/internal/bootstrap/bootstrap.star
+++ b/runtimes/starlarkrt/internal/bootstrap/bootstrap.star
@@ -70,8 +70,8 @@ def activity(fn):
         run=lambda *args, **kwargs: run_activity(fn, *args, **kwargs),
     )
 
-# EXPORT: withargs
-def withargs(f, *args, **kwargs):
+# EXPORT: partial
+def partial(f, *args, **kwargs):
     def wrapper(*args2, **kwargs2):
         kwargs.update(kwargs2)
         return f(*(args + args2), **kwargs)

--- a/tests/runs/partial.txtar
+++ b/tests/runs/partial.txtar
@@ -14,7 +14,7 @@ def dump(*args, **kwargs):
     print(sorted(kwargs.items()))
     return len(args) + len(kwargs)
 
-f = withargs(dump, 1, 2, a=4, b=5)
+f = partial(dump, 1, 2, a=4, b=5)
 
 print(f())
 print(f(3, c=6))

--- a/tests/runs/withargs.txtar
+++ b/tests/runs/withargs.txtar
@@ -1,0 +1,21 @@
+(1, 2)
+[("a", 4), ("b", 5)]
+4
+(1, 2, 3)
+[("a", 4), ("b", 5), ("c", 6)]
+6
+(1, 2, 1)
+[("a", 4), ("b", 9), ("c", 6)]
+6
+
+-- main.star --
+def dump(*args, **kwargs):
+    print(args)
+    print(sorted(kwargs.items()))
+    return len(args) + len(kwargs)
+
+f = withargs(dump, 1, 2, a=4, b=5)
+
+print(f())
+print(f(3, c=6))
+print(f(1, b=9))


### PR DESCRIPTION
not very different (if at all) from https://docs.python.org/3/library/functools.html#functools.partial.

allows:
```
def dump(*args, **kwargs):
    print(args)
    print(sorted(kwargs.items()))
    return len(args) + len(kwargs)

f = partial(dump, 1, 2, a=4, b=5)

print(f())
print(f(3, c=6))
print(f(1, b=9))
```