### PR TITLE
db: removed unused var warnings

### DIFF
--- a/internal/backend/db/dbgorm/builds.go
+++ b/internal/backend/db/dbgorm/builds.go
@@ -29,7 +29,7 @@ func (db *gormdb) GetBuild(ctx context.Context, buildID sdktypes.BuildID) (sdkty
 }
 
 func (db *gormdb) deleteBuild(ctx context.Context, buildID sdktypes.UUID) error {
-	return delete(db.db, ctx, scheme.Build{}, "build_id = ?", buildID)
+	return delete[scheme.Build](db.db, ctx, "build_id = ?", buildID)
 }
 
 func (db *gormdb) DeleteBuild(ctx context.Context, buildID sdktypes.BuildID) error {

--- a/internal/backend/db/dbgorm/builds_test.go
+++ b/internal/backend/db/dbgorm/builds_test.go
@@ -23,7 +23,7 @@ func assertBuildDeleted(t *testing.T, f *dbFixture, buildID sdktypes.UUID) {
 
 func preBuildTest(t *testing.T) *dbFixture {
 	f := newDBFixture()
-	findAndAssertCount(t, f, scheme.Build{}, 0, "")
+	findAndAssertCount[scheme.Build](t, f, 0, "")
 	return f
 }
 

--- a/internal/backend/db/dbgorm/connections_test.go
+++ b/internal/backend/db/dbgorm/connections_test.go
@@ -25,7 +25,7 @@ func (f *dbFixture) assertConnectionDeleted(t *testing.T, connections ...scheme.
 
 func preConnectionTest(t *testing.T) *dbFixture {
 	f := newDBFixture()
-	findAndAssertCount(t, f, scheme.Connection{}, 0, "") // no connections
+	findAndAssertCount[scheme.Connection](t, f, 0, "") // no connections
 	return f
 }
 
@@ -47,7 +47,7 @@ func TestCreateConnectionForeignKeys(t *testing.T) {
 
 	// FIXME: ENG-571 - integration table
 	// c.IntegrationID = &unexisting
-	//assert.ErrorIs(t, f.gormdb.createConnection(f.ctx, &c), gorm.ErrForeignKeyViolated)
+	// assert.ErrorIs(t, f.gormdb.createConnection(f.ctx, &c), gorm.ErrForeignKeyViolated)
 	// c.IntegrationID = nil
 
 	c.ProjectID = scheme.UUIDOrNil(sdktypes.NewProjectID().UUIDValue())

--- a/internal/backend/db/dbgorm/dbgorm.go
+++ b/internal/backend/db/dbgorm/dbgorm.go
@@ -210,7 +210,7 @@ func getOneWTransform[T any, R sdktypes.Object](db *gorm.DB, ctx context.Context
 }
 
 // TODO: change all get functions to use this
-func getOne[T any](db *gorm.DB, ctx context.Context, t T, where string, args ...any) (*T, error) {
+func getOne[T any](db *gorm.DB, ctx context.Context, where string, args ...any) (*T, error) {
 	var r T
 
 	// TODO: fetch all records and report if there is more than one record
@@ -226,7 +226,7 @@ func getOne[T any](db *gorm.DB, ctx context.Context, t T, where string, args ...
 }
 
 // TODO: this not working for deployments. Consider delete this function
-func delete[T any](db *gorm.DB, ctx context.Context, t T, where string, args ...any) error {
+func delete[T any](db *gorm.DB, ctx context.Context, where string, args ...any) error {
 	var r T
 	result := db.WithContext(ctx).Where(where, args...).Delete(&r)
 	if result.Error != nil {

--- a/internal/backend/db/dbgorm/deployments.go
+++ b/internal/backend/db/dbgorm/deployments.go
@@ -35,7 +35,7 @@ func (db *gormdb) CreateDeployment(ctx context.Context, deployment sdktypes.Depl
 }
 
 func (db *gormdb) getDeployment(ctx context.Context, deploymentID sdktypes.UUID) (*scheme.Deployment, error) {
-	return getOne(db.db, ctx, scheme.Deployment{}, "deployment_id = ?", deploymentID)
+	return getOne[scheme.Deployment](db.db, ctx, "deployment_id = ?", deploymentID)
 }
 
 func (db *gormdb) GetDeployment(ctx context.Context, id sdktypes.DeploymentID) (sdktypes.Deployment, error) {

--- a/internal/backend/db/dbgorm/envs_test.go
+++ b/internal/backend/db/dbgorm/envs_test.go
@@ -25,7 +25,7 @@ func (f *dbFixture) assertEnvDeleted(t *testing.T, envs ...scheme.Env) {
 
 func preEnvTest(t *testing.T) *dbFixture {
 	f := newDBFixture()
-	findAndAssertCount(t, f, scheme.Env{}, 0, "") // no envs
+	findAndAssertCount[scheme.Env](t, f, 0, "") // no envs
 	return f
 }
 

--- a/internal/backend/db/dbgorm/events_record_test.go
+++ b/internal/backend/db/dbgorm/events_record_test.go
@@ -18,7 +18,7 @@ func (f *dbFixture) createEventRecordsAndAssert(t *testing.T, eventRecords ...sc
 
 func TestCreateEventRecordForeignKeys(t *testing.T) {
 	f := newDBFixture()
-	findAndAssertCount(t, f, scheme.EventRecord{}, 0, "") // no events
+	findAndAssertCount[scheme.EventRecord](t, f, 0, "") // no events
 
 	evt := f.newEvent()
 	er := f.newEventRecord()

--- a/internal/backend/db/dbgorm/events_test.go
+++ b/internal/backend/db/dbgorm/events_test.go
@@ -23,7 +23,7 @@ func (f *dbFixture) assertEventsDeleted(t *testing.T, events ...scheme.Event) {
 
 func TestCreateEvent(t *testing.T) {
 	f := newDBFixtureFK(false)
-	findAndAssertCount(t, f, scheme.Event{}, 0, "") // no events
+	findAndAssertCount[scheme.Event](t, f, 0, "") // no events
 
 	evt := f.newEvent()
 	// test createEvent
@@ -32,7 +32,7 @@ func TestCreateEvent(t *testing.T) {
 
 func TestCreateEventForeignKeys(t *testing.T) {
 	f := newDBFixtureFK(false)
-	findAndAssertCount(t, f, scheme.Event{}, 0, "") // no events
+	findAndAssertCount[scheme.Event](t, f, 0, "") // no events
 
 	e := f.newEvent()
 	// unexisting := "unexisting"
@@ -53,8 +53,8 @@ func TestCreateEventForeignKeys(t *testing.T) {
 }
 
 func TestDeleteEvent(t *testing.T) {
-	f := newDBFixtureFK(true)                       // no foreign keys
-	findAndAssertCount(t, f, scheme.Event{}, 0, "") // no events
+	f := newDBFixtureFK(true)                     // no foreign keys
+	findAndAssertCount[scheme.Event](t, f, 0, "") // no events
 
 	evt := f.newEvent()
 	f.createEventsAndAssert(t, evt)

--- a/internal/backend/db/dbgorm/gorm_test.go
+++ b/internal/backend/db/dbgorm/gorm_test.go
@@ -211,7 +211,7 @@ func newDBFixtureFK(withoutForeignKeys bool) *dbFixture {
 // 	f.gormdb.db = f.db
 // }
 
-func findAndAssertCount[T any](t *testing.T, f *dbFixture, schemaObj T, expected int, where string, args ...any) []T {
+func findAndAssertCount[T any](t *testing.T, f *dbFixture, expected int, where string, args ...any) []T {
 	var objs []T
 	res := f.gormdb.db.Where(where, args...).Find(&objs)
 	require.NoError(t, res.Error)
@@ -221,7 +221,7 @@ func findAndAssertCount[T any](t *testing.T, f *dbFixture, schemaObj T, expected
 }
 
 func findAndAssertOne[T any](t *testing.T, f *dbFixture, schemaObj T, where string, args ...any) {
-	res := findAndAssertCount(t, f, schemaObj, 1, where, args...)
+	res := findAndAssertCount[T](t, f, 1, where, args...)
 	require.Equal(t, schemaObj, res[0])
 }
 

--- a/internal/backend/db/dbgorm/integrations_test.go
+++ b/internal/backend/db/dbgorm/integrations_test.go
@@ -23,7 +23,7 @@ func (f *dbFixture) assertIntegrationsDeleted(t *testing.T, integrations ...sche
 
 func preIntegrationTest(t *testing.T) *dbFixture {
 	f := newDBFixture()
-	findAndAssertCount(t, f, scheme.Integration{}, 0, "") // no integrations
+	findAndAssertCount[scheme.Integration](t, f, 0, "") // no integrations
 	return f
 }
 

--- a/internal/backend/db/dbgorm/projects.go
+++ b/internal/backend/db/dbgorm/projects.go
@@ -111,11 +111,11 @@ func (db *gormdb) UpdateProject(ctx context.Context, p sdktypes.Project) error {
 }
 
 func (db *gormdb) getProject(ctx context.Context, projectID sdktypes.UUID) (*scheme.Project, error) {
-	return getOne(db.db, ctx, scheme.Project{}, "project_id = ?", projectID)
+	return getOne[scheme.Project](db.db, ctx, "project_id = ?", projectID)
 }
 
 func (db *gormdb) getProjectByName(ctx context.Context, projectName string) (*scheme.Project, error) {
-	return getOne(db.db, ctx, scheme.Project{}, "name = ?", projectName)
+	return getOne[scheme.Project](db.db, ctx, "name = ?", projectName)
 }
 
 func schemaToSDKProject(p *scheme.Project, err error) (sdktypes.Project, error) {

--- a/internal/backend/db/dbgorm/projects_test.go
+++ b/internal/backend/db/dbgorm/projects_test.go
@@ -34,7 +34,7 @@ func (f *dbFixture) assertProjectDeleted(t *testing.T, projects ...scheme.Projec
 
 func preProjectTest(t *testing.T) *dbFixture {
 	f := newDBFixture()
-	findAndAssertCount(t, f, scheme.Project{}, 0, "") // no projects
+	findAndAssertCount[scheme.Project](t, f, 0, "") // no projects
 	return f
 }
 

--- a/internal/backend/db/dbgorm/sessions.go
+++ b/internal/backend/db/dbgorm/sessions.go
@@ -19,7 +19,7 @@ import (
 )
 
 func (db *gormdb) getSession(ctx context.Context, sessionID sdktypes.UUID) (*scheme.Session, error) {
-	return getOne(db.db, ctx, scheme.Session{}, "session_id = ?", sessionID)
+	return getOne[scheme.Session](db.db, ctx, "session_id = ?", sessionID)
 }
 
 func (db *gormdb) GetSession(ctx context.Context, id sdktypes.SessionID) (sdktypes.Session, error) {
@@ -31,7 +31,7 @@ func (db *gormdb) GetSession(ctx context.Context, id sdktypes.SessionID) (sdktyp
 }
 
 func (db *gormdb) deleteSession(ctx context.Context, sessionID sdktypes.UUID) error {
-	return delete(db.db, ctx, scheme.Session{}, "session_id = ?", sessionID)
+	return delete[scheme.Session](db.db, ctx, "session_id = ?", sessionID)
 }
 
 func (db *gormdb) DeleteSession(ctx context.Context, sessionID sdktypes.SessionID) error {

--- a/internal/backend/db/dbgorm/sessions_test.go
+++ b/internal/backend/db/dbgorm/sessions_test.go
@@ -22,7 +22,7 @@ func (f *dbFixture) createSessionsAndAssert(t *testing.T, sessions ...scheme.Ses
 
 func (f *dbFixture) addSessionLogRecordAndAssert(t *testing.T, logr scheme.SessionLogRecord, expected int) {
 	assert.NoError(t, addSessionLogRecordDB(f.gormdb.db, &logr))
-	findAndAssertCount(t, f, logr, expected, "session_id = ?", logr.SessionID)
+	findAndAssertCount[scheme.SessionLogRecord](t, f, expected, "session_id = ?", logr.SessionID)
 }
 
 func (f *dbFixture) listSessionsAndAssert(t *testing.T, expected int) []scheme.Session {
@@ -48,7 +48,7 @@ func (f *dbFixture) assertSessionsDeleted(t *testing.T, sessions ...scheme.Sessi
 func preSessionTest(t *testing.T) *dbFixture {
 	f := newDBFixture()
 	f.listSessionsAndAssert(t, 0) // no sessions
-	findAndAssertCount(t, f, scheme.SessionLogRecord{}, 0, "")
+	findAndAssertCount[scheme.SessionLogRecord](t, f, 0, "")
 	return f
 }
 
@@ -59,7 +59,7 @@ func TestCreateSession(t *testing.T) {
 	// test createSession without any assets session depends on, since they are soft-foreign keys and could be nil
 	f.createSessionsAndAssert(t, s)
 
-	logs := findAndAssertCount(t, f, scheme.SessionLogRecord{}, 1, "session_id = ?", s.SessionID)
+	logs := findAndAssertCount[scheme.SessionLogRecord](t, f, 1, "session_id = ?", s.SessionID)
 	assert.Equal(t, s.SessionID, logs[0].SessionID) // compare only ids, since actual log isn't empty
 }
 

--- a/internal/backend/db/dbgorm/signals_test.go
+++ b/internal/backend/db/dbgorm/signals_test.go
@@ -25,7 +25,7 @@ func (f *dbFixture) assertSignalsDeleted(t *testing.T, signals ...scheme.Signal)
 
 func preSignalTest(t *testing.T, no_foreign_keys bool) *dbFixture {
 	f := newDBFixtureFK(no_foreign_keys)
-	findAndAssertCount(t, f, scheme.Signal{}, 0, "") // no signals
+	findAndAssertCount[scheme.Signal](t, f, 0, "") // no signals
 	return f
 }
 

--- a/internal/backend/db/dbgorm/triggers_test.go
+++ b/internal/backend/db/dbgorm/triggers_test.go
@@ -36,7 +36,7 @@ func (f *dbFixture) assertTriggersDeleted(t *testing.T, triggers ...scheme.Trigg
 
 func preTriggerTest(t *testing.T, no_foreign_keys bool) *dbFixture {
 	f := newDBFixtureFK(no_foreign_keys)
-	findAndAssertCount(t, f, scheme.Trigger{}, 0, "") // no trigger
+	findAndAssertCount[scheme.Trigger](t, f, 0, "") // no trigger
 	return f
 }
 

--- a/internal/backend/db/dbgorm/vars_test.go
+++ b/internal/backend/db/dbgorm/vars_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.autokitteh.dev/autokitteh/internal/backend/db/dbgorm/scheme"
 )
 
@@ -22,7 +23,7 @@ func (f *dbFixture) assertVarDeleted(t *testing.T, vars ...scheme.Var) {
 
 func preVarTest(t *testing.T) *dbFixture {
 	f := newDBFixture()
-	findAndAssertCount(t, f, scheme.Var{}, 0, "") // no vars
+	findAndAssertCount[scheme.Var](t, f, 0, "") // no vars
 	return f
 }
 


### PR DESCRIPTION
no need to supply the actual var old-style to testing functions. can be just specified as a generic type parameter.