### PR TITLE
Quote paths if they contain spaces, in "config where" CLI command

### DIFF
--- a/cmd/ak/cmd/configuration/where.go
+++ b/cmd/ak/cmd/configuration/where.go
@@ -24,7 +24,6 @@ var whereCmd = common.StandardCommand(&cobra.Command{
 
 		data := xdg.DataHomeDir()
 		if strings.Contains(data, " ") {
-			data = fmt.Sprintf("%q", data)
 			data = `"` + data + `"`
 		}
 

--- a/cmd/ak/cmd/configuration/where.go
+++ b/cmd/ak/cmd/configuration/where.go
@@ -2,6 +2,7 @@ package configuration
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -16,8 +17,19 @@ var whereCmd = common.StandardCommand(&cobra.Command{
 	Args:    cobra.NoArgs,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("Config home directory:", xdg.ConfigHomeDir())
-		fmt.Println("Data home directory:  ", xdg.DataHomeDir())
+		cfg := xdg.ConfigHomeDir()
+		if strings.Contains(cfg, " ") {
+			cfg = `"` + cfg + `"`
+		}
+
+		data := xdg.DataHomeDir()
+		if strings.Contains(data, " ") {
+			data = fmt.Sprintf("%q", data)
+			data = `"` + data + `"`
+		}
+
+		fmt.Println("Config home directory:", cfg)
+		fmt.Println("Data home directory:  ", data)
 		fmt.Println()
 		fmt.Println("Override environment variable names:")
 		fmt.Println(xdg.ConfigEnvVar)

--- a/cmd/ak/cmd/configuration/where.go
+++ b/cmd/ak/cmd/configuration/where.go
@@ -2,6 +2,7 @@ package configuration
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -19,12 +20,12 @@ var whereCmd = common.StandardCommand(&cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := xdg.ConfigHomeDir()
 		if strings.Contains(cfg, " ") {
-			cfg = `"` + cfg + `"`
+			cfg = strconv.Quote(cfg)
 		}
 
 		data := xdg.DataHomeDir()
 		if strings.Contains(data, " ") {
-			data = `"` + data + `"`
+			data = strconv.Quote(data)
 		}
 
 		fmt.Fprintln(cmd.OutOrStdout(), "Config home directory:", cfg)

--- a/cmd/ak/cmd/configuration/where.go
+++ b/cmd/ak/cmd/configuration/where.go
@@ -27,12 +27,12 @@ var whereCmd = common.StandardCommand(&cobra.Command{
 			data = `"` + data + `"`
 		}
 
-		fmt.Println("Config home directory:", cfg)
-		fmt.Println("Data home directory:  ", data)
-		fmt.Println()
-		fmt.Println("Override environment variable names:")
-		fmt.Println(xdg.ConfigEnvVar)
-		fmt.Println(xdg.DataEnvVar)
+		fmt.Fprintln(cmd.OutOrStdout(), "Config home directory:", cfg)
+		fmt.Fprintln(cmd.OutOrStdout(), "Data home directory:  ", data)
+		fmt.Fprintln(cmd.OutOrStdout(), "")
+		fmt.Fprintln(cmd.OutOrStdout(), "Override environment variable names:")
+		fmt.Fprintln(cmd.OutOrStdout(), xdg.ConfigEnvVar)
+		fmt.Fprintln(cmd.OutOrStdout(), xdg.DataEnvVar)
 
 		return nil
 	},


### PR DESCRIPTION
This is a tiny optimization for users who want to copy & paste it in the terminal.

Also replace `fmt.Println(...)` with `fmt.Fprintln(cmd.OutOrStdout(), ...)` to allow Cobra to override the OS's stdout with its own (which is what we do in most CLI outputs).