### PR TITLE
Misc tweaks split from other PRs for cleanliness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ bin/ak:
 .PHONY: build
 build:
 	mkdir -p $(OUTDIR)
-	$(GO) build -v $(GO_BUILD_OPTS) ./...
+	$(GO) build $(GO_BUILD_OPTS) ./...
 
 .PHONY: debug
 debug:

--- a/integrations/github/oauth.go
+++ b/integrations/github/oauth.go
@@ -38,12 +38,12 @@ func NewHandler(l *zap.Logger, s sdkservices.Secrets, o sdkservices.OAuth, scope
 	return handler{logger: l, secrets: s, oauth: o, scope: scope}
 }
 
-// HandleOAuth receives an inbound redirect request from autokitteh's OAuth
+// handleOAuth receives an inbound redirect request from autokitteh's OAuth
 // management service. This request contains an OAuth token (if the OAuth
 // flow was successful) and form parameters for debugging and validation
 // (either way). If all is well, it saves a new autokitteh connection.
 // Either way, it redirects the user to success or failure webpages.
-func (h handler) HandleOAuth(w http.ResponseWriter, r *http.Request) {
+func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 	l := h.logger.With(zap.String("urlPath", r.URL.Path))
 
 	// Handle errors (e.g. the user didn't authorize us) based on:

--- a/integrations/github/pat.go
+++ b/integrations/github/pat.go
@@ -24,7 +24,7 @@ const (
 )
 
 // HandlePAT saves a new autokitteh connection with a user-submitted token.
-func (h handler) HandlePAT(w http.ResponseWriter, r *http.Request) {
+func (h handler) handlePAT(w http.ResponseWriter, r *http.Request) {
 	l := h.logger.With(zap.String("urlPath", r.URL.Path))
 
 	// Check "Content-Type" header.

--- a/integrations/github/server.go
+++ b/integrations/github/server.go
@@ -29,8 +29,8 @@ func Start(l *zap.Logger, mux *http.ServeMux, s sdkservices.Secrets, o sdkservic
 	mux.Handle(kittehs.Must1(url.JoinPath(uiPath, "success.html")), staticFiles)
 	mux.Handle(kittehs.Must1(url.JoinPath(uiPath, "success.js")), staticFiles)
 	h := NewHandler(l, s, o, "github")
-	mux.HandleFunc(patPath, h.HandlePAT)
-	mux.HandleFunc(oauthPath, h.HandleOAuth)
+	mux.HandleFunc(patPath, h.handlePAT)
+	mux.HandleFunc(oauthPath, h.handleOAuth)
 
 	// Event webhooks.
 	eventHandler := webhooks.NewHandler(l, s, d, "github", integrationID)

--- a/web/github/connect/index.html
+++ b/web/github/connect/index.html
@@ -31,7 +31,7 @@
     </a>
 
     <table class="title">
-      <td><img class="logo" src="/static/images/github.svg" alt="GitHub" /></td>
+      <td><img class="logo" src="/static/images/github.svg" alt="Logo" /></td>
       <td><h1>GitHub - Create a New Connection</h1></td>
     </table>
 

--- a/web/static/chatgpt/connect/error.html
+++ b/web/static/chatgpt/connect/error.html
@@ -32,7 +32,7 @@
 
     <table class="title">
       <td>
-        <img class="logo" src="/static/images/chatgpt.svg" alt="OpenAI ChatGPT" />
+        <img class="logo" src="/static/images/chatgpt.svg" alt="Logo" />
       </td>
       <td><h1>OpenAI ChatGPT - Connection Error</h1></td>
     </table>

--- a/web/static/chatgpt/connect/error.html
+++ b/web/static/chatgpt/connect/error.html
@@ -31,9 +31,7 @@
     </a>
 
     <table class="title">
-      <td>
-        <img class="logo" src="/static/images/chatgpt.svg" alt="Logo" />
-      </td>
+      <td><img class="logo" src="/static/images/chatgpt.svg" alt="Logo" /></td>
       <td><h1>OpenAI ChatGPT - Connection Error</h1></td>
     </table>
 

--- a/web/static/chatgpt/connect/index.html
+++ b/web/static/chatgpt/connect/index.html
@@ -30,9 +30,7 @@
     </a>
 
     <table class="title">
-      <td>
-        <img class="logo" src="/static/images/chatgpt.svg" alt="Logo" />
-      </td>
+      <td><img class="logo" src="/static/images/chatgpt.svg" alt="Logo" /></td>
       <td><h1>OpenAI ChatGPT - Create a New Connection</h1></td>
     </table>
 

--- a/web/static/chatgpt/connect/index.html
+++ b/web/static/chatgpt/connect/index.html
@@ -31,11 +31,7 @@
 
     <table class="title">
       <td>
-        <img
-          class="logo"
-          src="/static/images/chatgpt.svg"
-          alt="OpenAI ChatGPT"
-        />
+        <img class="logo" src="/static/images/chatgpt.svg" alt="Logo" />
       </td>
       <td><h1>OpenAI ChatGPT - Create a New Connection</h1></td>
     </table>
@@ -60,9 +56,7 @@
 
     <form method="post" action="/chatgpt/save">
       <div class="form-group">
-        <label for="key">
-          Secret API Key
-        </label>
+        <label for="key"> Secret API Key </label>
         <input
           type="text"
           name="key"

--- a/web/static/chatgpt/connect/success.html
+++ b/web/static/chatgpt/connect/success.html
@@ -32,7 +32,7 @@
 
     <table class="title">
       <td>
-        <img class="logo" src="/static/images/chatgpt.svg" alt="OpenAI ChatGPT" />
+        <img class="logo" src="/static/images/chatgpt.svg" alt="Logo" />
       </td>
       <td><h1>OpenAI ChatGPT - Connection Created</h1></td>
     </table>

--- a/web/static/chatgpt/connect/success.html
+++ b/web/static/chatgpt/connect/success.html
@@ -31,9 +31,7 @@
     </a>
 
     <table class="title">
-      <td>
-        <img class="logo" src="/static/images/chatgpt.svg" alt="Logo" />
-      </td>
+      <td><img class="logo" src="/static/images/chatgpt.svg" alt="Logo" /></td>
       <td><h1>OpenAI ChatGPT - Connection Created</h1></td>
     </table>
 

--- a/web/static/github/connect/error.html
+++ b/web/static/github/connect/error.html
@@ -17,7 +17,7 @@
     </a>
 
     <table class="title">
-      <td><img class="logo" src="/static/images/github.svg" alt="GitHub" /></td>
+      <td><img class="logo" src="/static/images/github.svg" alt="Logo" /></td>
       <td><h1>GitHub - Connection Error</h1></td>
     </table>
 

--- a/web/static/github/connect/success.html
+++ b/web/static/github/connect/success.html
@@ -31,7 +31,7 @@
     </a>
 
     <table class="title">
-      <td><img class="logo" src="/static/images/github.svg" alt="GitHub" /></td>
+      <td><img class="logo" src="/static/images/github.svg" alt="Logo" /></td>
       <td><h1>GitHub - Connection Created</h1></td>
     </table>
 

--- a/web/static/gmail/connect/error.html
+++ b/web/static/gmail/connect/error.html
@@ -31,7 +31,7 @@
     </a>
 
     <table class="title">
-      <td><img class="logo" src="/static/images/gmail.svg" alt="Gmail" /></td>
+      <td><img class="logo" src="/static/images/gmail.svg" alt="Logo" /></td>
       <td><h1>Gmail - Connection Error</h1></td>
     </table>
 

--- a/web/static/gmail/connect/index.html
+++ b/web/static/gmail/connect/index.html
@@ -31,7 +31,7 @@
     </a>
 
     <table class="title">
-      <td><img class="logo" src="/static/images/gmail.svg" alt="Gmail" /></td>
+      <td><img class="logo" src="/static/images/gmail.svg" alt="Logo" /></td>
       <td><h1>Gmail - Create a New Connection</h1></td>
     </table>
 

--- a/web/static/gmail/connect/success.html
+++ b/web/static/gmail/connect/success.html
@@ -31,7 +31,7 @@
     </a>
 
     <table class="title">
-      <td><img class="logo" src="/static/images/gmail.svg" alt="Gmail" /></td>
+      <td><img class="logo" src="/static/images/gmail.svg" alt="Logo" /></td>
       <td><h1>Gmail - Connection Created</h1></td>
     </table>
 

--- a/web/static/google/connect/error.html
+++ b/web/static/google/connect/error.html
@@ -31,7 +31,7 @@
     </a>
 
     <table class="title">
-      <td><img class="logo" src="/static/images/google.svg" alt="Google" /></td>
+      <td><img class="logo" src="/static/images/google.svg" alt="Logo" /></td>
       <td><h1>Google - Connection Error</h1></td>
     </table>
 

--- a/web/static/google/connect/index.html
+++ b/web/static/google/connect/index.html
@@ -31,7 +31,7 @@
     </a>
 
     <table class="title">
-      <td><img class="logo" src="/static/images/google.svg" alt="Google" /></td>
+      <td><img class="logo" src="/static/images/google.svg" alt="Logo" /></td>
       <td><h1>Google - Create a New Connection</h1></td>
     </table>
 

--- a/web/static/google/connect/success.html
+++ b/web/static/google/connect/success.html
@@ -31,7 +31,7 @@
     </a>
 
     <table class="title">
-      <td><img class="logo" src="/static/images/google.svg" alt="Google" /></td>
+      <td><img class="logo" src="/static/images/google.svg" alt="Logo" /></td>
       <td><h1>Google - Connection Created</h1></td>
     </table>
 

--- a/web/static/googlesheets/connect/error.html
+++ b/web/static/googlesheets/connect/error.html
@@ -32,11 +32,7 @@
 
     <table class="title">
       <td>
-        <img
-          class="logo"
-          src="/static/images/google_sheets.svg"
-          alt="Google Sheets"
-        />
+        <img class="logo" src="/static/images/google_sheets.svg" alt="Logo" />
       </td>
       <td><h1>Google Sheets - Connection Error</h1></td>
     </table>

--- a/web/static/googlesheets/connect/index.html
+++ b/web/static/googlesheets/connect/index.html
@@ -32,11 +32,7 @@
 
     <table class="title">
       <td>
-        <img
-          class="logo"
-          src="/static/images/google_sheets.svg"
-          alt="Google Sheets"
-        />
+        <img class="logo" src="/static/images/google_sheets.svg" alt="Logo" />
       </td>
       <td><h1>Google Sheets - Create a New Connection</h1></td>
     </table>

--- a/web/static/googlesheets/connect/success.html
+++ b/web/static/googlesheets/connect/success.html
@@ -32,11 +32,7 @@
 
     <table class="title">
       <td>
-        <img
-          class="logo"
-          src="/static/images/google_sheets.svg"
-          alt="Google Sheets"
-        />
+        <img class="logo" src="/static/images/google_sheets.svg" alt="Logo" />
       </td>
       <td><h1>Google Sheets - Connection Created</h1></td>
     </table>

--- a/web/static/scheduler/connect/error.html
+++ b/web/static/scheduler/connect/error.html
@@ -32,7 +32,7 @@
 
     <table class="title">
       <td>
-        <img class="logo" src="/static/images/scheduler.svg" alt="Scheduler" />
+        <img class="logo" src="/static/images/scheduler.svg" alt="Logo" />
       </td>
       <td><h1>Scheduler (Cron) - Connection Error</h1></td>
     </table>

--- a/web/static/scheduler/connect/index.html
+++ b/web/static/scheduler/connect/index.html
@@ -31,7 +31,7 @@
 
     <table class="title">
       <td>
-        <img class="logo" src="/static/images/scheduler.svg" alt="Scheduler" />
+        <img class="logo" src="/static/images/scheduler.svg" alt="Logo" />
       </td>
       <td><h1>Scheduler (Cron) - Create a New Connection</h1></td>
     </table>

--- a/web/static/scheduler/connect/success.html
+++ b/web/static/scheduler/connect/success.html
@@ -32,7 +32,7 @@
 
     <table class="title">
       <td>
-        <img class="logo" src="/static/images/scheduler.svg" alt="Scheduler" />
+        <img class="logo" src="/static/images/scheduler.svg" alt="Logo" />
       </td>
       <td><h1>Scheduler (Cron) - Connection Created</h1></td>
     </table>

--- a/web/static/slack/connect/error.html
+++ b/web/static/slack/connect/error.html
@@ -31,9 +31,7 @@
     </a>
 
     <table class="title">
-      <td>
-        <img class="logo" src="/static/images/slack.svg" alt="Logo" />
-      </td>
+      <td><img class="logo" src="/static/images/slack.svg" alt="Logo" /></td>
       <td><h1>Slack - Connection Error</h1></td>
     </table>
 

--- a/web/static/slack/connect/error.html
+++ b/web/static/slack/connect/error.html
@@ -32,7 +32,7 @@
 
     <table class="title">
       <td>
-        <img class="logo" src="/static/images/slack.svg" alt="Slack" />
+        <img class="logo" src="/static/images/slack.svg" alt="Logo" />
       </td>
       <td><h1>Slack - Connection Error</h1></td>
     </table>

--- a/web/static/slack/connect/index.html
+++ b/web/static/slack/connect/index.html
@@ -31,7 +31,7 @@
     </a>
 
     <table class="title">
-      <td><img class="logo" src="/static/images/slack.svg" alt="Slack" /></td>
+      <td><img class="logo" src="/static/images/slack.svg" alt="Logo" /></td>
       <td><h1>Slack - Create a New Connection</h1></td>
     </table>
 

--- a/web/static/slack/connect/success.html
+++ b/web/static/slack/connect/success.html
@@ -32,7 +32,7 @@
 
     <table class="title">
       <td>
-        <img class="logo" src="/static/images/slack.svg" alt="Slack" />
+        <img class="logo" src="/static/images/slack.svg" alt="Logo" />
       </td>
       <td><h1>Slack - Connection Created</h1></td>
     </table>

--- a/web/static/slack/connect/success.html
+++ b/web/static/slack/connect/success.html
@@ -31,9 +31,7 @@
     </a>
 
     <table class="title">
-      <td>
-        <img class="logo" src="/static/images/slack.svg" alt="Logo" />
-      </td>
+      <td><img class="logo" src="/static/images/slack.svg" alt="Logo" /></td>
       <td><h1>Slack - Connection Created</h1></td>
     </table>
 

--- a/web/static/twilio/connect/error.html
+++ b/web/static/twilio/connect/error.html
@@ -32,7 +32,7 @@
 
     <table class="title">
       <td>
-        <img class="logo" src="/static/images/twilio.png" alt="Twilio" />
+        <img class="logo" src="/static/images/twilio.png" alt="Logo" />
       </td>
       <td><h1>Twilio - Connection Error</h1></td>
     </table>

--- a/web/static/twilio/connect/error.html
+++ b/web/static/twilio/connect/error.html
@@ -31,9 +31,7 @@
     </a>
 
     <table class="title">
-      <td>
-        <img class="logo" src="/static/images/twilio.png" alt="Logo" />
-      </td>
+      <td><img class="logo" src="/static/images/twilio.png" alt="Logo" /></td>
       <td><h1>Twilio - Connection Error</h1></td>
     </table>
 

--- a/web/static/twilio/connect/index.html
+++ b/web/static/twilio/connect/index.html
@@ -31,7 +31,7 @@
     </a>
 
     <table class="title">
-      <td><img class="logo" src="/static/images/twilio.png" alt="Twilio" /></td>
+      <td><img class="logo" src="/static/images/twilio.png" alt="Logo" /></td>
       <td><h1>Twilio - Create a New Connection</h1></td>
     </table>
 

--- a/web/static/twilio/connect/success.html
+++ b/web/static/twilio/connect/success.html
@@ -32,7 +32,7 @@
 
     <table class="title">
       <td>
-        <img class="logo" src="/static/images/twilio.png" alt="Twilio" />
+        <img class="logo" src="/static/images/twilio.png" alt="Logo" />
       </td>
       <td><h1>Twilio - Connection Created</h1></td>
     </table>

--- a/web/static/twilio/connect/success.html
+++ b/web/static/twilio/connect/success.html
@@ -31,9 +31,7 @@
     </a>
 
     <table class="title">
-      <td>
-        <img class="logo" src="/static/images/twilio.png" alt="Logo" />
-      </td>
+      <td><img class="logo" src="/static/images/twilio.png" alt="Logo" /></td>
       <td><h1>Twilio - Connection Created</h1></td>
     </table>
 


### PR DESCRIPTION
- Remove -v from go build to simplify GitHub action output (we don't need that level of detail, and it may speed up the runtime a bit)
- Simplify logo hint in all integration HTML pages (done during work on HTTP secrets, but split to avoid PR pollution)