### PR TITLE
ENG-575: Fix OAuth redirect for GitHub Enterprise Server

### DIFF
--- a/integrations/github/jwt.go
+++ b/integrations/github/jwt.go
@@ -14,6 +14,7 @@ import (
 	ghinstallation "github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v60/github"
 
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 )
 
@@ -108,8 +109,8 @@ func (i integration) NewClientWithAppJWTFromGitHubID(appID int64) (*github.Clien
 
 	// Initialize a client with the generated JWT injected into outbound requests.
 	client := github.NewClient(&http.Client{Transport: atr})
-	if enterpriseURL := os.Getenv(enterpriseURLEnvVar); enterpriseURL != "" {
-		client, err = client.WithEnterpriseURLs(enterpriseURL, enterpriseURL)
+	if u := enterpriseURL(); u != "" {
+		client, err = client.WithEnterpriseURLs(u, u)
 		if err != nil {
 			return nil, err
 		}
@@ -132,8 +133,8 @@ func (i integration) NewClientWithInstallJWTFromGitHubIDs(appID, installID int64
 
 	// Initialize a client with the generated JWT injected into outbound requests.
 	client := github.NewClient(&http.Client{Transport: itr})
-	if enterpriseURL := os.Getenv(enterpriseURLEnvVar); enterpriseURL != "" {
-		client, err = client.WithEnterpriseURLs(enterpriseURL, enterpriseURL)
+	if u := enterpriseURL(); u != "" {
+		client, err = client.WithEnterpriseURLs(u, u)
 		if err != nil {
 			return nil, err
 		}
@@ -157,4 +158,17 @@ func getPrivateKey() []byte {
 		Bytes: x509.MarshalPKCS1PrivateKey(k),
 	}
 	return pem.EncodeToMemory(b)
+}
+
+func enterpriseURL() string {
+	u := os.Getenv(enterpriseURLEnvVar)
+	if u == "" {
+		return u
+	}
+
+	u, err := kittehs.NormalizeURL(u, true)
+	if err != nil {
+		return ""
+	}
+	return u
 }

--- a/integrations/github/jwt.go
+++ b/integrations/github/jwt.go
@@ -109,7 +109,11 @@ func (i integration) NewClientWithAppJWTFromGitHubID(appID int64) (*github.Clien
 
 	// Initialize a client with the generated JWT injected into outbound requests.
 	client := github.NewClient(&http.Client{Transport: atr})
-	if u := enterpriseURL(); u != "" {
+	u, err := enterpriseURL()
+	if err != nil {
+		return nil, err
+	}
+	if u != "" {
 		client, err = client.WithEnterpriseURLs(u, u)
 		if err != nil {
 			return nil, err
@@ -133,7 +137,11 @@ func (i integration) NewClientWithInstallJWTFromGitHubIDs(appID, installID int64
 
 	// Initialize a client with the generated JWT injected into outbound requests.
 	client := github.NewClient(&http.Client{Transport: itr})
-	if u := enterpriseURL(); u != "" {
+	u, err := enterpriseURL()
+	if err != nil {
+		return nil, err
+	}
+	if u != "" {
 		client, err = client.WithEnterpriseURLs(u, u)
 		if err != nil {
 			return nil, err
@@ -160,15 +168,11 @@ func getPrivateKey() []byte {
 	return pem.EncodeToMemory(b)
 }
 
-func enterpriseURL() string {
+func enterpriseURL() (string, error) {
 	u := os.Getenv(enterpriseURLEnvVar)
 	if u == "" {
-		return u
+		return u, nil
 	}
 
-	u, err := kittehs.NormalizeURL(u, true)
-	if err != nil {
-		return ""
-	}
-	return u
+	return kittehs.NormalizeURL(u, true)
 }

--- a/internal/backend/oauth/oauth.go
+++ b/internal/backend/oauth/oauth.go
@@ -19,6 +19,7 @@ import (
 	googleoauth2 "google.golang.org/api/oauth2/v2"
 	"google.golang.org/api/sheets/v4"
 
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 )
@@ -44,6 +45,14 @@ func New(l *zap.Logger) sdkservices.OAuth {
 	githubBaseURL := os.Getenv("GITHUB_ENTERPRISE_URL")
 	if githubBaseURL == "" {
 		githubBaseURL = "https://github.com"
+	}
+	var err error
+	githubBaseURL, err = kittehs.NormalizeURL(githubBaseURL, true)
+	if err != nil {
+		l.Fatal("Invalid environment variable value",
+			zap.String("name", "GITHUB_ENTERPRISE_URL"),
+			zap.Error(err),
+		)
 	}
 
 	return &oauth{

--- a/internal/kittehs/strings.go
+++ b/internal/kittehs/strings.go
@@ -3,6 +3,7 @@ package kittehs
 import (
 	"fmt"
 	"hash/fnv"
+	"net/url"
 	"strings"
 )
 
@@ -51,4 +52,30 @@ func PadLeft(s string, r rune, n int) string {
 	}
 
 	return strings.Repeat(string(r), n-len(s)) + s
+}
+
+// NormalizeURL ensures that the given URL has the right scheme
+// prefix, and no suffix (e.g. path) after the host address.
+func NormalizeURL(rawURL string, secure bool) (string, error) {
+	// Normalize the URL's scheme prefix.
+	scheme := "http://"
+	if secure {
+		scheme = "https://"
+		rawURL = strings.TrimPrefix(rawURL, "http://")
+	}
+	if !strings.HasPrefix(rawURL, scheme) {
+		rawURL = scheme + rawURL
+	}
+
+	// Parse the input URL.
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("no host in URL %q", rawURL)
+	}
+
+	// Reconstruct the URL with only the scheme and the host.
+	return fmt.Sprintf("%s://%s", u.Scheme, u.Host), nil
 }

--- a/internal/kittehs/strings_test.go
+++ b/internal/kittehs/strings_test.go
@@ -21,3 +21,71 @@ func TestMatchLongetSuffix(t *testing.T) {
 	assert.Equal(t, "", MatchLongestSuffix("", []string{"1", "3"}))
 	assert.Equal(t, "234", MatchLongestSuffix("1234", []string{"4", "234", "34", "23"}))
 }
+
+func TestNormalizeURL(t *testing.T) {
+	type args struct {
+		rawURL string
+		secure bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "basic happy path",
+			args:    args{rawURL: "http://example.com", secure: false},
+			want:    "http://example.com",
+			wantErr: false,
+		},
+		{
+			name:    "add HTTP scheme prefix",
+			args:    args{rawURL: "example.com", secure: false},
+			want:    "http://example.com",
+			wantErr: false,
+		},
+		{
+			name:    "add HTTPS scheme prefix",
+			args:    args{rawURL: "example.com", secure: true},
+			want:    "https://example.com",
+			wantErr: false,
+		},
+		{
+			name:    "change scheme",
+			args:    args{rawURL: "http://example.com", secure: true},
+			want:    "https://example.com",
+			wantErr: false,
+		},
+		{
+			name:    "strip path",
+			args:    args{rawURL: "http://example.com/foo/bar", secure: false},
+			want:    "http://example.com",
+			wantErr: false,
+		},
+		{
+			name:    "add scheme and strip path",
+			args:    args{rawURL: "example.com/path", secure: true},
+			want:    "https://example.com",
+			wantErr: false,
+		},
+		{
+			name:    "no host",
+			args:    args{rawURL: "/path", secure: true},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeURL(tt.args.rawURL, tt.args.secure)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NormalizeURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("NormalizeURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change ensures that the value in the env var "GITHUB_ENTERPRISE_URL" is a valid URL, i.e. with a scheme prefix (`http[s]://`), and without a suffix after the host address.