### PR TITLE
value wrapping: allow to wrap/unwrap from/into io.Reader

### DIFF
--- a/sdk/sdktypes/value_unwrap.go
+++ b/sdk/sdktypes/value_unwrap.go
@@ -253,6 +253,11 @@ func (w ValueWrapper) unwrapIntoReader(path string, dstv reflect.Value, v Value)
 
 func (w ValueWrapper) unwrapScalarInto(path string, dstv reflect.Value, v Value) (bool, error) {
 	if dstv.Type().Implements(reflect.TypeOf((*io.Reader)(nil)).Elem()) {
+		if w.IgnoreReader {
+			dstv.Set(reflect.Zero(dstv.Type()))
+			return true, nil
+		}
+
 		return w.unwrapIntoReader(path, dstv, v)
 	}
 

--- a/sdk/sdktypes/value_wrap_test.go
+++ b/sdk/sdktypes/value_wrap_test.go
@@ -1,6 +1,7 @@
 package sdktypes_test
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"maps"
@@ -142,6 +143,29 @@ func TestValueWrapper(t *testing.T) {
 				assert.Equal(t, test.unw, unw)
 			}
 		})
+	}
+}
+
+func TestWrapReader(t *testing.T) {
+	buf := bytes.NewBuffer([]byte("meow"))
+	v, err := w.Wrap(buf)
+	if assert.NoError(t, err) {
+		assert.Equal(t, []byte("meow"), v.GetBytes().Value())
+	}
+
+	ww := w
+	ww.WrapReaderAsString = true
+	buf = bytes.NewBuffer([]byte("meow"))
+	v, err = ww.Wrap(buf)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "meow", v.GetString().Value())
+	}
+
+	ww.IgnoreReader = true
+	buf = bytes.NewBuffer([]byte("meow"))
+	v, err = ww.Wrap(buf)
+	if assert.NoError(t, err) {
+		assert.True(t, v.IsNothing())
 	}
 }
 
@@ -307,6 +331,13 @@ func TestUnwrapIntoSpecials(t *testing.T) {
 		if assert.NoError(t, err) {
 			assert.Equal(t, "woof", string(txt))
 		}
+	}
+
+	ww := w
+	ww.IgnoreReader = true
+
+	if assert.NoError(t, ww.UnwrapInto(&r, sdktypes.NewBytesValue([]byte("woof")))) {
+		assert.Nil(t, r)
 	}
 }
 

--- a/sdk/sdktypes/value_wrap_test.go
+++ b/sdk/sdktypes/value_wrap_test.go
@@ -2,6 +2,7 @@ package sdktypes_test
 
 import (
 	"fmt"
+	"io"
 	"maps"
 	"testing"
 	"time"
@@ -291,6 +292,21 @@ func TestUnwrapIntoSpecials(t *testing.T) {
 	var tm time.Time
 	if assert.NoError(t, w.UnwrapInto(&tm, sdktypes.NewStringValue("1/1/23 18:32"))) {
 		assert.Equal(t, time.Date(2023, time.January, 1, 18, 32, 0, 0, time.UTC), tm)
+	}
+
+	var r io.Reader
+	if assert.NoError(t, w.UnwrapInto(&r, sdktypes.NewStringValue("meow"))) {
+		txt, err := io.ReadAll(r)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "meow", string(txt))
+		}
+	}
+
+	if assert.NoError(t, w.UnwrapInto(&r, sdktypes.NewBytesValue([]byte("woof")))) {
+		txt, err := io.ReadAll(r)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "woof", string(txt))
+		}
 	}
 }
 

--- a/sdk/sdktypes/value_wrapper.go
+++ b/sdk/sdktypes/value_wrapper.go
@@ -30,6 +30,12 @@ type ValueWrapper struct {
 	// Error out when trying to unwrap into a struct and the struct has fields that do not exist in the value.
 	UnwrapErrorOnNonexistentStructFields bool
 
+	// Wrap: if true, wrap a reader as a string instead of bytes.
+	WrapReaderAsString bool
+
+	// Ignore readers when wrapping and unwrapping.
+	IgnoreReader bool
+
 	// Unwrap: transform duration into microseconds, do not convert to string.
 	RawDuration bool
 


### PR DESCRIPTION
this is useful in aws integration when a caller need to supply data to functions that receive `io.Reader` for data.