### PR TITLE
ENG-670: make temporal worklow ids same as the object they're about

### DIFF
--- a/internal/backend/dispatcher/dispatcher.go
+++ b/internal/backend/dispatcher/dispatcher.go
@@ -100,7 +100,7 @@ func (d *dispatcher) Start(context.Context) error {
 
 func (d *dispatcher) startWorkflow(ctx context.Context, eventID sdktypes.EventID, opts *sdkservices.DispatchOptions) error {
 	options := client.StartWorkflowOptions{
-		ID:        fmt.Sprintf("%s_%s", workflowName, eventID.Value()),
+		ID:        eventID.String(),
 		TaskQueue: taskQueueName,
 	}
 	input := eventsWorkflowInput{

--- a/internal/backend/dispatcher/shared.go
+++ b/internal/backend/dispatcher/shared.go
@@ -5,10 +5,7 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-const (
-	workflowName  = "event"
-	taskQueueName = "events-task-queue"
-)
+const taskQueueName = "events-task-queue"
 
 // Events Workflow
 type eventsWorkflowInput struct {

--- a/internal/backend/sessions/sessionworkflows/workflows.go
+++ b/internal/backend/sessions/sessionworkflows/workflows.go
@@ -46,9 +46,7 @@ const (
 	sessionWorkflowName = "session_workflow"
 )
 
-func workflowID(sessionID sdktypes.SessionID) string {
-	return fmt.Sprintf("session_%s", sessionID.Value())
-}
+func workflowID(sessionID sdktypes.SessionID) string { return sessionID.String() }
 
 func New(z *zap.Logger, cfg Config, sessions sdkservices.Sessions, svcs *sessionsvcs.Svcs, calls sessioncalls.Calls) Workflows {
 	opts := cfg.Temporal.Worker


### PR DESCRIPTION
I think it makes it easier to correlate stuff