### PR TITLE
add compose-postgres.yaml to allow persistent / scale ak

### DIFF
--- a/compose-postgres.yaml
+++ b/compose-postgres.yaml
@@ -47,6 +47,7 @@ services:
       AK_TEMPORALCLIENT__HOSTPORT: "temporal:7233"
       AK_DB__TYPE: "postgres"
       AK_DB__DSN: "host=db dbname=postgres user=postgres password=postgres"
+      AK_STORE__SERVER_URL: "redis:6379"
     restart: unless-stopped
   temporal:
     build:
@@ -62,11 +63,22 @@ services:
       AK_TEMPORALCLIENT__HOSTPORT: "0.0.0.0:7233"
       AK_DB__TYPE: "postgres"
       AK_DB__DSN: "host=db dbname=postgres user=postgres password=postgres"
+      AK_STORE__SERVER_URL: "redis:6379"
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:9980"]
       interval: 1s
       timeout: 5s
       retries: 5
+  redis:
+    image: redis:7.2.4-alpine
+    restart: always
+    ports:
+      - '6379:6379'
+    command: redis-server --save 20 1 --loglevel warning
+    volumes: 
+      - redis:/data
 volumes:
   db:
+    driver: local
+  redis:
     driver: local

--- a/compose-postgres.yaml
+++ b/compose-postgres.yaml
@@ -1,0 +1,66 @@
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Docker compose reference guide at
+# https://docs.docker.com/compose/compose-file/
+
+# Here the instructions define your application as a service called "server".
+# This service is built from the Dockerfile in the current directory.
+# You can add other services your application may depend on here, such as a
+# database or a cache. For examples, see the Awesome Compose repository:
+# https://github.com/docker/awesome-compose
+services:
+  db:
+    image: postgres:16.1-alpine
+    restart: always
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+  nginx:
+    image: nginx:latest
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - server
+    ports:
+      - "9980:9980"
+  server:
+    build:
+      context: .
+      target: final
+    command: ["up"]
+    depends_on:
+      db:
+        condition: service_healthy
+      temporal:
+        condition: service_started
+    ports:
+      - 9980
+    environment:
+      AK_TEMPORALCLIENT__HOSTPORT: "temporal:7233"
+      AK_DB__TYPE: "postgres"
+      AK_DB__DSN: "host=db dbname=postgres user=postgres password=postgres"
+  temporal:
+    build:
+      context: .
+      target: final
+    command: ["up"]
+    ports:
+      - 7233
+    depends_on:
+      db: 
+        condition: service_healthy
+    environment:
+      AK_TEMPORALCLIENT__HOSTPORT: "0.0.0.0:7233"
+      AK_DB__TYPE: "postgres"
+      AK_DB__DSN: "host=db dbname=postgres user=postgres password=postgres"
+volumes:
+  db:
+    driver: local

--- a/compose-postgres.yaml
+++ b/compose-postgres.yaml
@@ -20,11 +20,11 @@ services:
       - db:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 5s
+      interval: 1s
       timeout: 5s
       retries: 5
   nginx:
-    image: nginx:latest
+    image: nginx:stable
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:
@@ -40,18 +40,19 @@ services:
       db:
         condition: service_healthy
       temporal:
-        condition: service_started
+        condition: service_healthy
     ports:
       - 9980
     environment:
       AK_TEMPORALCLIENT__HOSTPORT: "temporal:7233"
       AK_DB__TYPE: "postgres"
       AK_DB__DSN: "host=db dbname=postgres user=postgres password=postgres"
+    restart: unless-stopped
   temporal:
     build:
       context: .
       target: final
-    command: ["up"]
+    command: ["up", "--mode=dev"]
     ports:
       - 7233
     depends_on:
@@ -61,6 +62,11 @@ services:
       AK_TEMPORALCLIENT__HOSTPORT: "0.0.0.0:7233"
       AK_DB__TYPE: "postgres"
       AK_DB__DSN: "host=db dbname=postgres user=postgres password=postgres"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:9980"]
+      interval: 1s
+      timeout: 5s
+      retries: 5
 volumes:
   db:
     driver: local

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,13 @@
+user  nginx;
+
+events {
+    worker_connections   1000;
+}
+http {
+        server {
+              listen 9980;
+              location / {
+                proxy_pass http://server:9980;
+              }
+        }
+}


### PR DESCRIPTION
## Start AK with scaled version using compose

```bash
docker compose up --scale server=3 # can be any number
```

- This uses an nginx as a reverse proxy
- It uses AK as temporal dev server
- Uses postgres as a persistent db