### PR TITLE
ENG-843: Allow Slack to impersonate users when posting messages

### DIFF
--- a/integrations/slack/api/chat/data.go
+++ b/integrations/slack/api/chat/data.go
@@ -90,6 +90,11 @@ type PostMessageRequest struct {
 	// whether the reply should be made visible to everyone in the channel
 	// or conversation. Default = false.
 	ReplyBroadcast bool `json:"reply_broadcast,omitempty"`
+
+	// Name to display alongside the message, instead of the bot's name.
+	Username string `json:"username,omitempty"`
+	// URL to an image to use as the user's icon for this message, instead of the bot's.
+	IconURL string `json:"icon_url,omitempty"`
 }
 
 // https://api.slack.com/methods/chat.postMessage#examples

--- a/integrations/slack/api/chat/methods.go
+++ b/integrations/slack/api/chat/methods.go
@@ -151,6 +151,8 @@ func (a API) PostMessage(ctx context.Context, args []sdktypes.Value, kwargs map[
 		"blocks?", &req.Blocks,
 		"thread_ts?", &req.ThreadTS,
 		"reply_broadcast?", &req.ReplyBroadcast,
+		"username?", &req.Username,
+		"icon_url?", &req.IconURL,
 	)
 	if err != nil {
 		return sdktypes.InvalidValue, err

--- a/integrations/slack/client.go
+++ b/integrations/slack/client.go
@@ -104,7 +104,7 @@ func New(vars sdkservices.Vars) sdkservices.Integration {
 			"chat_post_message",
 			chatAPI.PostMessage,
 			sdkmodule.WithFuncDoc("https://api.slack.com/methods/chat.postMessage"),
-			sdkmodule.WithArgs("channel", "text?", "blocks?", "thread_ts?", "reply_broadcast?"),
+			sdkmodule.WithArgs("channel", "text?", "blocks?", "thread_ts?", "reply_broadcast?", "username?", "icon_url?"),
 		),
 		sdkmodule.ExportFunction(
 			"chat_update",


### PR DESCRIPTION
This is still discernible from the real user - there's an "App" label next to the user name.