### PR TITLE
Fix payload verification in GitHub webhooks

### DIFF
--- a/integrations/github/webhooks/webhook.go
+++ b/integrations/github/webhooks/webhook.go
@@ -95,7 +95,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		userCID = cids[0]
 
-		data, err := h.vars.Get(r.Context(), sdktypes.NewVarScopeID(userCID), vars.PATSecret)
+		data, err := h.vars.Reveal(r.Context(), sdktypes.NewVarScopeID(userCID), vars.PATSecret)
 		if err != nil {
 			l.Warn("Unrecognized connection for user event payload",
 				zap.String("suffix", suffix),


### PR DESCRIPTION
The webhook secret wasn't read correctly from our DB - the code wasn't fixed in #250 as other integrations.

This PR fixes event handling for PAT-based GitHub connections, OAuth-based GitHub connections were not affected by this bug.

This fix was verified manually.