### PR TITLE
bugfix: starlark: load relatives paths

### DIFF
--- a/cmd/ak/cmd/runtimes/build.go
+++ b/cmd/ak/cmd/runtimes/build.go
@@ -26,7 +26,7 @@ var (
 )
 
 var buildCmd = common.StandardCommand(&cobra.Command{
-	Use:     "build [<path> [<path> [...]] [--dir=...] [--output=...] [--values=...] [--describe]",
+	Use:     "build [<path> [<path> [...]] [--dir=...] [--output=...] [--values=...] [--describe] [--txtar]",
 	Short:   `Build program and save it locally (see also "project build" command)`,
 	Aliases: []string{"b"},
 	Args:    cobra.ArbitraryArgs,

--- a/runtimes/starlarkrt/runtime/build.go
+++ b/runtimes/starlarkrt/runtime/build.go
@@ -134,15 +134,20 @@ func Build(ctx context.Context, fs fs.FS, path string, symbols []sdktypes.Symbol
 		}
 
 		data[path] = modBuf.Bytes()
+		dir := filepath.Dir(path)
 
 		for i := 0; i < mod.NumLoads(); i++ {
 			lpath, pos := mod.Load(i)
 
-			if path != "" {
-				lpath = filepath.Join(filepath.Dir(path), lpath)
+			if lpath == "" {
+				return sdktypes.InvalidBuildArtifact, fmt.Errorf("empty load path: %v", pos)
 			}
 
-			if isStarlarkPath(lpath) {
+			if path != "" {
+				lpath = filepath.Join(dir, lpath)
+			}
+
+			if isStarlarkPath(lpath) && lpath[0] != '@' {
 				q = append(q, lpath)
 				continue
 			}

--- a/runtimes/starlarkrt/runtime/run.go
+++ b/runtimes/starlarkrt/runtime/run.go
@@ -73,7 +73,11 @@ func Run(
 		Name:  mainPath,
 		Print: func(_ *starlark.Thread, text string) { cbs.SafePrint(ctx, runID, text) },
 		Load: func(th *starlark.Thread, path string) (starlark.StringDict, error) {
-			path = filepath.Join(filepath.Dir(th.Name), path)
+			if len(th.CallStack()) > 0 {
+				// Path is relative to the file that called load.
+				pos := th.CallFrame(0).Pos.Filename()
+				path = filepath.Join(filepath.Dir(pos), path)
+			}
 
 			prog, err := getProgram(compiled, path)
 			if err != nil {

--- a/tests/runs/nested_dir_loads.txtar
+++ b/tests/runs/nested_dir_loads.txtar
@@ -1,0 +1,23 @@
+baz qux foo bar
+
+-- main.star --
+load("baz.star", "baz")
+load("foo/foo.star", "foo")
+
+print(baz, foo)
+
+-- baz.star --
+load("qux.star", "qux")
+
+baz = "baz " + qux
+
+-- qux.star --
+qux = "qux"
+
+-- foo/foo.star --
+load("bar.star", "bar")
+
+foo = "foo " + bar
+
+-- foo/bar.star --
+bar = "bar"


### PR DESCRIPTION
load of relative paths did not work correctly:

```
load("foo/foo.star", "foo")
-- foo/foo.star --
load("bar.star", bar)
foo = bar
-- foo/bar.star --
bar = "bar"
```

did not take into account the relative path for foo/bar.star.