### PR TITLE
ak session: show error with prints

### DIFF
--- a/sdk/sdktypes/session_log_record.go
+++ b/sdk/sdktypes/session_log_record.go
@@ -51,6 +51,10 @@ func (s SessionLogRecord) GetPrint() (string, bool) {
 	return "", false
 }
 
+func (s SessionLogRecord) GetState() SessionState {
+	return forceFromProto[SessionState](s.read().State)
+}
+
 func (s SessionLogRecord) GetStopRequest() (string, bool) {
 	if m := s.read(); m.StopRequest != nil {
 		return m.StopRequest.Reason, true

--- a/sdk/sdktypes/session_state_error.go
+++ b/sdk/sdktypes/session_state_error.go
@@ -40,6 +40,10 @@ func (s SessionState) GetError() SessionStateError {
 	return forceFromProto[SessionStateError](s.m.Error)
 }
 
+func (se SessionStateError) GetProgramError() ProgramError {
+	return forceFromProto[ProgramError](se.read().Error)
+}
+
 func NewSessionStateError(err error, prints []string) SessionState {
 	return forceFromProto[SessionState](&SessionStatePB{
 		Error: &SessionStateErrorPB{


### PR DESCRIPTION
show final error if exists in `ak session log --prints-only`