### PR TITLE
ENG-651: Fix GHES transport

### DIFF
--- a/integrations/github/jwt.go
+++ b/integrations/github/jwt.go
@@ -100,7 +100,7 @@ func (i integration) getConnection(ctx context.Context) (map[string]string, erro
 func (i integration) NewClientWithAppJWTFromGitHubID(appID int64) (*github.Client, error) {
 	// Shared transport to reuse TCP connections.
 	tr := http.DefaultTransport
-	entURL, err := enterpriseURL()
+	enterpriseURL, err := enterpriseURL()
 	if err != nil {
 		return nil, err
 	}
@@ -110,14 +110,14 @@ func (i integration) NewClientWithAppJWTFromGitHubID(appID int64) (*github.Clien
 	if err != nil {
 		return nil, err
 	}
-	if entURL != "" {
-		atr.BaseURL = entURL + "/api/v3"
+	if enterpriseURL != "" {
+		atr.BaseURL = enterpriseURL + "/api/v3"
 	}
 
 	// Initialize a client with the generated JWT injected into outbound requests.
 	client := github.NewClient(&http.Client{Transport: atr})
-	if entURL != "" {
-		client, err = client.WithEnterpriseURLs(entURL, entURL)
+	if enterpriseURL != "" {
+		client, err = client.WithEnterpriseURLs(enterpriseURL, enterpriseURL)
 		if err != nil {
 			return nil, err
 		}
@@ -131,7 +131,7 @@ func (i integration) NewClientWithAppJWTFromGitHubID(appID int64) (*github.Clien
 func (i integration) NewClientWithInstallJWTFromGitHubIDs(appID, installID int64) (*github.Client, error) {
 	// Shared transport to reuse TCP connections.
 	tr := http.DefaultTransport
-	entURL, err := enterpriseURL()
+	enterpriseURL, err := enterpriseURL()
 	if err != nil {
 		return nil, err
 	}
@@ -141,14 +141,14 @@ func (i integration) NewClientWithInstallJWTFromGitHubIDs(appID, installID int64
 	if err != nil {
 		return nil, err
 	}
-	if entURL != "" {
-		itr.BaseURL = entURL + "/api/v3"
+	if enterpriseURL != "" {
+		itr.BaseURL = enterpriseURL + "/api/v3"
 	}
 
 	// Initialize a client with the generated JWT injected into outbound requests.
 	client := github.NewClient(&http.Client{Transport: itr})
-	if entURL != "" {
-		client, err = client.WithEnterpriseURLs(entURL, entURL)
+	if enterpriseURL != "" {
+		client, err = client.WithEnterpriseURLs(enterpriseURL, enterpriseURL)
 		if err != nil {
 			return nil, err
 		}

--- a/integrations/github/jwt.go
+++ b/integrations/github/jwt.go
@@ -100,7 +100,7 @@ func (i integration) getConnection(ctx context.Context) (map[string]string, erro
 func (i integration) NewClientWithAppJWTFromGitHubID(appID int64) (*github.Client, error) {
 	// Shared transport to reuse TCP connections.
 	tr := http.DefaultTransport
-	u, err := enterpriseURL()
+	entURL, err := enterpriseURL()
 	if err != nil {
 		return nil, err
 	}
@@ -110,14 +110,14 @@ func (i integration) NewClientWithAppJWTFromGitHubID(appID int64) (*github.Clien
 	if err != nil {
 		return nil, err
 	}
-	if u != "" {
-		atr.BaseURL = u + "/api/v3"
+	if entURL != "" {
+		atr.BaseURL = entURL + "/api/v3"
 	}
 
 	// Initialize a client with the generated JWT injected into outbound requests.
 	client := github.NewClient(&http.Client{Transport: atr})
-	if u != "" {
-		client, err = client.WithEnterpriseURLs(u, u)
+	if entURL != "" {
+		client, err = client.WithEnterpriseURLs(entURL, entURL)
 		if err != nil {
 			return nil, err
 		}
@@ -131,7 +131,7 @@ func (i integration) NewClientWithAppJWTFromGitHubID(appID int64) (*github.Clien
 func (i integration) NewClientWithInstallJWTFromGitHubIDs(appID, installID int64) (*github.Client, error) {
 	// Shared transport to reuse TCP connections.
 	tr := http.DefaultTransport
-	u, err := enterpriseURL()
+	entURL, err := enterpriseURL()
 	if err != nil {
 		return nil, err
 	}
@@ -141,14 +141,14 @@ func (i integration) NewClientWithInstallJWTFromGitHubIDs(appID, installID int64
 	if err != nil {
 		return nil, err
 	}
-	if u != "" {
-		itr.BaseURL = u + "/api/v3"
+	if entURL != "" {
+		itr.BaseURL = entURL + "/api/v3"
 	}
 
 	// Initialize a client with the generated JWT injected into outbound requests.
 	client := github.NewClient(&http.Client{Transport: itr})
-	if u != "" {
-		client, err = client.WithEnterpriseURLs(u, u)
+	if entURL != "" {
+		client, err = client.WithEnterpriseURLs(entURL, entURL)
 		if err != nil {
 			return nil, err
 		}

--- a/integrations/github/jwt.go
+++ b/integrations/github/jwt.go
@@ -100,19 +100,22 @@ func (i integration) getConnection(ctx context.Context) (map[string]string, erro
 func (i integration) NewClientWithAppJWTFromGitHubID(appID int64) (*github.Client, error) {
 	// Shared transport to reuse TCP connections.
 	tr := http.DefaultTransport
+	u, err := enterpriseURL()
+	if err != nil {
+		return nil, err
+	}
 
 	// Wrap the shared transport.
 	atr, err := ghinstallation.NewAppsTransport(tr, appID, getPrivateKey())
 	if err != nil {
 		return nil, err
 	}
+	if u != "" {
+		atr.BaseURL = u + "/api/v3"
+	}
 
 	// Initialize a client with the generated JWT injected into outbound requests.
 	client := github.NewClient(&http.Client{Transport: atr})
-	u, err := enterpriseURL()
-	if err != nil {
-		return nil, err
-	}
 	if u != "" {
 		client, err = client.WithEnterpriseURLs(u, u)
 		if err != nil {
@@ -128,19 +131,22 @@ func (i integration) NewClientWithAppJWTFromGitHubID(appID int64) (*github.Clien
 func (i integration) NewClientWithInstallJWTFromGitHubIDs(appID, installID int64) (*github.Client, error) {
 	// Shared transport to reuse TCP connections.
 	tr := http.DefaultTransport
+	u, err := enterpriseURL()
+	if err != nil {
+		return nil, err
+	}
 
 	// Wrap the shared transport.
 	itr, err := ghinstallation.New(tr, appID, installID, getPrivateKey())
 	if err != nil {
 		return nil, err
 	}
+	if u != "" {
+		itr.BaseURL = u + "/api/v3"
+	}
 
 	// Initialize a client with the generated JWT injected into outbound requests.
 	client := github.NewClient(&http.Client{Transport: itr})
-	u, err := enterpriseURL()
-	if err != nil {
-		return nil, err
-	}
 	if u != "" {
 		client, err = client.WithEnterpriseURLs(u, u)
 		if err != nil {

--- a/internal/backend/oauth/oauth.go
+++ b/internal/backend/oauth/oauth.go
@@ -54,9 +54,9 @@ func New(l *zap.Logger) sdkservices.OAuth {
 		)
 	}
 
-	githubAppsURLPart := os.Getenv("GITHUB_APPS_URL_PART")
-	if githubAppsURLPart == "" {
-		githubAppsURLPart = "apps"
+	appsDir := "apps"
+	if os.Getenv("GITHUB_ENTERPRISE_URL") != "" {
+		appsDir = "github-apps"
 	}
 
 	return &oauth{
@@ -72,7 +72,7 @@ func New(l *zap.Logger) sdkservices.OAuth {
 				ClientSecret: os.Getenv("GITHUB_CLIENT_SECRET"),
 				Endpoint: oauth2.Endpoint{
 					// https://docs.github.com/en/apps/using-github-apps/installing-a-github-app-from-a-third-party#installing-a-github-app
-					AuthURL: fmt.Sprintf("%s/%s/%s/installations/new", githubBaseURL, githubAppsURLPart, os.Getenv("GITHUB_APP_NAME")),
+					AuthURL: fmt.Sprintf("%s/%s/%s/installations/new", githubBaseURL, appsDir, os.Getenv("GITHUB_APP_NAME")),
 					// https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow
 					DeviceAuthURL: fmt.Sprintf("%s/login/device/code", githubBaseURL),
 					// https://docs.github.com/en/enterprise-server/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github


### PR DESCRIPTION
Also generalize PR #154 after testing with GHES - `/github-apps/` (instead of `/apps/`) is a GHES feature rather than a configuration.