### PR TITLE
github: checks; modules: flat unpack

### DIFF
--- a/integrations/github/checks.go
+++ b/integrations/github/checks.go
@@ -1,0 +1,68 @@
+package github
+
+import (
+	"context"
+
+	"github.com/google/go-github/v60/github"
+
+	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+func (i integration) createCheckRun(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
+	var (
+		owner, repo string
+		opts        github.CreateCheckRunOptions
+	)
+
+	if err := sdkmodule.UnpackArgs(args, kwargs,
+		"owner", &owner,
+		"repo", &repo,
+		&opts,
+	); err != nil {
+		return sdktypes.InvalidValue, err
+	}
+
+	// Invoke the API method.
+	gh, err := i.NewClient(ctx, owner)
+	if err != nil {
+		return sdktypes.InvalidValue, err
+	}
+
+	resp, _, err := gh.Checks.CreateCheckRun(ctx, owner, repo, opts)
+	if err != nil {
+		return sdktypes.InvalidValue, err
+	}
+
+	return sdktypes.WrapValue(resp)
+}
+
+func (i integration) updateCheckRun(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
+	var (
+		owner, repo string
+		checkRunID  int64
+		opts        github.UpdateCheckRunOptions
+	)
+
+	if err := sdkmodule.UnpackArgs(args, kwargs,
+		"owner", &owner,
+		"repo", &repo,
+		"check_run_id", &checkRunID,
+		&opts,
+	); err != nil {
+		return sdktypes.InvalidValue, err
+	}
+
+	// Invoke the API method.
+	gh, err := i.NewClient(ctx, owner)
+	if err != nil {
+		return sdktypes.InvalidValue, err
+	}
+
+	resp, _, err := gh.Checks.UpdateCheckRun(ctx, owner, repo, checkRunID, opts)
+	if err != nil {
+		return sdktypes.InvalidValue, err
+	}
+
+	return sdktypes.WrapValue(resp)
+}

--- a/integrations/github/client.go
+++ b/integrations/github/client.go
@@ -391,13 +391,13 @@ func funcs(i *integration) []sdkmodule.Optfn {
 		sdkmodule.ExportFunction(
 			"create_check_run",
 			i.createCheckRun,
-			sdkmodule.WithFuncDoc("https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#create-a-check-run"),
+			sdkmodule.WithFuncDoc("https://docs.github.com/en/rest/checks/runs?create-a-check-run"),
 			sdkmodule.WithArgs("owner", "repo", "name", "head_sha", "details_url?", "external_url?", "status?", "conclusion?", "output?", "created_at?", "completed_at?", "actions?"),
 		),
 		sdkmodule.ExportFunction(
 			"update_check_run",
 			i.updateCheckRun,
-			sdkmodule.WithFuncDoc("https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#update-a-check-run"),
+			sdkmodule.WithFuncDoc("https://docs.github.com/en/rest/checks/runs?update-a-check-run"),
 			sdkmodule.WithArgs("owner", "repo", "check_run_id", "details_url?", "external_url?", "status?", "conclusion?", "output?", "created_at?", "completed_at?", "actions?"),
 		),
 	}

--- a/integrations/github/client.go
+++ b/integrations/github/client.go
@@ -387,5 +387,18 @@ func funcs(i *integration) []sdkmodule.Optfn {
 			sdkmodule.WithFuncDoc("https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event"),
 			sdkmodule.WithArgs("owner", "repo", "ref", "workflow_name", "inputs?"),
 		),
+		// Checks
+		sdkmodule.ExportFunction(
+			"create_check_run",
+			i.createCheckRun,
+			sdkmodule.WithFuncDoc("https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#create-a-check-run"),
+			sdkmodule.WithArgs("owner", "repo", "name", "head_sha", "details_url?", "external_url?", "status?", "conclusion?", "output?", "created_at?", "completed_at?", "actions?"),
+		),
+		sdkmodule.ExportFunction(
+			"update_check_run",
+			i.updateCheckRun,
+			sdkmodule.WithFuncDoc("https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#update-a-check-run"),
+			sdkmodule.WithArgs("owner", "repo", "check_run_id", "details_url?", "external_url?", "status?", "conclusion?", "output?", "created_at?", "completed_at?", "actions?"),
+		),
 	}
 }

--- a/sdk/sdkmodule/unpack.go
+++ b/sdk/sdkmodule/unpack.go
@@ -15,6 +15,8 @@ import (
 //
 // If the parameter name ends with "?", it is optional.
 // If the parameter name ends with "=", it must be supplied in kwargs.
+// If the parameter name ends with "?=" or "?="", it must be supplied in kwargs but is optional.
+// If the parameter name ends with "=", it must be supplied in kwargs.
 // If the parameter name starts with "**", the destination will accept all kwargs as a dict.
 // If the parameter name starts with "*", the destination will aceppt all args as a list.
 //
@@ -32,7 +34,9 @@ import (
 //			  args []int
 //			)
 //
-//			if err := UnpackArgs(args, kwargs, "x", &x, "y=", &y, "*args", &args); err != nil {
+//			var st struct { Z int `json:"z"`}
+//
+//			if err := UnpackArgs(args, kwargs, "x", &x, &st, "y=", &y, "*args", &args); err != nil {
 //		  		return err
 //			}
 //
@@ -40,9 +44,7 @@ import (
 //		}
 //
 // (this function is heavily inspired by https://pkg.go.dev/go.starlark.net/starlark#UnpackArgs,
-// it essentially does the same thing, but on autokitteh level and not starlark)
-//
-// TODO: varargs.
+// it essentially does the same thing with some bells and whistles, but on autokitteh level)
 func UnpackArgs(args []sdktypes.Value, kwargs map[string]sdktypes.Value, dsts ...any) error {
 	kwargs = maps.Clone(kwargs)
 

--- a/sdk/sdkmodule/unpack.go
+++ b/sdk/sdkmodule/unpack.go
@@ -3,6 +3,7 @@ package sdkmodule
 import (
 	"fmt"
 	"maps"
+	"reflect"
 	"strings"
 
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
@@ -16,6 +17,11 @@ import (
 // If the parameter name ends with "=", it must be supplied in kwargs.
 // If the parameter name starts with "**", the destination will accept all kwargs as a dict.
 // If the parameter name starts with "*", the destination will aceppt all args as a list.
+//
+// A nameless parameter can also be specified. That parameter must be a pointer to a struct.
+// The function will use the member names of the struct as the parameter names. If the fields
+// are tagged with `json:"..."`, the tag will be used as the parameter name. If the tag is
+// "-", the field will be ignored. If the tag modifier is "omitempty", the field will be optional.
 //
 // Example:
 //
@@ -37,14 +43,64 @@ import (
 // it essentially does the same thing, but on autokitteh level and not starlark)
 //
 // TODO: varargs.
-func UnpackArgs(args []sdktypes.Value, kwargs map[string]sdktypes.Value, dsts ...interface{}) error {
+func UnpackArgs(args []sdktypes.Value, kwargs map[string]sdktypes.Value, dsts ...any) error {
 	kwargs = maps.Clone(kwargs)
 
-	if len(dsts)%2 != 0 {
-		return fmt.Errorf("must have even number of dsts")
+	var flattened []any
+
+	for i := 0; i < len(dsts); i++ {
+		if _, ok := dsts[i].(string); ok {
+			i++
+			continue
+		}
+
+		t := reflect.TypeOf(dsts[i])
+		if t.Kind() != reflect.Ptr {
+			return fmt.Errorf("dst %d must be name or a pointer to a struct", i)
+		}
+
+		tt := t.Elem()
+		if tt.Kind() != reflect.Struct {
+			return fmt.Errorf("dst %d must be a pointer to a struct", i)
+		}
+
+		for j := 0; j < tt.NumField(); j++ {
+			ttf := tt.Field(j)
+
+			name := ttf.Name
+			optional := ttf.Type.Kind() == reflect.Ptr
+
+			if j := ttf.Tag.Get("json"); j != "" {
+				if j == "-" {
+					continue
+				}
+
+				var rest string
+				name, rest, _ = strings.Cut(j, ",")
+				if rest == "omitempty" {
+					optional = true
+				}
+			}
+
+			if len(name) == 0 {
+				continue
+			}
+
+			name += "="
+
+			if optional {
+				name += "?"
+			}
+
+			flattened = append(flattened, name, reflect.ValueOf(dsts[i]).Elem().Field(j).Addr().Interface())
+		}
+
+		dsts = append(dsts[:i], dsts[i+1:]...)
 	}
 
-	for i := 0; i < len(dsts); i += 2 {
+	dsts = append(dsts, flattened...)
+
+	for i := 0; i+1 < len(dsts); i += 2 {
 		nameitf, dst := dsts[i], dsts[i+1]
 
 		name, ok := nameitf.(string)

--- a/sdk/sdkmodule/unpack.go
+++ b/sdk/sdkmodule/unpack.go
@@ -77,10 +77,13 @@ func UnpackArgs(args []sdktypes.Value, kwargs map[string]sdktypes.Value, dsts ..
 					continue
 				}
 
-				var rest string
-				name, rest, _ = strings.Cut(j, ",")
+				jname, rest, _ := strings.Cut(j, ",")
 				if rest == "omitempty" {
 					optional = true
+				}
+
+				if jname != "" {
+					name = jname
 				}
 			}
 

--- a/sdk/sdkmodule/unpack_test.go
+++ b/sdk/sdkmodule/unpack_test.go
@@ -12,11 +12,18 @@ import (
 func TestUnpack(t *testing.T) {
 	assert.NoError(t, UnpackArgs(nil, nil))
 
-	var i int
-	assert.Error(t, UnpackArgs(nil, nil, "i", &i))
+	var (
+		i  int
+		st struct {
+			X int
+		}
+	)
+
+	assert.Error(t, UnpackArgs(nil, nil, "i", &i, &st))
 
 	if assert.NoError(t, UnpackArgs([]sdktypes.Value{sdktypes.NewIntegerValue(42)}, nil, "i", &i)) {
 		assert.Equal(t, 42, i)
+		assert.Zero(t, st)
 	}
 
 	var s string
@@ -26,5 +33,38 @@ func TestUnpack(t *testing.T) {
 	}, "i", &i, "s=", &s)) {
 		assert.Equal(t, 64, i)
 		assert.Equal(t, "meow", s)
+		assert.Zero(t, st)
 	}
+}
+
+func TestUnpackFlat(t *testing.T) {
+	var (
+		i  int
+		st struct {
+			X int     `json:"x"`
+			Y *string `json:"y"`
+			S struct {
+				Z int `json:"z"`
+			} `json:"s"`
+			Sptr *struct {
+				Z int `json:"z"`
+			} `json:"s"`
+		}
+	)
+
+	assert.NoError(t, UnpackArgs([]sdktypes.Value{
+		sdktypes.NewIntegerValue(42),
+	}, map[string]sdktypes.Value{
+		"x": sdktypes.NewIntegerValue(64),
+		"y": sdktypes.NewStringValue("meow"),
+		"s": sdktypes.NewDictValueFromStringMap(map[string]sdktypes.Value{
+			"z": sdktypes.NewIntegerValue(128),
+		}),
+	}, "i", &i, &st))
+
+	assert.Equal(t, 42, i)
+	assert.Equal(t, 64, st.X)
+	assert.Equal(t, "meow", *st.Y)
+	assert.Equal(t, 128, st.S.Z)
+	assert.Zero(t, st.Sptr)
 }

--- a/sdk/sdkmodule/unpack_test.go
+++ b/sdk/sdkmodule/unpack_test.go
@@ -48,7 +48,7 @@ func TestUnpackFlat(t *testing.T) {
 			} `json:"s"`
 			Sptr *struct {
 				Z int `json:"z"`
-			} `json:"s"`
+			} `json:"sptr"`
 		}
 	)
 

--- a/sdk/sdkmodule/unpack_test.go
+++ b/sdk/sdkmodule/unpack_test.go
@@ -8,8 +8,7 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-// TODO: These tests are faaaaaaar from exhaustive.
-func TestUnpack(t *testing.T) {
+func TestSimpleUnpack(t *testing.T) {
 	assert.NoError(t, UnpackArgs(nil, nil))
 
 	var (
@@ -67,4 +66,115 @@ func TestUnpackFlat(t *testing.T) {
 	assert.Equal(t, "meow", *st.Y)
 	assert.Equal(t, 128, st.S.Z)
 	assert.Zero(t, st.Sptr)
+}
+
+func TestUnpack(t *testing.T) {
+	one := sdktypes.NewIntegerValue(1)
+	two := sdktypes.NewIntegerValue(2)
+	three := sdktypes.NewIntegerValue(3)
+	meow := sdktypes.NewStringValue("meow")
+
+	type outs struct {
+		I  int `json:"j"`
+		S  string
+		Xs []int          `json:",omitempty"`
+		M  map[string]int `json:"m,omitempty"`
+	}
+
+	var dsts outs
+
+	tests := []struct {
+		name   string
+		args   []sdktypes.Value
+		kwargs map[string]sdktypes.Value
+		dsts   []any
+		want   outs
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "positionals",
+			args: []sdktypes.Value{
+				one,
+				meow,
+			},
+			dsts: []any{"i", &dsts.I, "s", &dsts.S},
+			want: outs{
+				I: 1,
+				S: "meow",
+			},
+		},
+		{
+			name: "kwargs",
+			kwargs: map[string]sdktypes.Value{
+				"i": one,
+				"s": meow,
+			},
+			dsts: []any{"i", &dsts.I, "s=", &dsts.S},
+			want: outs{
+				I: 1,
+				S: "meow",
+			},
+		},
+		{
+			name: "mixed",
+			args: []sdktypes.Value{one},
+			kwargs: map[string]sdktypes.Value{
+				"s": meow,
+			},
+			dsts: []any{"i", &dsts.I, "s=", &dsts.S},
+			want: outs{
+				I: 1,
+				S: "meow",
+			},
+		},
+		{
+			name: "varargs",
+			args: []sdktypes.Value{one, two, three},
+			dsts: []any{"i", &dsts.I, "*args", &dsts.Xs},
+			want: outs{
+				I:  1,
+				Xs: []int{2, 3},
+			},
+		},
+		{
+			name: "varargs-mixed",
+			args: []sdktypes.Value{two, three},
+			kwargs: map[string]sdktypes.Value{
+				"one": one,
+				"two": two,
+			},
+			dsts: []any{"*args", &dsts.Xs, "**kwargs", &dsts.M},
+			want: outs{
+				Xs: []int{2, 3},
+				M:  map[string]int{"one": 1, "two": 2},
+			},
+		},
+		{
+			name: "struct",
+			kwargs: map[string]sdktypes.Value{
+				"j": one,
+				"S": meow,
+				"m": sdktypes.NewDictValueFromStringMap(map[string]sdktypes.Value{"one": one, "two": two}),
+			},
+			dsts: []any{&dsts},
+			want: outs{
+				S: "meow",
+				I: 1,
+				M: map[string]int{
+					"one": 1,
+					"two": 2,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dsts = outs{}
+			assert.NoError(t, UnpackArgs(test.args, test.kwargs, test.dsts...))
+			assert.Equal(t, test.want, dsts)
+		})
+	}
 }

--- a/sdk/sdktypes/value_unwrap.go
+++ b/sdk/sdktypes/value_unwrap.go
@@ -252,6 +252,15 @@ func (w ValueWrapper) unwrapIntoReader(path string, dstv reflect.Value, v Value)
 }
 
 func (w ValueWrapper) unwrapScalarInto(path string, dstv reflect.Value, v Value) (bool, error) {
+	if v.IsNothing() {
+		if dstv.Kind() == reflect.Ptr {
+			dstv.Set(reflect.Zero(dstv.Type()))
+			return true, nil
+		}
+
+		return true, fmt.Errorf("%scannot convert Nothing to target type", path)
+	}
+
 	if dstv.Type().Implements(reflect.TypeOf((*io.Reader)(nil)).Elem()) {
 		if w.IgnoreReader {
 			dstv.Set(reflect.Zero(dstv.Type()))

--- a/sdk/sdktypes/value_wrap_test.go
+++ b/sdk/sdktypes/value_wrap_test.go
@@ -18,8 +18,8 @@ var (
 	w = sdktypes.DefaultValueWrapper
 
 	iv           = sdktypes.NewIntegerValue(42)
-	nothing      = sdktypes.Nothing
 	intsList     = kittehs.Must1(sdktypes.NewListValue([]sdktypes.Value{sdktypes.NewIntegerValue(1), sdktypes.NewIntegerValue(2), sdktypes.NewIntegerValue(3)}))
+	nothing      = sdktypes.Nothing
 	intsSet      = kittehs.Must1(sdktypes.NewSetValue([]sdktypes.Value{sdktypes.NewIntegerValue(1), sdktypes.NewIntegerValue(2), sdktypes.NewIntegerValue(3)}))
 	mixedList    = kittehs.Must1(sdktypes.NewListValue([]sdktypes.Value{sdktypes.NewIntegerValue(1), sdktypes.NewStringValue("meow"), sdktypes.NewFloatValue(1.2)}))
 	stringIntMap = map[string]sdktypes.Value{
@@ -412,4 +412,9 @@ func TestUnwrapIntoKitchenSink(t *testing.T) {
 	if assert.NoError(t, w.UnwrapInto(&x, wx)) {
 		assert.Equal(t, in, x)
 	}
+}
+
+func TestUnwrapNothing(t *testing.T) {
+	var i int
+	assert.Error(t, sdktypes.UnwrapValueInto(&i, sdktypes.Nothing))
 }


### PR DESCRIPTION
- sdkmodule: add the ability to just specify a struct and unpack will use its fields as destination.
- github: add create and update checks API. this is using the abovementioned feature and a good example.

lmk if you want me to split this pr.
