### PR TITLE
[ENG-516] Simplify Python Callbacks

### DIFF
--- a/runtimes/pythonrt/README.md
+++ b/runtimes/pythonrt/README.md
@@ -85,8 +85,33 @@ We're using JSON over Unix domain socket, one JSON object per line.
 The reason do this is that `ak_runner.py` should not have any external dependencies outside the standard library.
 Once we introduce an external dependency, it will conflict with the user dependencies.
 
-The message payload is handled by Python and is opaque to autokitteh.
-Currently, it's base64 of a pickle. We're using pickle protocol 0 which is text based and mostly Python version agnostic.
+All messages have top level `type` and `payload`, the `payload` changes depending on the `type`.
+
+**run**
+
+- func_name: Function name (string)
+- event: Data payload (map)
+
+**module**
+
+- entries: List of exported functions (array of strings)
+
+**callback**
+
+- name: Function name (string)
+- args: Function args (array of strings)
+- kw: Mapping of name → value (both strings)
+- data: Pickled (protocol 0) tuple of `(func, args, kw)` encoded in base64
+
+**response**
+
+- value: Return type from Python (base64 of Python's pickle protocol 0)
+
+**done**
+
+- No fields
+
+
 ### Integration Testing
 
 If you run `ak` with a database, then run `make create-workflow` once. 

--- a/runtimes/pythonrt/ak_runner.py
+++ b/runtimes/pythonrt/ak_runner.py
@@ -18,9 +18,7 @@ from importlib.machinery import SourceFileLoader
 from inspect import isbuiltin
 from os import mkdir
 from pathlib import Path
-from queue import Queue
 from socket import AF_UNIX, SOCK_STREAM, socket
-from threading import Thread
 
 # TODO(ENG-552): Log to AutoKitteh
 logging.basicConfig(
@@ -150,13 +148,90 @@ def run_code(mod, entry_point, data):
     return fn(data)
 
 
+class MessageType:
+    callback = 'callback'
+    done = 'done'
+    module = 'module'
+    response = 'response'
+    run = 'run'
+    
+
+class Comm:
+    def __init__(self, sock):
+        self.sock = sock
+        self.rdr = sock.makefile('r')
+
+    def _send(self, message):
+        data = json.dumps(message) + '\n'
+        self.sock.sendall(data.encode('utf-8'))
+
+    def _recv(self, expected_type):
+        data = self.rdr.readline()
+        message = json.loads(data)
+        if (typ := message['type']) != expected_type:
+            raise ValueError(f'message type: expected {expected_type!r}, got {typ!r}')
+        return message
+
+    def _picklize(self, data):
+        data = pickle.dumps(data, protocol=0)
+        return b64encode(data).decode('utf-8')
+
+    def send_activity(self, fn, args, kw):
+        args = [str(a) for a in args]
+        kw = {k: str(v) for k, v in kw.items()}
+        data = (fn, args, kw)
+        message = {
+            'type': MessageType.callback,
+            'payload': {
+                'name': fn.__name__,
+                'args': args,
+                'kw': kw or {},
+                'data': self._picklize(data),
+            },
+        }
+        self._send(message)
+
+    def receive_activity(self):
+        message = self._recv(MessageType.callback)
+
+        payload = message['payload']
+        data = b64decode(payload['data'])
+        payload['data'] = pickle.loads(data)
+        return payload
+
+    def send_exported(self, entries):
+        message = {
+            'type': MessageType.module,
+            'payload': {
+                'names': entries,
+            }
+        }
+        self._send(message)
+
+    def send_done(self):
+        message = {'type': MessageType.done}
+        self._send(message)
+
+    def receive_run(self):
+        message = self._recv(MessageType.run)
+        return message['payload']
+
+    def send_response(self, data):
+        message = {
+            'type': MessageType.response,
+            'payload': {
+                'value': self._picklize(data),
+            }
+        }
+        self._send(message)
+
+
 class AKCall:
     """Callable wrapping functions with activities."""
-    def __init__(self, module_name):
+    def __init__(self, module_name, comm: Comm):
         self.module_name = module_name
         self.in_activity = False
-        # Queue for passing requests from execution thread to main working with Go.
-        self.activity_request, self.activity_response = Queue(), Queue()
+        self.comm = comm
 
     def ignore(self, fn):
         if isbuiltin(fn):
@@ -173,23 +248,10 @@ class AKCall:
 
         logging.info('ACTION: calling %s (args=%r, kw=%r)', func.__name__, args, kw)
         self.in_activity = True
-        request = (func, args, kw)
-        self.activity_request.put(request)
-        response = self.activity_response.get()
-        self.in_activity = False
-        return response
-
-
-class RunWrapper:
-    """Wrapper that captures the module so we can access it outside the running
-    thread. And also send sentinel to activity_request queue to signal we're done."""
-    def __init__(self, mod, queue):
-        self.mod = mod
-        self.queue = queue
-
-    def run(self, func_name, data):
-        run_code(self.mod, func_name, data)
-        self.queue.put(None)  # Signal we're done
+        self.comm.send_activity(func, args, kw)
+        message = self.comm.receive_activity()
+        fn, args, kw = message['data']
+        return fn(*args, **kw)
 
 
 def extract_code(tar_path):
@@ -284,34 +346,25 @@ if __name__ == '__main__':
 
     sock = socket(AF_UNIX, SOCK_STREAM)
     sock.connect(args.sock)
-    rdr = sock.makefile('r')
     logging.info('connected to %r', args.sock)
 
     logging.info('loading %r', module_name)
-    ak_call = AKCall(module_name)
+    comm = Comm(sock)
+    ak_call = AKCall(module_name, comm)
     mod = load_code(code_dir, ak_call, module_name)
     MODULE_NAME = mod.__name__
     entries = module_entries(mod)
-    event = encode_msg('module', '', json.dumps(entries))
-    sock.sendall(event)
+    comm.send_exported(entries)
 
     # Initial call
-    request = decode_msg(rdr.readline())
-    if request['type'] != 'run':
-        logging.error('bad initial request: %r', request)
-        raise SystemExit(1)
-
-    func_name = request.get('name')
+    request = comm.receive_run()
+    func_name = request.get('func_name')
     if func_name is None:
         logging.error('no function name in %r', request)
         raise SystemExit(1)
 
-    event = request.get('payload')
+    event = request.get('event')
     event = {} if event is None else json.loads(event)
-
-    rw = RunWrapper(mod, ak_call.activity_request)
-    Thread(target=rw.run, args=(func_name, event), daemon=True).start()
-    logging.info('execution thread started, func=%r, event=%r', func_name, event)
 
     while True:
         request = ak_call.activity_request.get()

--- a/runtimes/pythonrt/ak_runner_test.py
+++ b/runtimes/pythonrt/ak_runner_test.py
@@ -129,7 +129,7 @@ def test_comm():
     assert data, 'no data'
     message = json.loads(data)
     assert message['type'] == ak_runner.MessageType.module
-    assert message['payload']['names'] == names
+    assert message['payload']['entries'] == names
 
 
     # Done

--- a/runtimes/pythonrt/ak_runner_test.py
+++ b/runtimes/pythonrt/ak_runner_test.py
@@ -1,7 +1,9 @@
 import json
+import pickle
 import sys
 import types
 from pathlib import Path
+from socket import socketpair
 from subprocess import run
 from threading import Thread
 
@@ -22,7 +24,7 @@ def test_load_code():
             if fn.__module__ != mod_name:
                 calls.append((fn, args, kw))
             return fn(*args, **kw)
-    ak_call = MockCall(mod_name)
+    ak_call = MockCall(mod_name, None, None)
 
     mod = ak_runner.load_code('testdata', ak_call, mod_name)
     fn = getattr(mod, 'parse', None)
@@ -49,7 +51,7 @@ def test_module_entries():
     names = ['a', 'b']
     for name in names:
         setattr(mod, name, lambda: None)
-    mod.c = 7
+    setattr(mod, 'c', 7)  # Not a callable
 
     entries = ak_runner.module_entries(mod)
     assert names == sorted(entries)
@@ -72,3 +74,47 @@ def test_nested():
     assert val == out
     ak.activity_response.put(out)
     thr.join(0.1)  # Will raise if ak still waits
+
+
+def sub(a, b, *, verbose=False):
+    if verbose:
+        print(f'{a} - {b}')
+    return a - b
+
+
+def test_comm():
+    go, py = socketpair()
+
+    # Callback
+    comm = ak_runner.Comm(py)
+    args, kw = (1, 7), {'verbose': False}
+    comm.send_activity(sub, args, kw)
+    data = go.recv(2048)
+    assert data, 'no data'
+
+    go.sendall(data)
+    message = comm.receive_activity()
+    assert message['name'] == sub.__name__
+    assert message['args'] == [str(v) for v in args]
+    assert message['kw'] == {k: str(v) for k, v in kw.items()}
+    fn, args, kw = message['data']
+    assert fn == sub
+    assert args == args
+    assert kw == kw
+
+    # Module
+    names = ['a', 'c', 'f']
+    comm.send_exported(names)
+    data = go.recv(2048)
+    assert data, 'no data'
+    message = json.loads(data)
+    assert message['type'] == ak_runner.MessageType.module
+    assert message['payload']['names'] == names
+
+
+    # Done
+    comm.send_done()
+    data = go.recv(2048)
+    assert data, 'no data'
+    message = json.loads(data)
+    assert message['type'] == ak_runner.MessageType.done

--- a/runtimes/pythonrt/comm.go
+++ b/runtimes/pythonrt/comm.go
@@ -1,0 +1,118 @@
+package pythonrt
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+)
+
+// Messages should be in sync with MesssageType in ak_runner.py
+
+const callbackType = "callback"
+
+type CallbackMessage struct {
+	Name string            `json:"name"`
+	Args []string          `json:"args"`
+	Kw   map[string]string `json:"kw"`
+	Data []byte            `json:"data"`
+}
+
+func (CallbackMessage) Type() string {
+	return "callback"
+}
+
+// There's no data in the done message
+
+type ModuleMessage struct {
+	Entries []string `json:"entries"`
+}
+
+func (ModuleMessage) Type() string { return "module" }
+
+type ResponseMessage struct {
+	Value []byte `json:"value"`
+}
+
+func (ResponseMessage) Type() string { return "response" }
+
+type RunMessage struct {
+	FuncName string         `json:"func_name"`
+	Event    map[string]any `json:"event"`
+}
+
+func (RunMessage) Type() string { return "run" }
+
+type SubMessage interface {
+	CallbackMessage | ModuleMessage | ResponseMessage
+
+	Type() string
+}
+
+type Message struct {
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+func zero[T any]() (out T) {
+	return
+}
+
+func extractMessage[T SubMessage](m Message) (T, error) {
+	var sm T
+	if m.Type != sm.Type() {
+		return zero[T](), fmt.Errorf("message type: expected %q, got %q", sm.Type(), m.Type)
+	}
+
+	if err := json.Unmarshal(m.Payload, &sm); err != nil {
+		return zero[T](), err
+	}
+
+	return sm, nil
+}
+
+type Comm struct {
+	conn net.Conn
+	dec  *json.Decoder
+	enc  *json.Encoder
+}
+
+func NewComm(conn net.Conn) *Comm {
+	c := Comm{
+		conn: conn,
+		dec:  json.NewDecoder(conn),
+		enc:  json.NewEncoder(conn),
+	}
+
+	return &c
+}
+
+func (c *Comm) Close() error {
+	return c.conn.Close()
+}
+
+type Typed interface {
+	Type() string
+}
+
+func (c *Comm) Send(msg Typed) error {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	m := Message{
+		Type:    msg.Type(),
+		Payload: data,
+	}
+
+	return c.enc.Encode(m)
+}
+
+func (c *Comm) Recv() (Message, error) {
+	var m Message
+	if err := c.dec.Decode(&m); err != nil {
+		return Message{}, nil
+	}
+
+	return m, nil
+}

--- a/runtimes/pythonrt/comm.go
+++ b/runtimes/pythonrt/comm.go
@@ -8,8 +8,6 @@ import (
 
 // Messages should be in sync with MesssageType in ak_runner.py
 
-const callbackType = "callback"
-
 type CallbackMessage struct {
 	Name string            `json:"name"`
 	Args []string          `json:"args"`

--- a/runtimes/pythonrt/pythonrt.go
+++ b/runtimes/pythonrt/pythonrt.go
@@ -2,7 +2,6 @@ package pythonrt
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
@@ -37,8 +36,7 @@ type pySvc struct {
 	cbs       *sdkservices.RunCallbacks
 	exports   map[string]sdktypes.Value
 	firstCall bool
-	dec       *json.Decoder
-	enc       *json.Encoder
+	comm      *Comm
 }
 
 func New() (sdkservices.Runtime, error) {
@@ -110,17 +108,6 @@ func (py *pySvc) Build(ctx context.Context, fs fs.FS, path string, values []sdkt
 	return art, nil
 }
 
-type PyMessage struct {
-	Type    string `json:"type"`
-	Name    string `json:"name"`
-	Payload []byte `json:"payload"`
-	Func    struct {
-		Name string            `json:"name"`
-		Args []string          `json:"args"`
-		Kw   map[string]string `json:"kw"`
-	} `json:"func"`
-}
-
 // All Python handler function get all event information.
 var pyModuleFunc = kittehs.Must1(sdktypes.ModuleFunctionFromProto(&sdktypes.ModuleFunctionPB{
 	Input: []*sdktypes.ModuleFunctionFieldPB{
@@ -144,12 +131,6 @@ func entriesToValues(xid sdktypes.ExecutorID, entries []string) (map[string]sdkt
 
 	return values, nil
 }
-
-const (
-	callbackType = "callback"
-	doneType     = "done"
-	moduleType   = "module"
-)
 
 /*
 Run starts a Python workflow.
@@ -208,33 +189,28 @@ func (py *pySvc) Run(
 		return nil, err
 	}
 	py.log.Info("python connected", zap.String("peer", conn.RemoteAddr().String()))
+	comm := NewComm(conn)
 
-	// Initial message from Python is list of exported callables.
-	dec := json.NewDecoder(conn)
-	var msg PyMessage
-	if err := dec.Decode(&msg); err != nil {
+	// FIXME (ENG-577) We might get activity calls before module is loaded if there are module level function calls.
+
+	msg, err := comm.Recv()
+	if err != nil {
+		py.log.Error("initial message from python", zap.Error(err))
+		return nil, err
+	}
+	mod, err := extractMessage[ModuleMessage](msg)
+	if err != nil {
 		py.log.Error("initial message from python", zap.Error(err))
 		return nil, err
 	}
 
-	// FIXME (ENG-577) We might get activity calls before module is loaded if there are module level function calls.
-	if msg.Type != moduleType {
-		py.log.Error("wrong initial message type from python", zap.String("type", msg.Type))
-		return nil, fmt.Errorf("wrong initial message: type=%q", msg.Type)
-	}
 	py.log.Info("module loaded")
 
-	py.xid = sdktypes.NewExecutorID(runID)
-	py.log.Info("executor", zap.String("id", py.xid.String()))
+	xid := sdktypes.NewExecutorID(runID)
+	py.log.Info("executor", zap.String("id", xid.String()))
 
-	var entries []string
-	if err := json.Unmarshal(msg.Payload, &entries); err != nil {
-		py.log.Error("can't parse module entries", zap.Error(err))
-		return nil, fmt.Errorf("can't parse module entries: %w", err)
-	}
-	py.log.Info("module entries", zap.Any("entries", entries))
-
-	exports, err := entriesToValues(py.xid, entries)
+	py.log.Info("module entries", zap.Any("entries", mod.Entries))
+	exports, err := entriesToValues(xid, mod.Entries)
 	if err != nil {
 		py.log.Error("can't create module entries", zap.Error(err))
 		return nil, fmt.Errorf("can't create module entries: %w", err)
@@ -242,12 +218,12 @@ func (py *pySvc) Run(
 
 	killPy = false // All is good, don't kill Python subprocess.
 
-	py.run = ri
 	py.cbs = cbs
+	py.comm = comm
 	py.exports = exports
 	py.firstCall = true
-	py.dec = dec
-	py.enc = json.NewEncoder(conn)
+	py.run = ri
+	py.xid = xid
 
 	return py, nil
 }
@@ -260,6 +236,7 @@ func (py *pySvc) Values() map[string]sdktypes.Value {
 }
 
 func (py *pySvc) Close() {
+	py.comm.Close()
 	py.log.Info("closing")
 	// AK calls Close after `Run`, but we need the Python process running for `Call` as well.
 	// We kill the Python process once the initial `Call` is completed.
@@ -267,7 +244,7 @@ func (py *pySvc) Close() {
 
 // initialCall handles initial call from autokitteh.
 // We split it from Call since Call is also used to execute activities.
-func (py *pySvc) initialCall(ctx context.Context, funcName string, payload []byte) (sdktypes.Value, error) {
+func (py *pySvc) initialCall(ctx context.Context, funcName string, event map[string]any) (sdktypes.Value, error) {
 	defer func() {
 		py.log.Info("python done, killing")
 		if err := py.run.proc.Kill(); err != nil {
@@ -276,47 +253,53 @@ func (py *pySvc) initialCall(ctx context.Context, funcName string, payload []byt
 		py.run.proc = nil
 	}()
 
-	// Initial run cal.
-	msg := PyMessage{
-		Type:    "run",
-		Name:    funcName,
-		Payload: payload,
+	py.log.Info("initial call", zap.Any("func", funcName))
+
+	// Initial run call.
+	msg := RunMessage{
+		FuncName: funcName,
+		Event:    event,
 	}
-	py.log.Info("initial call", zap.Any("message", msg))
-	if err := py.enc.Encode(msg); err != nil {
+	if err := py.comm.Send(msg); err != nil {
 		return sdktypes.InvalidValue, err
 	}
 
 	// Activity callback loop.
 	for {
-		var msg PyMessage
 		py.log.Info("waiting for Python call")
-		if err := py.dec.Decode(&msg); err != nil {
+		msg, err := py.comm.Recv()
+		if err != nil {
 			py.log.Error("communication error", zap.Error(err))
 			return sdktypes.InvalidValue, err
 		}
 		py.log.Info("from python", zap.Any("message", msg))
 
-		if msg.Type == doneType {
+		if msg.Type == "done" {
 			break
+		}
+
+		cbm, err := extractMessage[CallbackMessage](msg)
+		if err != nil {
+			py.log.Error("callback", zap.Error(err))
+			return sdktypes.InvalidValue, err
 		}
 
 		// Generate activity, it'll call Python with the result
 		// The function name is irrelevant, all the information Python needs is in the Payload
-		fn, err := sdktypes.NewFunctionValue(py.xid, msg.Func.Name, msg.Payload, nil, pyModuleFunc)
+		fn, err := sdktypes.NewFunctionValue(py.xid, cbm.Name, cbm.Data, nil, pyModuleFunc)
 		if err != nil {
 			py.log.Error("create function", zap.Error(err))
 			return sdktypes.InvalidValue, err
 		}
 
-		py.log.Info("callback", zap.String("func", msg.Func.Name))
+		py.log.Info("callback", zap.String("func", cbm.Name))
 		_, err = py.cbs.Call(
 			ctx,
 			py.xid.ToRunID(),
 			// The Python function to call is encoded in the payload
 			fn,
-			kittehs.Transform(msg.Func.Args, sdktypes.NewStringValue),
-			kittehs.TransformMap(msg.Func.Kw, func(key, val string) (string, sdktypes.Value) {
+			kittehs.Transform(cbm.Args, sdktypes.NewStringValue),
+			kittehs.TransformMap(cbm.Kw, func(key, val string) (string, sdktypes.Value) {
 				return key, sdktypes.NewStringValue(val)
 			}),
 		)
@@ -355,38 +338,38 @@ func (py *pySvc) Call(ctx context.Context, v sdktypes.Value, args []sdktypes.Val
 		event[k] = gv
 	}
 
-	payload, err := json.Marshal(event)
-	if err != nil {
-		py.log.Error("can't marshal kwargs", zap.Error(err))
-		return sdktypes.InvalidValue, err
-	}
-
 	fnName := fn.Name().String()
 	py.log.Info("call", zap.String("function", fnName))
 	if py.firstCall { // TODO: mutex. Ask Itay
 		py.firstCall = false
 
-		return py.initialCall(ctx, fnName, payload)
+		return py.initialCall(ctx, fnName, event)
 	}
 
 	// Activity call
-	msg := PyMessage{
-		Type:    callbackType,
-		Payload: fn.Data(),
+	cbm := CallbackMessage{
+		Name: fnName,
+		Data: fn.Data(),
 	}
-	py.log.Info("callback to Python", zap.Any("message", msg))
+	py.log.Info("callback to Python", zap.Any("message", cbm))
 
-	if err := py.enc.Encode(msg); err != nil {
+	if err := py.comm.Send(cbm); err != nil {
 		py.log.Error("send to python", zap.Error(err))
 		return sdktypes.InvalidValue, err
 	}
 
-	var reply PyMessage
-	if err := py.dec.Decode(&reply); err != nil {
+	msg, err := py.comm.Recv()
+	if err != nil {
 		py.log.Error("from python", zap.Error(err))
 		return sdktypes.InvalidValue, err
 	}
-	py.log.Info("python return", zap.Any("message", reply))
 
-	return sdktypes.NewBytesValue(reply.Payload), nil
+	rm, err := extractMessage[ResponseMessage](msg)
+	if err != nil {
+		py.log.Error("from python", zap.Error(err))
+		return sdktypes.InvalidValue, err
+	}
+	py.log.Info("python return", zap.Any("message", rm))
+
+	return sdktypes.NewBytesValue(rm.Value), nil
 }


### PR DESCRIPTION
This remove the old thread with message queue in Python that was there due to how the gRPC protocol worked.
It also creates a more "format" communication protocol between Python & Go. In the future this protocol between Go runtime and a language server can be used to create new runtime only by implementing the target language server.

Messages are now format `{"type": "run", "payload": ...}` so Go can use `json.RawMessage` and decode the underlying message type according to top level type (see `comm.go`).

Fixes ENG-516