### PR TITLE
feat(git): hide diff autogenerated proto

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+proto/gen/**    linguist-generated
+proto/gen	text -diff


### PR DESCRIPTION
mark autogenerated files as autogenerated and hide them in diffs