### PR TITLE
Updates in the session CLI commands

### DIFF
--- a/cmd/ak/cmd/sessions/list.go
+++ b/cmd/ak/cmd/sessions/list.go
@@ -13,7 +13,6 @@ import (
 )
 
 var (
-	env        string
 	stateType  stateString
 	withInputs bool
 )

--- a/cmd/ak/cmd/sessions/log.go
+++ b/cmd/ak/cmd/sessions/log.go
@@ -14,7 +14,7 @@ import (
 var skip int
 
 var logCmd = common.StandardCommand(&cobra.Command{
-	Use:   "log [sessions ID] [--fail] [--skip N] [--no-timestamps]",
+	Use:   "log [sessions ID] [--fail] [--skip <N>] [--no-timestamps]",
 	Short: "Get session runtime logs (prints, calls, errors, state changes)",
 	Args:  cobra.MaximumNArgs(1),
 
@@ -48,8 +48,8 @@ var logCmd = common.StandardCommand(&cobra.Command{
 
 func init() {
 	// Command-specific flags.
-	logCmd.Flags().IntVar(&skip, "skip", 0, "number of entries to skip")
-	logCmd.Flags().BoolVar(&noTimestamps, "no-timestamps", false, "omit timestamps from track output")
+	logCmd.Flags().IntVarP(&skip, "skip", "s", 0, "number of entries to skip")
+	logCmd.Flags().BoolVarP(&noTimestamps, "no-timestamps", "n", false, "omit timestamps from track output")
 
 	common.AddFailIfNotFoundFlag(logCmd)
 }

--- a/cmd/ak/cmd/sessions/restart.go
+++ b/cmd/ak/cmd/sessions/restart.go
@@ -11,7 +11,7 @@ import (
 )
 
 var restartCmd = common.StandardCommand(&cobra.Command{
-	Use:   "restart [session ID] [--watch] [--poll-interval] [--watch-timeout DURARTION] [--no-timestamps] [--quiet]",
+	Use:   "restart [session ID] [--watch [--watch-timeout <duration>] [--poll-interval <duration>] [--no-timestamps] [--quiet]]",
 	Short: "Start new instance of existing session",
 	Args:  cobra.MaximumNArgs(1),
 
@@ -44,7 +44,7 @@ var restartCmd = common.StandardCommand(&cobra.Command{
 
 		common.RenderKVIfV("session_id", sid)
 
-		if track {
+		if watch {
 			_, err := sessionWatch(sid, sdktypes.SessionStateTypeUnspecified)
 			return err
 		}
@@ -55,8 +55,10 @@ var restartCmd = common.StandardCommand(&cobra.Command{
 
 func init() {
 	// Command-specific flags.
-	restartCmd.Flags().BoolVarP(&track, "watch", "w", false, "watch session to completion")
-	restartCmd.Flags().DurationVar(&pollInterval, "poll-interval", defaultPollInterval, "poll interval")
-	restartCmd.Flags().DurationVar(&watchTimeout, "watch-timeout", 0, "watch time out duration")
-	restartCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "do not print anything, just wait to finish")
+	restartCmd.Flags().BoolVarP(&watch, "watch", "w", false, "watch session to completion")
+
+	restartCmd.Flags().DurationVarP(&watchTimeout, "watch-timeout", "t", 0, "watch timeout duration")
+	restartCmd.Flags().DurationVarP(&pollInterval, "poll-interval", "i", defaultPollInterval, "watch poll interval")
+	restartCmd.Flags().BoolVarP(&noTimestamps, "no-timestamps", "n", false, "omit timestamps from watch output")
+	restartCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "don't print anything, just wait to finish")
 }

--- a/cmd/ak/cmd/sessions/sessions.go
+++ b/cmd/ak/cmd/sessions/sessions.go
@@ -3,6 +3,7 @@ package sessions
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -10,8 +11,21 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 )
 
-// Flags shared by the "list" and "start" subcommands.
-var deploymentID, eventID string
+// Default flag value shared by the "start", "restart", and "watch" subcommands.
+const (
+	defaultPollInterval = 1 * time.Second
+)
+
+var (
+	// Flags shared by the "list" and "start" subcommands.
+	deploymentID, env, eventID string
+
+	// Flags shared by the "start", "restart", and "watch" subcommands.
+	pollInterval time.Duration
+	watchTimeout time.Duration
+	watch, quiet bool
+	noTimestamps bool
+)
 
 var sessionsCmd = common.StandardCommand(&cobra.Command{
 	Use:     "sessions",

--- a/cmd/ak/cmd/sessions/start.go
+++ b/cmd/ak/cmd/sessions/start.go
@@ -54,7 +54,6 @@ func init() {
 	startCmd.Flags().StringVarP(&buildID, "build-id", "b", "", "build ID, mutually exclusive with --deployment-id")
 	startCmd.Flags().StringVarP(&env, "env", "e", "", "environment name or ID, mutually exclusive with --deployment-id")
 	startCmd.MarkFlagsOneRequired("deployment-id", "build-id")
-	startCmd.MarkFlagsRequiredTogether("build-id", "env")
 
 	startCmd.Flags().StringVarP(&entryPoint, "entrypoint", "p", "", `entry point ("file:function")`)
 	kittehs.Must0(startCmd.MarkFlagRequired("entrypoint"))

--- a/cmd/ak/cmd/sessions/stop.go
+++ b/cmd/ak/cmd/sessions/stop.go
@@ -15,7 +15,7 @@ var (
 )
 
 var stopCmd = common.StandardCommand(&cobra.Command{
-	Use:   "stop [session ID] [--reason=...] [--force]",
+	Use:   "stop [session ID] [--reason <...>] [--force]",
 	Short: "Stop running session",
 	Args:  cobra.MaximumNArgs(1),
 

--- a/cmd/ak/cmd/sessions/test.go
+++ b/cmd/ak/cmd/sessions/test.go
@@ -120,7 +120,7 @@ var testCmd = common.StandardCommand(&cobra.Command{
 })
 
 func init() {
-	testCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "do not print anything, just wait to finish")
-	testCmd.Flags().BoolVar(&noTimestamps, "no-timestamps", false, "omit timestamps from track output")
-	testCmd.Flags().DurationVar(&watchTimeout, "timeout", 0, "watch time out duration")
+	testCmd.Flags().DurationVarP(&watchTimeout, "timeout", "t", 0, "watch timeout duration")
+	testCmd.Flags().BoolVar(&noTimestamps, "no-timestamps", false, "omit timestamps from watch output")
+	testCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "don't print anything, just wait to finish")
 }

--- a/cmd/ak/cmd/sessions/watch.go
+++ b/cmd/ak/cmd/sessions/watch.go
@@ -12,18 +12,11 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-var (
-	track        bool
-	pollInterval time.Duration
-	noTimestamps bool
-	endState     string
-	watchTimeout time.Duration
-	quiet        bool
-)
+var endState string
 
 var watchCmd = common.StandardCommand(&cobra.Command{
-	Use:   "watch [sessions ID] [--fail] [--no-timestamps] [--poll-interval] [--end-state STATE] [--timeout DURATION] [--quiet]",
-	Short: "Watch for session runtime logs (prints, calls, errors, state changes)",
+	Use:   "watch [sessions ID] [--fail] [--end-state <state>] [--timeout <duration>] [--poll-interval <duration>] [--no-timestamps] [--quiet]",
+	Short: "Watch session runtime logs (prints, calls, errors, state changes)",
 	Args:  cobra.MaximumNArgs(1),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -57,11 +50,12 @@ var watchCmd = common.StandardCommand(&cobra.Command{
 
 func init() {
 	// Command-specific flags.
-	watchCmd.Flags().DurationVar(&pollInterval, "poll-interval", defaultPollInterval, "poll interval")
-	watchCmd.Flags().BoolVar(&noTimestamps, "no-timestamps", false, "omit timestamps from track output")
-	watchCmd.Flags().StringVar(&endState, "end-state", "", "stop watching when state is reached")
-	watchCmd.Flags().DurationVar(&watchTimeout, "timeout", 0, "time out duration")
-	watchCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "do not print anything, just wait to finish")
+	watchCmd.Flags().StringVarP(&endState, "end-state", "e", "", "stop watching when state is reached")
+
+	watchCmd.Flags().DurationVarP(&watchTimeout, "timeout", "t", 0, "timeout duration")
+	watchCmd.Flags().DurationVarP(&pollInterval, "poll-interval", "i", defaultPollInterval, "poll interval")
+	watchCmd.Flags().BoolVarP(&noTimestamps, "no-timestamps", "n", false, "omit timestamps from output")
+	watchCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "don't print anything, just wait to finish")
 
 	common.AddFailIfNotFoundFlag(watchCmd)
 }


### PR DESCRIPTION
- Move shared flag variables to `sessions.go`
- Add abbreviations for flags that didn't have any
- Cosmetic standardization of usage strings
- Start command: Cobra flag settings instead of custom checks