### PR TITLE
fix: disable foreign keys for automigrate

### DIFF
--- a/internal/backend/db/dbgorm/dbgorm.go
+++ b/internal/backend/db/dbgorm/dbgorm.go
@@ -85,9 +85,11 @@ func translateError(err error) error {
 }
 
 func (db *gormdb) Setup(ctx context.Context) error {
+	db.db.Exec("PRAGMA foreign_keys = OFF")
 	if err := db.db.WithContext(ctx).AutoMigrate(scheme.Tables...); err != nil {
 		return fmt.Errorf("automigrate: %w", err)
 	}
+	db.db.Exec("PRAGMA foreign_keys = ON")
 
 	return nil
 }

--- a/internal/backend/db/dbgorm/dbgorm.go
+++ b/internal/backend/db/dbgorm/dbgorm.go
@@ -85,7 +85,7 @@ func translateError(err error) error {
 }
 
 func (db *gormdb) Setup(ctx context.Context) error {
-	isSqlite := db.db.Dialector.Name() == "sqlite"
+	isSqlite := db.cfg.Type == "sqlite"
 	if isSqlite {
 		db.db.Exec("PRAGMA foreign_keys = OFF")
 	}
@@ -100,7 +100,7 @@ func (db *gormdb) Setup(ctx context.Context) error {
 }
 
 func (db *gormdb) Teardown(ctx context.Context) error {
-	isSqlite := db.db.Dialector.Name() == "sqlite"
+	isSqlite := db.cfg.Type == "sqlite"
 	if isSqlite {
 		db.db.Exec("PRAGMA foreign_keys = OFF")
 	}

--- a/internal/backend/db/dbgorm/gorm_test.go
+++ b/internal/backend/db/dbgorm/gorm_test.go
@@ -17,6 +17,7 @@ import (
 	"gorm.io/gorm/logger"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/db/dbgorm/scheme"
+	"go.autokitteh.dev/autokitteh/internal/backend/gormkitteh"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
@@ -47,9 +48,7 @@ func setupDB(dbName string) *gorm.DB {
 			Colorful:      false,         // Disable color
 		},
 	)
-	if dbName == "" {
-		dbName = "file::memory:"
-	}
+
 	db, err := gorm.Open(sqlite.Open(dbName), &gorm.Config{
 		NowFunc: func() time.Time { // operate always in UTC to simplify object comparison upon creation and fetching
 			return time.Now().UTC()
@@ -65,11 +64,13 @@ func setupDB(dbName string) *gorm.DB {
 }
 
 func newDBFixture(withoutForeignKeys bool) *dbFixture {
-	db := setupDB("") // in-memory db, specify filename to use file db
+	dsn := "file::memory:"
+	db := setupDB(dsn) // in-memory db, specify filename to use file db
 
 	ctx := context.Background()
+	cfg := gormkitteh.Config{Type: "sqlite", DSN: dsn}
 
-	gormdb := gormdb{db: db, cfg: nil, mu: nil, z: zap.NewExample()}
+	gormdb := gormdb{db: db, cfg: &cfg, mu: nil, z: zap.NewExample()}
 	if err := gormdb.Teardown(ctx); err != nil { // delete tables if any
 		log.Printf("Failed to termdown gormdb: %v", err)
 	}

--- a/internal/backend/db/dbgorm/gorm_test.go
+++ b/internal/backend/db/dbgorm/gorm_test.go
@@ -66,9 +66,6 @@ func setupDB(dbName string) *gorm.DB {
 
 func newDBFixture(withoutForeignKeys bool) *dbFixture {
 	db := setupDB("") // in-memory db, specify filename to use file db
-	if withoutForeignKeys {
-		db.Exec("PRAGMA foreign_keys = OFF")
-	}
 
 	ctx := context.Background()
 
@@ -78,6 +75,9 @@ func newDBFixture(withoutForeignKeys bool) *dbFixture {
 	}
 	if err := gormdb.Setup(ctx); err != nil { // ensure migration/schemas
 		log.Fatalf("Failed to setup gormdb: %v", err)
+	}
+	if withoutForeignKeys { // run after setup, since this pragma may be reset by setup
+		db.Exec("PRAGMA foreign_keys = OFF")
 	}
 
 	return &dbFixture{db: db, gormdb: &gormdb, ctx: ctx}


### PR DESCRIPTION
due to limitations in `alter` commands, GORM SQLite implementation moves data to temp tables and then recreates schema, table by table. Thus On DROP of original table (in persistent DB) we will fail on foreign key constrains.

Solution is to temporarily disable foreign keys for migration