### PR TITLE
http integration: return body functions

### DIFF
--- a/examples/testprograms/http/http.star
+++ b/examples/testprograms/http/http.star
@@ -19,7 +19,8 @@ def on_http_get():
     print(resp, err)
     if err:
         print(err.op)
-
+    else:
+        print(resp.body.text())
 
 def on_http_post(data):
     def again(x):
@@ -37,3 +38,4 @@ def on_http_post(data):
     sleep(3)
     resp = http1.get("http://example.com")
     print(resp)
+    print(resp.body.text())

--- a/internal/backend/sessions/sessionworkflows/workflow.go
+++ b/internal/backend/sessions/sessionworkflows/workflow.go
@@ -138,6 +138,10 @@ func (w *sessionWorkflow) load(ctx context.Context, _ sdktypes.RunID, path strin
 }
 
 func (w *sessionWorkflow) call(ctx workflow.Context, runID sdktypes.RunID, v sdktypes.Value, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
+	if f := v.GetFunction(); f.HasFlag(sdktypes.ConstFunctionFlag) {
+		return f.ConstValue()
+	}
+
 	w.callSeq++
 
 	z := w.z.With(zap.Any("run_id", runID), zap.Any("v", v), zap.Uint32("seq", w.callSeq))

--- a/sdk/sdktypes/event.go
+++ b/sdk/sdktypes/event.go
@@ -105,6 +105,16 @@ func eventFilterField(name string, expr string) error {
 	return nil
 }
 
+var matchUnwrapper = ValueWrapper{
+	Preunwrap: func(v Value) (Value, error) {
+		// Ignore functions.
+		if v.IsFunction() {
+			return InvalidValue, nil
+		}
+		return v, nil
+	},
+}
+
 func (e Event) Matches(expr string) (bool, error) {
 	if expr == "" {
 		return true, nil
@@ -120,7 +130,7 @@ func (e Event) Matches(expr string) (bool, error) {
 		return false, fmt.Errorf("program: %w", err)
 	}
 
-	data, err := kittehs.TransformMapValuesError(e.Data(), UnwrapValue)
+	data, err := kittehs.TransformMapValuesError(e.Data(), matchUnwrapper.Unwrap)
 	if err != nil {
 		return false, fmt.Errorf("convert: %w", err)
 	}

--- a/sdk/sdktypes/executor_id.go
+++ b/sdk/sdktypes/executor_id.go
@@ -9,6 +9,8 @@ import (
 
 type ExecutorID struct{ id[typeid.AnyPrefix] }
 
+var InvalidExecutorID ExecutorID
+
 type concreteExecutorID interface {
 	RunID | IntegrationID
 	ID
@@ -20,16 +22,20 @@ func NewExecutorID[T concreteExecutorID](in T) ExecutorID {
 }
 
 func ParseExecutorID(s string) (ExecutorID, error) {
+	if s == "" {
+		return InvalidExecutorID, nil
+	}
+
 	parsed, err := ParseID[id[typeid.AnyPrefix]](s)
 	if err != nil {
-		return ExecutorID{}, err
+		return InvalidExecutorID, err
 	}
 
 	switch parsed.Kind() {
 	case runIDKind, integrationIDKind:
 		return ExecutorID{parsed}, nil
 	default:
-		return ExecutorID{}, sdkerrors.NewInvalidArgumentError("invalid executor id")
+		return InvalidExecutorID, sdkerrors.NewInvalidArgumentError("invalid executor id")
 	}
 }
 

--- a/sdk/sdktypes/value_unwrap.go
+++ b/sdk/sdktypes/value_unwrap.go
@@ -19,6 +19,9 @@ func (w ValueWrapper) Unwrap(v Value) (any, error) {
 		if v, err = w.Preunwrap(v); err != nil {
 			return nil, err
 		}
+		if !v.IsValid() {
+			return nil, nil
+		}
 	}
 
 	return w.unwrap(v)
@@ -154,6 +157,9 @@ func (w ValueWrapper) unwrapInto(path string, dstv reflect.Value, v Value) error
 		v, err := w.Preunwrap(v)
 		if err != nil {
 			return err
+		}
+		if !v.IsValid() {
+			return nil
 		}
 
 		return w.unwrapInto(path, dstv, v)

--- a/sdk/sdktypes/value_wrapper.go
+++ b/sdk/sdktypes/value_wrapper.go
@@ -33,7 +33,7 @@ type ValueWrapper struct {
 	// Unwrap: transform duration into microseconds, do not convert to string.
 	RawDuration bool
 
-	// Unwrap: Tranform value before unwrapping. If returns nil, ignore value.
+	// Unwrap: Tranform value before unwrapping. If returns InvalidValue, ignore value.
 	Preunwrap func(Value) (Value, error)
 
 	// Unwrap: if not handled, use this unwrapper.


### PR DESCRIPTION
instead of returning `body_json`, `body_bytes` etc, which is... not pretty, we return now functions that return the appropriate data. These are functions and not just values since in the future we'll do it lazily and not just duplicating the payload.

For that purpose, "const function" constructors are implemented that just return their data as values.