### PR TITLE
ENG-790: login via cli

### DIFF
--- a/cmd/ak/cmd/auth/auth.go
+++ b/cmd/ak/cmd/auth/auth.go
@@ -22,6 +22,8 @@ func init() {
 	// Subcommands.
 	authCmd.AddCommand(whoamiCmd)
 	authCmd.AddCommand(createTokenCmd)
+	authCmd.AddCommand(loginCmd)
+	authCmd.AddCommand(setTokenCmd)
 }
 
 func auth() sdkservices.Auth { return common.Client().Auth() }

--- a/cmd/ak/cmd/auth/login.go
+++ b/cmd/ak/cmd/auth/login.go
@@ -1,0 +1,85 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"go.autokitteh.dev/autokitteh/cmd/ak/common"
+
+	"github.com/pkg/browser"
+)
+
+var loginCmd = common.StandardCommand(&cobra.Command{
+	Use:   "login",
+	Short: "Login",
+	Args:  cobra.NoArgs,
+
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		port, wait, done, err := initServer()
+		defer done()
+
+		if err != nil {
+			return err
+		}
+
+		url := fmt.Sprintf("%s/auth/cli-login?p=%d", common.ServerURL().String(), port)
+		if err := browser.OpenURL(url); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "To start, open this address in your browser: %s\n", url)
+		} else {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Please continue in browser (%s).\n", url)
+		}
+
+		token, err := wait(cmd.Context())
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintln(cmd.ErrOrStderr(), "You are now logged in.")
+
+		return common.StoreToken(token)
+	},
+})
+
+func initServer() (port int, wait func(context.Context) (string, error), done func(), err error) {
+	type resp struct {
+		token string
+		err   error
+	}
+
+	ch := make(chan *resp)
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		ch <- &resp{token: r.URL.Query().Get("token")}
+		fmt.Fprintf(w, "You can close this tab now.")
+	})
+
+	var l net.Listener
+	if l, err = net.Listen("tcp", ":0"); err != nil {
+		return
+	}
+
+	go func() {
+		if err = http.Serve(l, nil); err != nil {
+			ch <- &resp{err: err}
+		}
+	}()
+
+	done = func() { _ = l.Close() }
+
+	port = l.Addr().(*net.TCPAddr).Port
+
+	wait = func(ctx context.Context) (string, error) {
+		select {
+		case resp := <-ch:
+			return resp.token, resp.err
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+
+	return
+}

--- a/cmd/ak/cmd/auth/set_token.go
+++ b/cmd/ak/cmd/auth/set_token.go
@@ -1,0 +1,17 @@
+package auth
+
+import (
+	"github.com/spf13/cobra"
+
+	"go.autokitteh.dev/autokitteh/cmd/ak/common"
+)
+
+var setTokenCmd = common.StandardCommand(&cobra.Command{
+	Use:   "set-token <token>",
+	Short: "Set authentication token",
+	Args:  cobra.ExactArgs(1),
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return common.StoreToken(args[0])
+	},
+})

--- a/cmd/ak/cmd/root.go
+++ b/cmd/ak/cmd/root.go
@@ -27,9 +27,7 @@ import (
 	"go.autokitteh.dev/autokitteh/cmd/ak/cmd/triggers"
 	"go.autokitteh.dev/autokitteh/cmd/ak/cmd/vars"
 	"go.autokitteh.dev/autokitteh/cmd/ak/common"
-	"go.autokitteh.dev/autokitteh/config"
 	"go.autokitteh.dev/autokitteh/internal/xdg"
-	"go.autokitteh.dev/autokitteh/sdk/sdkclients/sdkclient"
 )
 
 var (
@@ -67,22 +65,8 @@ var RootCmd = common.StandardCommand(&cobra.Command{
 		if err := common.InitConfig(confmap); err != nil {
 			return fmt.Errorf("root init config: %w", err)
 		}
-		cfg := common.Config()
 
-		url := sdkclient.DefaultLocalURL
-		if _, err := cfg.Get(config.ServiceUrlConfigKey, &url); err != nil {
-			return fmt.Errorf("failed parse config: %w", err)
-		} // if not overriden by config, then url will remain default
-		if !strings.HasPrefix(url, "http") {
-			url = "http://" + url
-		}
-
-		if token != "" {
-			token = "Bearer " + token
-		}
-		common.InitRPCClient(url, token)
-
-		return nil
+		return common.InitRPCClient(token)
 	},
 })
 

--- a/cmd/ak/common/client.go
+++ b/cmd/ak/common/client.go
@@ -8,8 +8,15 @@ import (
 
 var client sdkservices.Services
 
-func InitRPCClient(url string, authToken string) {
-	client = sdkclients.New(sdkclient.Params{URL: url, AuthToken: authToken})
+func InitRPCClient(authToken string) (err error) {
+	if authToken == "" {
+		if authToken, err = GetToken(); err != nil {
+			return
+		}
+	}
+
+	client = sdkclients.New(sdkclient.Params{URL: serverURL.String(), AuthToken: authToken})
+	return
 }
 
 func Client() sdkservices.Services { return client }

--- a/cmd/ak/common/config.go
+++ b/cmd/ak/common/config.go
@@ -1,10 +1,13 @@
 package common
 
 import (
+	"net/url"
 	"path/filepath"
 
 	"go.autokitteh.dev/autokitteh/backend/svc"
+	"go.autokitteh.dev/autokitteh/config"
 	"go.autokitteh.dev/autokitteh/internal/xdg"
+	"go.autokitteh.dev/autokitteh/sdk/sdkclients/sdkclient"
 )
 
 const (
@@ -12,7 +15,10 @@ const (
 	ConfigYAMLFileName = "config.yaml"
 )
 
-var cfg *svc.Config
+var (
+	cfg       *svc.Config
+	serverURL *url.URL
+)
 
 func ConfigYAMLFilePath() string {
 	return filepath.Join(xdg.ConfigHomeDir(), ConfigYAMLFileName)
@@ -20,8 +26,32 @@ func ConfigYAMLFilePath() string {
 
 func InitConfig(confmap map[string]any) (err error) {
 	// Reminder: cfg is a package-scoped variable, not function-scoped.
-	cfg, err = svc.LoadConfig(EnvVarPrefix, confmap, ConfigYAMLFilePath())
+	if cfg, err = svc.LoadConfig(EnvVarPrefix, confmap, ConfigYAMLFilePath()); err != nil {
+		return
+	}
+
+	serverURL, err = readServerURL()
+
 	return
 }
 
 func Config() *svc.Config { return cfg }
+
+func ServerURL() *url.URL { return serverURL }
+
+func readServerURL() (ret *url.URL, err error) {
+	u := sdkclient.DefaultLocalURL
+	if _, err = cfg.Get(config.ServiceUrlConfigKey, &u); err != nil {
+		return
+	} // if not overriden by config, then url will remain default
+
+	if ret, err = url.Parse(u); err != nil {
+		return
+	}
+
+	if ret.Scheme == "" {
+		ret.Scheme = "http"
+	}
+
+	return
+}

--- a/cmd/ak/common/creds.go
+++ b/cmd/ak/common/creds.go
@@ -1,0 +1,79 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"go.autokitteh.dev/autokitteh/internal/xdg"
+)
+
+var credsPath = filepath.Join(xdg.ConfigHomeDir(), "credentials")
+
+func readCreds() (creds map[string]string, err error) {
+	creds = map[string]string{}
+
+	var bs []byte
+	if bs, err = os.ReadFile(credsPath); err != nil {
+		if os.IsNotExist(err) {
+			err = nil
+		}
+
+		return
+	}
+
+	if len(bs) != 0 {
+		err = yaml.Unmarshal(bs, &creds)
+	}
+
+	return
+}
+
+func credsHost() string {
+	host := serverURL.Hostname()
+	if serverURL.Port() != "" {
+		host += ":" + serverURL.Port()
+	}
+	return host
+}
+
+func GetToken() (string, error) {
+	creds, err := readCreds()
+	if err != nil {
+		return "", err
+	}
+
+	tok, ok := creds[credsHost()]
+	if !ok {
+		tok = creds["default"]
+	}
+
+	return tok, nil
+}
+
+func StoreToken(token string) error {
+	creds, err := readCreds()
+	if err != nil {
+		return err
+	}
+
+	host := credsHost()
+
+	if token == "" {
+		delete(creds, host)
+	} else {
+		creds[host] = token
+	}
+
+	var bs []byte
+
+	// If creds are empty, make the file empty instead of yaml's '{}'.
+	if len(creds) != 0 {
+		if bs, err = yaml.Marshal(creds); err != nil {
+			return err
+		}
+	}
+
+	return os.WriteFile(credsPath, bs, 0o600)
+}

--- a/go.mod
+++ b/go.mod
@@ -189,6 +189,7 @@ require (
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/paulmach/orb v0.11.1 // indirect
 	github.com/pborman/uuid v1.2.1 // indirect
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/go.sum
+++ b/go.sum
@@ -735,6 +735,7 @@ golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/sdk/sdkclients/internal/auth.go
+++ b/sdk/sdkclients/internal/auth.go
@@ -20,7 +20,7 @@ func newClientAuthInterceptor(token string) connect.UnaryInterceptorFunc {
 					return nil, errors.New(msg)
 				}
 
-				req.Header().Set(sdkclient.AuthorizationHeader, token)
+				req.Header().Set(sdkclient.AuthorizationHeader, "Bearer "+token)
 
 				return next(ctx, req)
 			},

--- a/sdk/sdkclients/sdkclients.go
+++ b/sdk/sdkclients/sdkclients.go
@@ -18,7 +18,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkclients/sdkstoreclient"
 	sdktriggerclient "go.autokitteh.dev/autokitteh/sdk/sdkclients/sdktriggersclient"
 	"go.autokitteh.dev/autokitteh/sdk/sdkclients/sdkvarsclient"
-	"go.autokitteh.dev/autokitteh/sdk/sdklogger"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 )
 
@@ -61,21 +60,6 @@ func New(params sdkclient.Params) sdkservices.Services {
 		triggers:     kittehs.Lazy1(sdktriggerclient.New, params),
 		vars:         kittehs.Lazy1(sdkvarsclient.New, params),
 	}
-}
-
-func ClientWithToken(c sdkservices.Services, t string) sdkservices.Services {
-	v, ok := c.(*client)
-	if !ok {
-		sdklogger.Panic("original client is not a valid client")
-	}
-
-	params := v.params
-
-	if t != "" {
-		params.AuthToken = t
-	}
-
-	return New(params)
 }
 
 func (c *client) Auth() sdkservices.Auth                 { return c.auth() }


### PR DESCRIPTION
cli opens a browser at the server with a local port to respond to. server logs in, redirects back with token. token is persisted. everyone is happy.

also added the ability to store a token manually.