### PR TITLE
fix descope login

### DIFF
--- a/internal/backend/auth/authloginhttpsvc/config.go
+++ b/internal/backend/auth/authloginhttpsvc/config.go
@@ -23,9 +23,8 @@ func (c oauth2Config) cookieConfig() gologin.CookieConfig {
 }
 
 type descopeConfig struct {
-	Enabled       bool   `koanf:"enabled"`
-	ProjectID     string `koanf:"project_id"`
-	ManagementKey string `koanf:"management_key"`
+	Enabled   bool   `koanf:"enabled"`
+	ProjectID string `koanf:"project_id"`
 }
 
 type Config struct {

--- a/internal/backend/auth/authloginhttpsvc/redir.go
+++ b/internal/backend/auth/authloginhttpsvc/redir.go
@@ -26,3 +26,12 @@ func getRedirect(r *http.Request) string {
 
 	return "/"
 }
+
+func killRedirect(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:   redirCookieName,
+		Value:  "",
+		Path:   "/",
+		MaxAge: -1,
+	})
+}

--- a/internal/backend/auth/authloginhttpsvc/svc.go
+++ b/internal/backend/auth/authloginhttpsvc/svc.go
@@ -151,7 +151,10 @@ func (a *svc) newSuccessLoginHandler(user sdktypes.User) http.Handler {
 			return
 		}
 
-		http.Redirect(w, req, getRedirect(req), http.StatusFound)
+		redir := getRedirect(req)
+		killRedirect(w)
+
+		http.Redirect(w, req, redir, http.StatusFound)
 	}
 
 	return http.HandlerFunc(fn)

--- a/internal/backend/auth/authloginhttpsvc/web/descope.html
+++ b/internal/backend/auth/authloginhttpsvc/web/descope.html
@@ -31,6 +31,7 @@
         const wcElement = document.getElementsByTagName("descope-wc")[0];
 
         const onSuccess = (e) => {
+            document.cookie = `DSR=${e.detail.refreshJwt}; path=/`;
             window.location.replace(loggedinPath);
         };
 


### PR DESCRIPTION
looks like the mgmt api is not working all the time. instead we're using now the `auth.me` method. for some reason it mandates refresh token. looks like the web component doesn't propagates the DSR to the server, so we do it here manually.

also kill the redir cookie once it's used.