### PR TITLE
cli: allow to reset local config and data; separate data and config dirs

### DIFF
--- a/cmd/ak/cmd/configuration/configuration.go
+++ b/cmd/ak/cmd/configuration/configuration.go
@@ -21,6 +21,7 @@ func AddSubcommands(parentCmd *cobra.Command) {
 func init() {
 	// Subcommands.
 	configurationCmd.AddCommand(listCmd)
+	configurationCmd.AddCommand(resetCmd)
 	configurationCmd.AddCommand(setCmd)
 	configurationCmd.AddCommand(whereCmd)
 }

--- a/cmd/ak/cmd/configuration/reset.go
+++ b/cmd/ak/cmd/configuration/reset.go
@@ -1,0 +1,44 @@
+package configuration
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"go.autokitteh.dev/autokitteh/cmd/ak/common"
+	"go.autokitteh.dev/autokitteh/internal/xdg"
+)
+
+var resetData, resetCfg bool
+
+var resetCmd = common.StandardCommand(&cobra.Command{
+	Use:   "reset [--data] [--config]",
+	Short: "Reset persistent configuration",
+	Args:  cobra.NoArgs,
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, data := xdg.ConfigHomeDir(), xdg.DataHomeDir()
+
+		if cfg == data && (!resetData || !resetCfg) {
+			return errors.New("data and config dirs are the same, must specify both --data and --config")
+		}
+
+		if resetData {
+			return os.RemoveAll(filepath.Join(data, "*"))
+		}
+
+		if resetCfg {
+			return os.RemoveAll(filepath.Join(cfg, "*"))
+		}
+
+		return nil
+	},
+})
+
+func init() {
+	resetCmd.Flags().BoolVarP(&resetData, "data", "d", false, "reset data configuration")
+	resetCmd.Flags().BoolVarP(&resetCfg, "config", "c", false, "reset configuration")
+	resetCmd.MarkFlagsOneRequired("data", "config")
+}

--- a/cmd/ak/cmd/configuration/where.go
+++ b/cmd/ak/cmd/configuration/where.go
@@ -11,6 +11,36 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/xdg"
 )
 
+type config struct {
+	ConfigDir        string `json:"config_dir"`
+	DataDir          string `json:"data_dir"`
+	ConfigEnvVarName string `json:"config_env_var_name"`
+	DataEnvVarName   string `json:"data_env_var_name"`
+}
+
+func (c config) Text() string {
+	cfg := c.ConfigDir
+	if strings.Contains(cfg, " ") {
+		cfg = strconv.Quote(cfg)
+	}
+
+	data := c.DataDir
+	if strings.Contains(data, " ") {
+		data = strconv.Quote(data)
+	}
+
+	var out strings.Builder
+
+	fmt.Fprintln(&out, "Config home directory:", cfg)
+	fmt.Fprintln(&out, "Data home directory:  ", data)
+	fmt.Fprintln(&out, "")
+	fmt.Fprintln(&out, "Override environment variable names:")
+	fmt.Fprintln(&out, c.ConfigEnvVarName)
+	fmt.Fprintln(&out, c.DataEnvVarName)
+
+	return out.String()
+}
+
 var whereCmd = common.StandardCommand(&cobra.Command{
 	Use:     "where",
 	Short:   "Where are the config and data directories",
@@ -18,22 +48,14 @@ var whereCmd = common.StandardCommand(&cobra.Command{
 	Args:    cobra.NoArgs,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg := xdg.ConfigHomeDir()
-		if strings.Contains(cfg, " ") {
-			cfg = strconv.Quote(cfg)
+		c := config{
+			ConfigDir:        xdg.ConfigHomeDir(),
+			DataDir:          xdg.DataHomeDir(),
+			ConfigEnvVarName: xdg.ConfigEnvVar,
+			DataEnvVarName:   xdg.DataEnvVar,
 		}
 
-		data := xdg.DataHomeDir()
-		if strings.Contains(data, " ") {
-			data = strconv.Quote(data)
-		}
-
-		fmt.Fprintln(cmd.OutOrStdout(), "Config home directory:", cfg)
-		fmt.Fprintln(cmd.OutOrStdout(), "Data home directory:  ", data)
-		fmt.Fprintln(cmd.OutOrStdout(), "")
-		fmt.Fprintln(cmd.OutOrStdout(), "Override environment variable names:")
-		fmt.Fprintln(cmd.OutOrStdout(), xdg.ConfigEnvVar)
-		fmt.Fprintln(cmd.OutOrStdout(), xdg.DataEnvVar)
+		common.Render(c)
 
 		return nil
 	},


### PR DESCRIPTION
- if config and data dirs from XDG are the same, append `/config` and `/data` to them
- enable json output for `cfg where`
- add `cfg reset` command to clear config and/or data.

```
$ ./bin/ak cfg where                       
Config home directory: "/Users/itay/Library/Application Support/autokitteh/config"
Data home directory:   "/Users/itay/Library/Application Support/autokitteh/data"

Override environment variable names:
XDG_CONFIG_HOME
XDG_DATA_HOME

$ ./bin/ak cfg where -j                 
{"config_dir":"/Users/itay/Library/Application Support/autokitteh/config","data_dir":"/Users/itay/Library/Application Support/autokitteh/data","config_env_var_name":"XDG_CONFIG_HOME","data_env_var_name":"XDG_DATA_HOME"}

$ ./bin/ak cfg where -J                  
{
  "config_dir": "/Users/itay/Library/Application Support/autokitteh/config",
  "data_dir": "/Users/itay/Library/Application Support/autokitteh/data",
  "config_env_var_name": "XDG_CONFIG_HOME",
  "data_env_var_name": "XDG_DATA_HOME"
}
```