### PR TITLE
BUGFIX: deal with http routes that do not begin with '/'

### DIFF
--- a/internal/backend/dispatcher/special_triggers.go
+++ b/internal/backend/dispatcher/special_triggers.go
@@ -25,7 +25,7 @@ func processHTTPTrigger(trigger sdktypes.Trigger, event sdktypes.Event) (bool, m
 	// Get expected path pattern from the trigger.
 	pathValue, ok := trigger.Data()["path"]
 	if !ok {
-		// No pattern means we don't need to match anything.
+		// No path means we don't need to match anything.
 		return true, nil, nil
 	}
 
@@ -34,6 +34,15 @@ func processHTTPTrigger(trigger sdktypes.Trigger, event sdktypes.Event) (bool, m
 	}
 
 	triggerPath := pathValue.GetString().Value()
+
+	if triggerPath == "" {
+		// Empty path means we don't need to match anything.
+		return true, nil, nil
+	}
+
+	if triggerPath[0] != '/' {
+		triggerPath = "/" + triggerPath
+	}
 
 	// Get actual URL from the event.
 	urlValue, ok := event.Data()["url"]

--- a/internal/backend/dispatcher/special_triggers.go
+++ b/internal/backend/dispatcher/special_triggers.go
@@ -2,6 +2,7 @@ package dispatcher
 
 import (
 	"errors"
+	"strings"
 
 	httpint "go.autokitteh.dev/autokitteh/integrations/http"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
@@ -40,7 +41,7 @@ func processHTTPTrigger(trigger sdktypes.Trigger, event sdktypes.Event) (bool, m
 		return true, nil, nil
 	}
 
-	if triggerPath[0] != '/' {
+	if !strings.HasPrefix(triggerPath, "/") {
 		triggerPath = "/" + triggerPath
 	}
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -45,7 +45,7 @@ type Connection struct {
 	ProjectKey string `yaml:"-" json:"-"` // belongs to project.
 
 	Name           string `yaml:"name" json:"name" jsonschema:"required"`
-	Token          string `yaml:"token" json:"token"`
+	Token          string `yaml:"token,omitempty" json:"token,omitempty"`
 	IntegrationKey string `yaml:"integration" json:"integration" jsonschema:"required"`
 }
 
@@ -73,7 +73,7 @@ type Trigger struct {
 	// Arbitrary data to be passed with the trigger.
 	// The dispatcher can use this data, for example, to extract HTTP path parameters.
 	// For example: `data: { "path": "/a/{b}/{c...}"}`, if the connection is an HTTP connection.
-	Data map[string]any `yaml:"data,omitempty" json:"additional_data,omitempty"`
+	Data map[string]any `yaml:"data,omitempty" json:"data,omitempty"`
 
 	Call       string `yaml:"call,omitempty" json:"call,omitempty" jsonschema:"oneof_required=call"`
 	Entrypoint string `yaml:"entrypoint,omitempty" json:"entrypoint,omitempty" jsonschema:"oneof_required=entrypoint"`


### PR DESCRIPTION
- add a leading '/' for paths that do not begin with it in the dispatcher special triggers handler
- do not error on env not found in dispatcher
- manifest schema fixes