### PR TITLE
[ENG-678] Skip if python not installed 

### DIFF
--- a/runtimes/pythonrt/py_test.go
+++ b/runtimes/pythonrt/py_test.go
@@ -16,6 +16,13 @@ import (
 	"go.uber.org/zap"
 )
 
+func skipIfNoPython(t *testing.T) {
+	_, err := exec.LookPath("python")
+	if err != nil {
+		t.Skip("no python installed")
+	}
+}
+
 func Test_createVEnv(t *testing.T) {
 	if testing.Short() {
 		t.Skip("short mode")
@@ -23,7 +30,7 @@ func Test_createVEnv(t *testing.T) {
 
 	info, err := pyExecInfo(context.Background())
 	if errors.Is(errors.Unwrap(err), exec.ErrNotFound) {
-		t.Skipf("python not found")
+		t.Skip("python not found")
 	}
 	require.NoError(t, err)
 
@@ -36,6 +43,8 @@ func Test_createVEnv(t *testing.T) {
 var tarData []byte
 
 func Test_runPython(t *testing.T) {
+	skipIfNoPython(t)
+
 	log := zap.NewExample()
 	defer log.Sync() //nolint:all
 

--- a/runtimes/pythonrt/pythonrt_test.go
+++ b/runtimes/pythonrt/pythonrt_test.go
@@ -90,6 +90,8 @@ func testCtx(t *testing.T) (context.Context, context.CancelFunc) {
 }
 
 func Test_pySvc_Run(t *testing.T) {
+	skipIfNoPython(t)
+
 	rt, err := New()
 	require.NoError(t, err, "New")
 	svc, ok := rt.(*pySvc)


### PR DESCRIPTION
Skip tests that require Python if it's not installed.

Fixes ENG-678.