### PR TITLE
dev mode default log level is info

### DIFF
--- a/internal/backend/logger/logger.go
+++ b/internal/backend/logger/logger.go
@@ -15,7 +15,7 @@ type Config struct {
 	Zap zap.Config `koanf:"zap"`
 }
 
-var defaultZapLevel = zap.NewAtomicLevelAt(zap.DebugLevel)
+var defaultZapLevel = zap.NewAtomicLevelAt(zap.InfoLevel)
 
 var Configs = configset.Set[Config]{
 	Default: &Config{Zap: zap.NewProductionConfig()},


### PR DESCRIPTION
debug is too noisy and messy. people can enable it manually if they really want it.