### PR TITLE
change HTTP integration API

### DIFF
--- a/examples/testprograms/http/http.star
+++ b/examples/testprograms/http/http.star
@@ -36,7 +36,7 @@ def on_http_post(data):
     sleep(1)
     n += 1000
 
-    print(catch(lambda: myhttp.post('http://localhost:9980/webtools/api/msgs/' + addr, body_type="raw", body="woof")))
+    print(catch(lambda: myhttp.post('http://localhost:9980/webtools/api/msgs/' + addr, data="woof")))
 
     print("zzzz2", n, time.now())
     sleep(2)
@@ -45,7 +45,7 @@ def on_http_post(data):
     print("zzzz3", n, time.now())
     sleep(3)
 
-    print(catch(lambda: myhttp.post('http://localhost:9980/webtools/api/msgs/' + addr, body_type="raw", body="meow")))
+    print(catch(lambda: myhttp.post('http://localhost:9980/webtools/api/msgs/' + addr, data="meow")))
 
 def on_http_test(data, event, trigger):
     print(data)

--- a/examples/testprograms/http/http.star
+++ b/examples/testprograms/http/http.star
@@ -36,7 +36,7 @@ def on_http_post(data):
     sleep(1)
     n += 1000
 
-    print(catch(lambda: myhttp.post('http://localhost:9980/webtools/api/msgs/' + addr, raw_body="woof")))
+    print(catch(lambda: myhttp.post('http://localhost:9980/webtools/api/msgs/' + addr, body_type="raw", body="woof")))
 
     print("zzzz2", n, time.now())
     sleep(2)
@@ -45,7 +45,7 @@ def on_http_post(data):
     print("zzzz3", n, time.now())
     sleep(3)
 
-    print(catch(lambda: myhttp.post('http://localhost:9980/webtools/api/msgs/' + addr, raw_body="meow")))
+    print(catch(lambda: myhttp.post('http://localhost:9980/webtools/api/msgs/' + addr, body_type="raw", body="meow")))
 
 def on_http_test(data, event, trigger):
     print(data)

--- a/integrations/http/client.go
+++ b/integrations/http/client.go
@@ -31,6 +31,11 @@ func New(sec sdkservices.Secrets) sdkservices.Integration {
 		sdkmodule.WithConfigAsData(),
 
 		sdkmodule.ExportFunction(
+			"delete",
+			i.request(http.MethodDelete),
+			sdkmodule.WithFuncDoc("https://www.rfc-editor.org/rfc/rfc9110#DELETE"),
+			args),
+		sdkmodule.ExportFunction(
 			"get",
 			i.request(http.MethodGet),
 			sdkmodule.WithFuncDoc("https://www.rfc-editor.org/rfc/rfc9110#GET"),
@@ -41,20 +46,6 @@ func New(sec sdkservices.Secrets) sdkservices.Integration {
 			sdkmodule.WithFuncDoc("https://www.rfc-editor.org/rfc/rfc9110#HEAD"),
 			args),
 		sdkmodule.ExportFunction(
-			"post",
-			i.request(http.MethodPost),
-			sdkmodule.WithFuncDoc("https://www.rfc-editor.org/rfc/rfc9110#POST"),
-			args),
-		sdkmodule.ExportFunction("put",
-			i.request(http.MethodPut),
-			sdkmodule.WithFuncDoc("https://www.rfc-editor.org/rfc/rfc9110#PUT"),
-			args),
-		sdkmodule.ExportFunction(
-			"delete",
-			i.request(http.MethodDelete),
-			sdkmodule.WithFuncDoc("https://www.rfc-editor.org/rfc/rfc9110#DELETE"),
-			args),
-		sdkmodule.ExportFunction(
 			"options",
 			i.request(http.MethodOptions),
 			sdkmodule.WithFuncDoc("https://www.rfc-editor.org/rfc/rfc9110#OPTIONS"),
@@ -63,6 +54,16 @@ func New(sec sdkservices.Secrets) sdkservices.Integration {
 			"patch",
 			i.request(http.MethodPatch),
 			sdkmodule.WithFuncDoc("https://www.rfc-editor.org/rfc/rfc5789"),
+			args),
+		sdkmodule.ExportFunction(
+			"post",
+			i.request(http.MethodPost),
+			sdkmodule.WithFuncDoc("https://www.rfc-editor.org/rfc/rfc9110#POST"),
+			args),
+		sdkmodule.ExportFunction(
+			"put",
+			i.request(http.MethodPut),
+			sdkmodule.WithFuncDoc("https://www.rfc-editor.org/rfc/rfc9110#PUT"),
 			args),
 	))
 }

--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -68,19 +68,16 @@ func (i integration) request(method string) sdkexecutor.Function {
 
 		// GET request doesn't have user-defined body
 		if method != http.MethodGet && body.IsValid() {
-			if bodyType == "" {
-				bodyType = "missing"
-			}
 
 			var err error
 			bodyType = strings.ToLower(bodyType)
 			switch bodyType {
-			case bodyTypeForm:
-				err = body.UnwrapInto(&formBody)
+			case "", bodyTypeRaw:
+				err = body.UnwrapInto(&rawBody)
 			case bodyTypeJSON:
 				jsonBody = body
-			case bodyTypeRaw:
-				err = body.UnwrapInto(&rawBody)
+			case bodyTypeForm:
+				err = body.UnwrapInto(&formBody)
 			default:
 				err = errors.New("body_type must be one of <form|json|raw>")
 			}
@@ -184,7 +181,7 @@ func (i integration) getConnection(ctx context.Context) map[string]string {
 
 func setBody(req *http.Request, bodyType string, rawBody string, formBody map[string]string, jsonBody sdktypes.Value) error {
 	switch bodyType {
-	case bodyTypeRaw:
+	case "", bodyTypeRaw:
 		if rawBody == "" {
 			return nil
 		}

--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -58,6 +58,8 @@ func (i integration) request(method string) sdkexecutor.Function {
 			"form_body?", &formBody,
 			"json_body?", &jsonBody,
 		)
+		// NOTE: for HTTP.GET {raw,form,json}_body will be ignored
+
 		if err != nil {
 			return sdktypes.InvalidValue, err
 		}

--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -35,9 +35,8 @@ var args = sdkmodule.WithArgs(
 	"url",
 	"params?",
 	"headers?",
-	"raw_body?",
-	"form_body?",
-	"json_body?",
+	"body_type?",
+	"body?",
 )
 
 // request is a factory function for generating autokitteh

--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -36,6 +36,7 @@ var args = sdkmodule.WithArgs(
 	"params?",
 	"headers?",
 	"data?",
+	"json?",
 )
 
 const (

--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -194,7 +194,6 @@ func setBody(req *http.Request, bodyType string, rawBody string, formBody map[st
 		// (see ShouldSendChunkedRequestBody() in the library mentioned above).
 		req.ContentLength = int64(len(rawBody))
 
-		// Set the Content-Type header only if it's not already set.
 		if req.Header.Get(contentTypeHeader) == "" {
 			req.Header.Set(contentTypeHeader, "text/plain") // or "application/octet-stream"
 		}
@@ -204,7 +203,7 @@ func setBody(req *http.Request, bodyType string, rawBody string, formBody map[st
 		if !jsonBody.IsValid() || jsonBody.IsNothing() {
 			return nil
 		}
-		// Set the Content-Type header only if it's not already set.
+
 		if req.Header.Get(contentTypeHeader) == "" {
 			req.Header.Set(contentTypeHeader, contentTypeJSON)
 		}
@@ -232,7 +231,6 @@ func setBody(req *http.Request, bodyType string, rawBody string, formBody map[st
 			form.Add(k, v)
 		}
 
-		// Set the Content-Type header only if it's not already set.
 		contentType := req.Header.Get(contentTypeHeader)
 		if contentType == "" {
 			req.Header.Set(contentTypeHeader, contentTypeForm)

--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -54,7 +54,7 @@ type request struct {
 }
 
 // parses provided body and updates headers accordingly
-func parseBody(req request, body sdktypes.Value) (err error) {
+func parseBody(req *request, body sdktypes.Value) (err error) {
 	var (
 		rawBody, contentType string
 		formBody             map[string]string
@@ -285,7 +285,7 @@ func (i integration) request(method string) sdkexecutor.Function {
 		// NOTE: GET request shouldn't have user-defined body.
 		// Python's requests lib will ignore body on GET as well
 		if method != http.MethodGet && body.IsValid() {
-			if err = parseBody(req, body); err != nil {
+			if err = parseBody(&req, body); err != nil {
 				return sdktypes.InvalidValue, err
 			}
 		}

--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -56,19 +56,22 @@ func (i integration) request(method string) sdkexecutor.Function {
 			jsonBody, body            sdktypes.Value
 		)
 
+		if len(args) > 1 {
+			return sdktypes.InvalidValue, errors.New("pass non-URL arguments as kwargs only")
+		}
+
 		if err := sdkmodule.UnpackArgs(args, kwargs,
 			"url", &rawURL,
 			"params?", &params,
 			"headers?", &headers,
-			"body_type?", &bodyType,
 			"body?", &body,
+			"body_type?", &bodyType,
 		); err != nil {
 			return sdktypes.InvalidValue, err
 		}
 
 		// GET request doesn't have user-defined body
 		if method != http.MethodGet && body.IsValid() {
-
 			var err error
 			bodyType = strings.ToLower(bodyType)
 			switch bodyType {

--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -35,8 +35,7 @@ var args = sdkmodule.WithArgs(
 	"url",
 	"params?",
 	"headers?",
-	"body_type?",
-	"body?",
+	"data?",
 )
 
 const (
@@ -260,7 +259,7 @@ func (i integration) request(method string) sdkexecutor.Function {
 	return func(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
 		// Parse the input arguments.
 		var (
-			body sdktypes.Value
+			data sdktypes.Value
 			err  error
 			req  request
 		)
@@ -273,7 +272,7 @@ func (i integration) request(method string) sdkexecutor.Function {
 			"url", &req.url,
 			"params=?", &req.params,
 			"headers=?", &req.headers,
-			"body=?", &body,
+			"data=?", &data,
 		); err != nil {
 			return sdktypes.InvalidValue, err
 		}
@@ -284,8 +283,8 @@ func (i integration) request(method string) sdkexecutor.Function {
 
 		// NOTE: GET request shouldn't have user-defined body.
 		// Python's requests lib will ignore body on GET as well
-		if method != http.MethodGet && body.IsValid() {
-			if err = parseBody(&req, body); err != nil {
+		if method != http.MethodGet && data.IsValid() {
+			if err = parseBody(&req, data); err != nil {
 				return sdktypes.InvalidValue, err
 			}
 		}

--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -56,11 +56,6 @@ func (i integration) request(method string) sdkexecutor.Function {
 			jsonBody, body            sdktypes.Value
 		)
 
-		// if body, found := kwargs["body"]; found {
-		// 	delete(kwargs, "body")
-		// } else if len(args) > 4 {
-		// 	body = args[5]
-
 		if err := sdkmodule.UnpackArgs(args, kwargs,
 			"url", &rawURL,
 			"params?", &params,

--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -326,7 +326,6 @@ func toStruct(r *http.Response) (sdktypes.Value, error) {
 func bodyToStruct(body []byte, form url.Values) sdktypes.Value {
 	var (
 		v        any
-		formBody sdktypes.Value = sdktypes.Nothing
 		jsonBody sdktypes.Value
 	)
 
@@ -343,20 +342,27 @@ func bodyToStruct(body []byte, form url.Values) sdktypes.Value {
 
 	// Right now, form is always nil. We need to handle this case.
 	if form != nil {
-		formBody = kittehs.Must1(sdktypes.NewConstFunctionValue("form", sdktypes.NewDictValueFromStringMap(
+		formBody := kittehs.Must1(sdktypes.NewConstFunctionValue("form", sdktypes.NewDictValueFromStringMap(
 			kittehs.TransformMapValues(form, func(vs []string) sdktypes.Value {
 				return sdktypes.NewStringValue(strings.Join(vs, ","))
 			}),
 		)))
+		return kittehs.Must1(sdktypes.NewStructValue(
+			sdktypes.NewStringValue("body"),
+			map[string]sdktypes.Value{
+				"text":  kittehs.Must1(sdktypes.NewConstFunctionValue("text", sdktypes.NewStringValue(string(body)))),
+				"bytes": kittehs.Must1(sdktypes.NewConstFunctionValue("bytes", sdktypes.NewBytesValue(body))),
+				"json":  jsonBody,
+				"form":  formBody,
+			},
+		))
 	}
-
 	return kittehs.Must1(sdktypes.NewStructValue(
 		sdktypes.NewStringValue("body"),
 		map[string]sdktypes.Value{
 			"text":  kittehs.Must1(sdktypes.NewConstFunctionValue("text", sdktypes.NewStringValue(string(body)))),
 			"bytes": kittehs.Must1(sdktypes.NewConstFunctionValue("bytes", sdktypes.NewBytesValue(body))),
 			"json":  jsonBody,
-			"form":  formBody,
 		},
 	))
 }

--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -56,15 +56,15 @@ func (i integration) request(method string) sdkexecutor.Function {
 			jsonBody, body            sdktypes.Value
 		)
 
-		if len(args) > 1 {
+		if len(args) > 1 { // just to have a better error message
 			return sdktypes.InvalidValue, errors.New("pass non-URL arguments as kwargs only")
 		}
 
 		if err := sdkmodule.UnpackArgs(args, kwargs,
 			"url", &rawURL,
-			"params?", &params,
-			"headers?", &headers,
-			"body?", &body,
+			"params=?", &params,
+			"headers=?", &headers,
+			"body=?", &body,
 		); err != nil {
 			return sdktypes.InvalidValue, err
 		}

--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -39,6 +39,12 @@ var args = sdkmodule.WithArgs(
 	"body?",
 )
 
+const (
+	bodyTypeRaw  = "raw"
+	bodyTypeJSON = "json"
+	bodyTypeForm = "form"
+)
+
 // request is a factory function for generating autokitteh
 // functions for different HTTP request methods.
 func (i integration) request(method string) sdkexecutor.Function {
@@ -74,11 +80,11 @@ func (i integration) request(method string) sdkexecutor.Function {
 			var err error
 			bodyType = strings.ToLower(bodyType)
 			switch bodyType {
-			case "form":
+			case bodyTypeForm:
 				err = body.UnwrapInto(&formBody)
-			case "json":
+			case bodyTypeJSON:
 				jsonBody = body
-			case "raw":
+			case bodyTypeRaw:
 				err = body.UnwrapInto(&rawBody)
 			default:
 				err = errors.New("body_type must be one of <form|json|raw>")
@@ -183,7 +189,7 @@ func (i integration) getConnection(ctx context.Context) map[string]string {
 
 func setBody(req *http.Request, bodyType string, rawBody string, formBody map[string]string, jsonBody sdktypes.Value) error {
 	switch bodyType {
-	case "raw":
+	case bodyTypeRaw:
 		if rawBody == "" {
 			return nil
 		}
@@ -202,7 +208,7 @@ func setBody(req *http.Request, bodyType string, rawBody string, formBody map[st
 		}
 		return nil
 
-	case "json":
+	case bodyTypeJSON:
 		if !jsonBody.IsValid() || jsonBody.IsNothing() {
 			return nil
 		}
@@ -225,7 +231,7 @@ func setBody(req *http.Request, bodyType string, rawBody string, formBody map[st
 		req.ContentLength = int64(len(data))
 		return nil
 
-	case "form":
+	case bodyTypeForm:
 		if formBody == nil {
 			return nil
 		}

--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -118,7 +118,7 @@ func parseBody(req *request, body sdktypes.Value) (err error) {
 		if err = body.UnwrapInto(&formBody); err == nil {
 			req.bodyType = bodyTypeForm
 			if contentType == "" {
-				req.headers[contentTypeHeader] = contentTypeJSON
+				req.headers[contentTypeHeader] = contentTypeForm
 			}
 		}
 	}
@@ -126,7 +126,7 @@ func parseBody(req *request, body sdktypes.Value) (err error) {
 		if err = body.UnwrapInto(&jsonBody); err == nil {
 			req.bodyType = bodyTypeJSON
 			if contentType == "" {
-				req.headers[contentTypeHeader] = contentTypeForm
+				req.headers[contentTypeHeader] = contentTypeJSON
 			}
 		}
 	}

--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -185,7 +185,7 @@ func (i integration) getConnection(ctx context.Context) map[string]string {
 func setBody(req *http.Request, rawBody string, formBody map[string]string, jsonBody sdktypes.Value) error {
 	errMutuallyExclusive := errors.New("raw_body, form_body, and json_body are mutually exclusive")
 
-	// Raw body with unknown content type.
+	// Raw body
 	if rawBody != "" {
 		if formBody != nil || (jsonBody.IsValid() && !jsonBody.IsNothing()) {
 			return errMutuallyExclusive
@@ -198,6 +198,12 @@ func setBody(req *http.Request, rawBody string, formBody map[string]string, json
 		// This is required when using ioutil.NopCloser method for the request body
 		// (see ShouldSendChunkedRequestBody() in the library mentioned above).
 		req.ContentLength = int64(len(rawBody))
+
+		// Set the Content-Type header only if it's not already set.
+		if req.Header.Get(contentTypeHeader) == "" {
+			req.Header.Set(contentTypeHeader, "text/plain") // or "application/octet-stream"
+		}
+
 		return nil
 	}
 

--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -65,7 +65,7 @@ func unpackAndParseArgs(req *request, method string, args []sdktypes.Value, kwar
 		"params=?", &req.params,
 		"headers=?", &req.headers,
 		"json=?", &data, // alias for data
-		"data=?", &data, // will override json, if both are provided
+		"data=?", &data, // will override json, if both json and data are provided
 	); err != nil {
 		return err
 	}
@@ -76,6 +76,14 @@ func unpackAndParseArgs(req *request, method string, args []sdktypes.Value, kwar
 	// NOTE: GET request shouldn't have user-defined body.
 	// Python's requests lib will ignore body on GET as well
 	if method != http.MethodGet && data.IsValid() {
+
+		// if data passed as JSON and data is not passed, then request to parse as JSON content
+		if _, isJson := kwargs["json"]; isJson {
+			if _, isData := kwargs["data"]; !isData {
+				req.headers[contentTypeHeader] = contentTypeJSON
+			}
+		}
+
 		if err = parseBody(req, data); err != nil {
 			return err
 		}

--- a/integrations/http/http_test.go
+++ b/integrations/http/http_test.go
@@ -198,7 +198,7 @@ func TestUnpackAndParseArgs(t *testing.T) {
 			method: "POST",
 			args:   []interface{}{"http://dummy.url"},
 			kwargs: map[string]interface{}{"json": "woof"},
-			body:   "woof",
+			body:   `"woof"`,
 		},
 		{
 			name:   "passing json + body #1. json ignored",

--- a/integrations/http/http_test.go
+++ b/integrations/http/http_test.go
@@ -103,19 +103,19 @@ func TestParseBody(t *testing.T) {
 	}{
 		{
 			name:     "empty body",
-			body:     sdktypes.NewStringValue(""),
+			body:     "",
 			bodyType: bodyTypeRaw,
 			reqBody:  "",
 		},
 		{
 			name:     "string",
-			body:     sdktypes.NewStringValue("meow"),
+			body:     "meow",
 			bodyType: bodyTypeRaw,
 			reqBody:  "meow",
 		},
 		{
 			name:     "json as string => raw",
-			body:     sdktypes.NewStringValue(`{"k":"v"}`),
+			body:     `{"k":"v"}`,
 			bodyType: bodyTypeRaw,
 			reqBody:  `{"k":"v"}`,
 		},


### PR DESCRIPTION
- removed `json_body`, `raw_body` and `form_body` params
- replaced by single `body` param which will be autoparsed to the relevant type (type match and/or headers)
- added tests
- disallow passing args, except url. All other params should be passed as kwargs
- remove form() from response body