### PR TITLE
ENG-580: dev mode is persistent by default

### DIFF
--- a/internal/backend/db/dbfactory/factory.go
+++ b/internal/backend/db/dbfactory/factory.go
@@ -2,6 +2,7 @@ package dbfactory
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/backend/db"
 	"go.autokitteh.dev/autokitteh/internal/backend/db/dbgorm"
 	"go.autokitteh.dev/autokitteh/internal/backend/gormkitteh"
+	"go.autokitteh.dev/autokitteh/internal/xdg"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
@@ -19,7 +21,13 @@ type Config = gormkitteh.Config
 var Configs = configset.Set[Config]{
 	Default: &Config{
 		SlowQueryThreshold: 300 * time.Millisecond,
+		Type:               gormkitteh.RequireExplicitDSNType,
 	},
+	Dev: &Config{
+		Type: "sqlite",
+		DSN:  "file:" + filepath.Join(xdg.DataHomeDir(), "autokitteh.sqlite"),
+	},
+	Test: &Config{},
 }
 
 func New(z *zap.Logger, cfg *Config) (db.DB, error) {

--- a/internal/backend/gormkitteh/config.go
+++ b/internal/backend/gormkitteh/config.go
@@ -2,15 +2,19 @@
 package gormkitteh
 
 import (
+	"errors"
 	"strings"
 	"time"
 )
+
+const RequireExplicitDSNType = "require"
 
 type Config struct {
 	// If `Type` is empty, `DSN` must be in the form of "type:actual_dsn".
 	// If both `Type` and `DSN` are empty, `Type` will be considered "sqlite"
 	// with an empty DSN, which will make sqlite use a temporary database
 	// (see https://www.sqlite.org/inmemorydb.html).
+	// If `Type` is "require" (RequireExplicitDSNType), `DSN` must be specified.
 	Type  string `koanf:"type"`
 	DSN   string `koanf:"dsn"`
 	Debug bool   `koanf:"debug"`
@@ -19,6 +23,14 @@ type Config struct {
 }
 
 func (c Config) Explicit() (*Config, error) {
+	if c.Type == RequireExplicitDSNType {
+		if c.DSN == "" {
+			return nil, errors.New("db config must be specified")
+		}
+
+		c.Type = ""
+	}
+
 	if c.Type == "" {
 		if c.DSN == "" {
 			// With empty DSN, assume type is "sqlite". Will make sqlite

--- a/internal/backend/temporalclient/config.go
+++ b/internal/backend/temporalclient/config.go
@@ -1,6 +1,7 @@
 package temporalclient
 
 import (
+	"path/filepath"
 	"time"
 
 	"go.temporal.io/sdk/testsuite"
@@ -8,6 +9,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/configset"
+	"go.autokitteh.dev/autokitteh/internal/xdg"
 )
 
 type tlsConfig struct {
@@ -52,8 +54,9 @@ var (
 			Monitor:               defaultMonitorConfig,
 			StartDevServerIfNotUp: true,
 			DevServer: testsuite.DevServerOptions{
-				LogLevel: zapcore.WarnLevel.String(),
-				EnableUI: true,
+				LogLevel:   zapcore.WarnLevel.String(),
+				EnableUI:   true,
+				DBFilename: filepath.Join(xdg.DataHomeDir(), "temporal_dev.sqlite"),
 			},
 		},
 		Test: &Config{


### PR DESCRIPTION
maintains persistency by two files: `autokitteh.sqlite` and `temporal_dev.sqlite`.

Note: this does not take care of redis, since it's volatile by definition - unless using an external redis.

Qs:
- Should we use the regular `dev` mode for this, or create another `persistent-dev`? or `volatile-dev`?
- Should we add a command to clean up stuff?
- Should we save the files in XDG_DATA or current dir?