### PR TITLE
Fix for sending form over HTTP without specifying content type

### DIFF
--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -214,7 +214,7 @@ func setBody(req *http.Request, rawBody string, formBody map[string]string, json
 
 		// Ignore (but allow the user to set) the charset in the Content-Type header.
 		switch strings.Split(contentType, ";")[0] {
-		case contentTypeForm:
+		case "", contentTypeForm:
 			s := form.Encode()
 			req.Body = io.NopCloser(strings.NewReader(s))
 			req.ContentLength = int64(len(s))


### PR DESCRIPTION
See lines 210-213 (not modified by this PR): if there's no custom content-type, we set the default one in the HTTP request we're preparing (`req.Header`), but not the helper variable (`contentType`). So in the switch block (which evaluates at least a part of the content-type value) we still need to consider that `contentType` may be `""`.