### PR TITLE
fix: increase session wait timeout for system tests

### DIFF
--- a/tests/system/testdata/sessions/stop.txtar
+++ b/tests/system/testdata/sessions/stop.txtar
@@ -9,13 +9,13 @@ ak sessions start --build-id bld_00000000000000000000000002 --entrypoint main.st
 return code == 0
 output equals 'session_id: ses_00000000000000000000000003'
 
-ak sessions watch ses_00000000000000000000000003 --no-timestamps --end-state RUNNING --timeout 5s
+ak sessions watch ses_00000000000000000000000003 --no-timestamps --end-state RUNNING --timeout 7s
 return code == 0
 
 ak sessions stop ses_00000000000000000000000003 --reason test
 return code == 0
 
-ak sessions watch ses_00000000000000000000000003 --no-timestamps --timeout 5s
+ak sessions watch ses_00000000000000000000000003 --no-timestamps --timeout 7s
 return code == 0
 
 ak sessions log ses_00000000000000000000000003 --no-timestamps -j

--- a/tests/system/testdata/sessions/terminate.txtar
+++ b/tests/system/testdata/sessions/terminate.txtar
@@ -9,7 +9,7 @@ ak sessions start --build-id bld_00000000000000000000000002 --entrypoint main.st
 return code == 0
 output equals 'session_id: ses_00000000000000000000000003'
 
-ak sessions watch ses_00000000000000000000000003 --no-timestamps --end-state RUNNING --timeout 5s
+ak sessions watch ses_00000000000000000000000003 --no-timestamps --end-state RUNNING --timeout 7s
 return code == 0
 
 ak sessions stop ses_00000000000000000000000003 --reason test --force

--- a/tests/system/testdata/workflows/builtin_funcs.txtar
+++ b/tests/system/testdata/workflows/builtin_funcs.txtar
@@ -14,7 +14,7 @@ return code == 0
 http get /http/my_url_path
 resp code == 200
 
-wait 5s for session ses_00000000000000000000000008
+wait 7s for session ses_00000000000000000000000008
 
 # Check session's output and final state.
 ak session log -J


### PR DESCRIPTION
increase session wait timeout to prevent context invalidation when running tests with internal temporal dev server.
relevant tests:  builtins, terminate, stop