### PR TITLE
ENG-573: fix & re-enable "built-in funcs" system test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,11 +110,9 @@ test-dbgorm:
 	go test -v ./internal/backend/db/dbgorm -dbtype $$dbtype ; \
 	done
 
-# TODO(ENG-427): Fix E2E test's data race.
-# TODO(ENG-447): Fix HTTP trigger flakiness.
 .PHONY: test-unit
 test-unit:
-	$(GOTEST) ./... -skip /end2end/builtin_funcs
+	$(GOTEST) ./...
 
 # Subset of "test-unit", for simplicity.
 .PHONY: test-system
@@ -134,11 +132,9 @@ test-cover:
 	$(GOTEST) -covermode=atomic -coverprofile=tmp/cover.out ./...
 	go tool cover -html=tmp/cover.out
 
-# TODO(ENG-427): Fix E2E test's data race.
-# TODO(ENG-447): Fix HTTP trigger flakiness.
 .PHONY: test-race
 test-race:
-	$(GOTEST) -race ./... -skip /end2end/builtin_funcs
+	$(GOTEST) -race ./...
 
 .PHONY: test-cli
 # We don't want test-cli to explicitly depend on bin since

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ test-dbgorm:
 # TODO(ENG-447): Fix HTTP trigger flakiness.
 .PHONY: test-unit
 test-unit:
-	$(GOTEST) ./... -skip /workflows/builtin_funcs
+	$(GOTEST) ./... -skip /end2end/builtin_funcs
 
 # Subset of "test-unit", for simplicity.
 .PHONY: test-system
@@ -138,7 +138,7 @@ test-cover:
 # TODO(ENG-447): Fix HTTP trigger flakiness.
 .PHONY: test-race
 test-race:
-	$(GOTEST) -race ./... -skip /workflows/builtin_funcs
+	$(GOTEST) -race ./... -skip /end2end/builtin_funcs
 
 .PHONY: test-cli
 # We don't want test-cli to explicitly depend on bin since

--- a/tests/system/testdata/end2end/builtin_funcs.txtar
+++ b/tests/system/testdata/end2end/builtin_funcs.txtar
@@ -1,36 +1,27 @@
-# Apply, build, and deploy project with program that
-# runs all built-in AK functions, and HTTP connection.
-ak manifest apply project.yaml
-return code == 0
-
-ak project build my_project --file my_program.star
-return code == 0
-output equals 'build_id: bld_00000000000000000000000005'
-
-ak deployment create --build-id=bld_00000000000000000000000005 --env=my_project/default --activate
+# Deploy project with HTTP trigger that runs all custom built-in functions.
+ak deploy --manifest project.yaml
 return code == 0
 
 # Send HTTP GET request to trigger deployment to start new session.
-http get /http/my_url_path
+http get /http/my_project/my_url_path
 resp code == 200
 
 wait 5s for session ses_00000000000000000000000008
 
 # Check session's output and final state.
-ak session log -J
+ak session log --prints-only
 return code == 0
-output contains '"text": "1st random int with seed: 5"'
-output contains '"text": "2nd random int with seed: 2"'
-output contains '"text": "3rd random int with seed: 1"'
-output contains '"text": "Store set = OK"'
-output contains '"text": "Store get = value"'
-output contains '"Store del = 1"'
-output regex '"text": "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{1,9} \+0000 UTC"'
-output contains '"text": "done"'
+output contains '1st random int with seed: 5'
+output contains '2nd random int with seed: 2'
+output contains '3rd random int with seed: 1'
+output contains 'Store set = OK'
+output contains 'Store get = value'
+output contains 'Store del = 1'
+output regex ' \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{1,9} \+0000 UTC'
+output contains 'done'
 
-ak sessions list
+ak session list
 return code == 0
-output contains 'session_id:"ses_00000000000000000000000008"'
 output contains 'state:SESSION_STATE_TYPE_COMPLETED'
 
 -- project.yaml --
@@ -41,13 +32,15 @@ project:
   connections:
     - name: my_connection
       integration: http
-      token: my_url_path
   triggers:
-    - connection: my_connection
+    - name: http_get
+      connection: my_connection
       event_type: get
-      entrypoint: my_program.star:on_http_get
+      data:
+        path: my_url_path
+      call: program.star:on_http_get
 
--- my_program.star --
+-- program.star --
 def on_http_get(data):
     # runtimes/starlarkrt/internal/libs/rand/rand.go
     rand.seed(0x533d)

--- a/tests/system/testdata/end2end/http.txtar
+++ b/tests/system/testdata/end2end/http.txtar
@@ -1,64 +1,60 @@
-ak manifest apply project.yaml
+# Deploy project with HTTP triggers that check session data.
+ak deploy --manifest project.yaml
 return code == 0
 
-ak project build myproject --file main.star
-return code == 0
-output equals 'build_id: bld_00000000000000000000000006'
-
-ak deployment create --build-id=bld_00000000000000000000000006 --env=myproject/default --activate
-return code == 0
-
-http get /http/myproject/meow
+# Send HTTP GET request to trigger deployment to start new session.
+http get /http/my_project/
 resp code == 200
 
-wait 10s for session ses_00000000000000000000000009
+wait 5s for session ses_00000000000000000000000009
 
 ak session log --no-timestamps --skip -1 -J
 return code == 0
-output equals_json file get_meow.json
+output equals_json file expected_without_path.json
 
-http post /http/myproject/test/aaa/bbb/ccc
+# Send HTTP POST request to trigger deployment to start new session.
+http post /http/my_project/test/aaa/bbb/ccc
 resp code == 200
 
-wait 10s for session ses_0000000000000000000000000c
+wait 5s for session ses_0000000000000000000000000c
 
 ak session log --no-timestamps --skip -1 -J
 return code == 0
-output equals_json file get_test.json
+output equals_json file expected_with_path.json
 
 -- project.yaml --
 version: v1
 
 project:
-  name: myproject
+  name: my_project
   connections:
-    - name: myhttp
+    - name: my_connection
       integration: http
   triggers:
-    - name: get
-      connection: myhttp
+    - name: http_get_without_path
+      connection: my_connection
       event_type: get
-      entrypoint: main.star:on_http
-    - name: test
-      connection: myhttp
-      entrypoint: main.star:on_http
+      call: program.star:on_http
+    - name: http_get_with_path
+      connection: my_connection
       data:
         path: "/test/{a}/{b...}"
+      call: program.star:on_http
 
--- main.star --
+-- program.star --
 def on_http(data, trigger, event):
     print(data)
     print(event)
     print(trigger)
 
--- get_meow.json --
+-- expected_without_path.json --
 {
     "state": {
         "completed": {
             "prints": [
-                "data(body = body(bytes = \u003cbuilt-in function .bytes\u003e, form = \u003cbuilt-in function .form\u003e, json = \u003cbuilt-in function .json\u003e, text = \u003cbuilt-in function .text\u003e), headers = {\"Accept-Encoding\": \"gzip\", \"User-Agent\": \"Go-http-client/1.1\"}, method = \"GET\", url = url(fragment = \"\", host = \"\", opaque = \"\", path = \"/meow\", query = {}, raw = \"\", raw_fragment = \"\", raw_query = \"\", scheme = \"\"))",
-                "event(data = event_data(body = body(bytes = \u003cbuilt-in function .bytes\u003e, form = \u003cbuilt-in function .form\u003e, json = \u003cbuilt-in function .json\u003e, text = \u003cbuilt-in function .text\u003e), headers = {\"Accept-Encoding\": \"gzip\", \"User-Agent\": \"Go-http-client/1.1\"}, method = \"GET\", url = url(fragment = \"\", host = \"\", opaque = \"\", path = \"/meow\", query = {}, raw = \"\", raw_fragment = \"\", raw_query = \"\", scheme = \"\")), id = \"evt_00000000000000000000000008\", integration_id = \"int_3kth00httpf1201a7ed83f7cd5\", type = \"get\")",
-                "trigger(data = event_data(), name = \"get\")"
+                "data(body = body(bytes = \u003cbuilt-in function .bytes\u003e, form = \u003cbuilt-in function .form\u003e, json = \u003cbuilt-in function .json\u003e, text = \u003cbuilt-in function .text\u003e), headers = {\"Accept-Encoding\": \"gzip\", \"User-Agent\": \"Go-http-client/1.1\"}, method = \"GET\", url = url(fragment = \"\", host = \"\", opaque = \"\", path = \"/\", query = {}, raw = \"\", raw_fragment = \"\", raw_query = \"\", scheme = \"\"))",
+                "event(data = event_data(body = body(bytes = \u003cbuilt-in function .bytes\u003e, form = \u003cbuilt-in function .form\u003e, json = \u003cbuilt-in function .json\u003e, text = \u003cbuilt-in function .text\u003e), headers = {\"Accept-Encoding\": \"gzip\", \"User-Agent\": \"Go-http-client/1.1\"}, method = \"GET\", url = url(fragment = \"\", host = \"\", opaque = \"\", path = \"/\", query = {}, raw = \"\", raw_fragment = \"\", raw_query = \"\", scheme = \"\")), id = \"evt_00000000000000000000000008\", integration_id = \"int_3kth00httpf1201a7ed83f7cd5\", type = \"get\")",
+                "trigger(data = event_data(), name = \"http_get_without_path\")"
             ],
             "exports": {
                 "on_http": {
@@ -89,14 +85,14 @@ def on_http(data, trigger, event):
     }
 }
 
--- get_test.json --
+-- expected_with_path.json --
 {
     "state": {
         "completed": {
             "prints": [
                 "data(body = body(bytes = \u003cbuilt-in function .bytes\u003e, form = \u003cbuilt-in function .form\u003e, json = \u003cbuilt-in function .json\u003e, text = \u003cbuilt-in function .text\u003e), headers = {\"Accept-Encoding\": \"gzip\", \"User-Agent\": \"Go-http-client/1.1\", \"Content-Length\": \"0\"}, method = \"POST\", params = {\"a\": \"aaa\", \"b\": \"bbb/ccc\"}, path = \"/test/{a}/{b...}\", url = url(fragment = \"\", host = \"\", opaque = \"\", path = \"/test/aaa/bbb/ccc\", query = {}, raw = \"\", raw_fragment = \"\", raw_query = \"\", scheme = \"\"))",
                 "event(data = event_data(body = body(bytes = \u003cbuilt-in function .bytes\u003e, form = \u003cbuilt-in function .form\u003e, json = \u003cbuilt-in function .json\u003e, text = \u003cbuilt-in function .text\u003e), headers = {\"Accept-Encoding\": \"gzip\", \"User-Agent\": \"Go-http-client/1.1\", \"Content-Length\": \"0\"}, method = \"POST\", url = url(fragment = \"\", host = \"\", opaque = \"\", path = \"/test/aaa/bbb/ccc\", query = {}, raw = \"\", raw_fragment = \"\", raw_query = \"\", scheme = \"\")), id = \"evt_0000000000000000000000000b\", integration_id = \"int_3kth00httpf1201a7ed83f7cd5\", type = \"post\")",
-                "trigger(data = data(params = {\"a\": \"aaa\", \"b\": \"bbb/ccc\"}, path = \"/test/{a}/{b...}\"), name = \"test\")"
+                "trigger(data = data(params = {\"a\": \"aaa\", \"b\": \"bbb/ccc\"}, path = \"/test/{a}/{b...}\"), name = \"http_get_with_path\")"
             ],
             "exports": {
                 "on_http": {


### PR DESCRIPTION
After some investigation and work related to flakiness, it looks like the biggest offender (which was disabled in CI runs) is no longer failing around 20%-30%.

So I fixed that test and re-enabled it, so see if that's indeed the case.

I also refactored the HTTP system test with similar updates, and moved them under a single `testdata` subdir for end-to-end tests.

Note that ENG-573 and ENG-520 are still kept open for continued investigation - see my latest 2 comments in ENG-573.
