### PR TITLE
ENG-661: code location should not validate name

### DIFF
--- a/sdk/sdktypes/code_location.go
+++ b/sdk/sdktypes/code_location.go
@@ -22,13 +22,8 @@ type CodeLocationPB = programv1.CodeLocation
 
 type CodeLocationTraits struct{}
 
-func (CodeLocationTraits) Validate(m *CodeLocationPB) error {
-	return nameField("name", m.Name)
-}
-
-func (t CodeLocationTraits) StrictValidate(m *CodeLocationPB) error {
-	return nonzeroMessage(m)
-}
+func (CodeLocationTraits) Validate(m *CodeLocationPB) error         { return nil }
+func (t CodeLocationTraits) StrictValidate(m *CodeLocationPB) error { return nonzeroMessage(m) }
 
 func (l CodeLocation) Path() string { return l.read().Path }
 func (l CodeLocation) Col() uint32  { return l.read().Col }


### PR DESCRIPTION
name can be unknown, empty, or some random string. this sometimes prevents callstack and detailed error from appearing in log.