### PR TITLE
db: recreate projects with the same name

### DIFF
--- a/internal/backend/db/dbgorm/projects_test.go
+++ b/internal/backend/db/dbgorm/projects_test.go
@@ -46,6 +46,30 @@ func TestCreateProject(t *testing.T) {
 	f.createProjectsAndAssert(t, p)
 }
 
+func TestCreateDuplicatedProjectName(t *testing.T) {
+	f := preProjectTest(t)
+
+	p := f.newProject()
+	// test createProject
+	f.createProjectsAndAssert(t, p)
+
+	p2 := f.newProject()
+	p2.Name = p.Name
+
+	assert.Equal(t, p.Name, p2.Name)
+	assert.NotEqual(t, p.ProjectID, p2.ProjectID)
+
+	// test create another project with the same name
+	assert.ErrorIs(t, f.gormdb.createProject(f.ctx, &p2), gorm.ErrDuplicatedKey)
+
+	// delete project
+	assert.NoError(t, f.gormdb.deleteProject(f.ctx, p.ProjectID))
+	f.assertProjectDeleted(t, p)
+
+	// test create another project with the same name after delete
+	f.createProjectsAndAssert(t, p2)
+}
+
 func TestGetProjects(t *testing.T) {
 	f := preProjectTest(t)
 

--- a/migrations/postgres/20240522074209_project_name_non_unique_index.sql
+++ b/migrations/postgres/20240522074209_project_name_non_unique_index.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- drop index "idx_projects_name" from table: "projects"
+DROP INDEX "idx_projects_name";
+-- create index "idx_projects_name" to table: "projects"
+CREATE INDEX "idx_projects_name" ON "projects" ("name");
+
+-- +goose Down
+-- reverse: create index "idx_projects_name" to table: "projects"
+DROP INDEX "idx_projects_name";
+-- reverse: drop index "idx_projects_name" from table: "projects"
+CREATE UNIQUE INDEX "idx_projects_name" ON "projects" ("name");

--- a/migrations/postgres/atlas.sum
+++ b/migrations/postgres/atlas.sum
@@ -1,6 +1,7 @@
-h1:ARWVf0MPMVJ0l8tWG/boPcuffnn8daxZsFJkiXO4VRA=
+h1:KRl9kvYREiEbLL8NSFx/bmIhydXPJ9tcoEfm7BIp4vs=
 20240507104234_baseline.sql h1:u+/m2oVxbl8ocxuOGDK5ZvK1FSiFFDWpyDIY9lFOXv4=
 20240508111542_secret-string-value.sql h1:LMcOKQmbE418Nmj2HwOaRv6d2X8UQnblUh79EwLsamU=
 20240515105256_trigger_opional_connection.sql h1:Yf5xwhI8IpZXfrOvbi7wwWcmggl2f5Z2shOulpxwT0M=
 20240515122624_event_optional_connection_and_integration.sql h1:q/k5xsfzA1cbGpHJ1HHVk+ssoN1lqceF8ky272j3aVk=
 20240517051313_conn-status.sql h1:Znc5Lu8rusof/IfieCDf/TvW8tG1LyGCGwfjKrkF/Mw=
+20240522074209_project_name_non_unique_index.sql h1:+XwG1fO/hBGfjWfZwoXHI0MJYCoVrOzDaivQDV8VSVE=

--- a/migrations/sqlite/20240522074202_project_name_non_unique_index.sql
+++ b/migrations/sqlite/20240522074202_project_name_non_unique_index.sql
@@ -1,0 +1,32 @@
+-- +goose Up
+-- disable the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = off;
+-- create "new_projects" table
+CREATE TABLE `new_projects` (
+  `project_id` uuid NOT NULL,
+  `name` text NULL,
+  `root_url` text NULL,
+  `resources` blob NULL,
+  `deleted_at` datetime NULL,
+  PRIMARY KEY (`project_id`)
+);
+-- copy rows from old table "projects" to new temporary table "new_projects"
+INSERT INTO `new_projects` (`project_id`, `name`, `root_url`, `resources`, `deleted_at`) SELECT `project_id`, `name`, `root_url`, `resources`, `deleted_at` FROM `projects`;
+-- drop "projects" table after copying rows
+DROP TABLE `projects`;
+-- rename temporary table "new_projects" to "projects"
+ALTER TABLE `new_projects` RENAME TO `projects`;
+-- create index "idx_projects_deleted_at" to table: "projects"
+CREATE INDEX `idx_projects_deleted_at` ON `projects` (`deleted_at`);
+-- create index "idx_projects_name" to table: "projects"
+CREATE INDEX `idx_projects_name` ON `projects` (`name`);
+-- enable back the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = on;
+
+-- +goose Down
+-- reverse: create index "idx_projects_name" to table: "projects"
+DROP INDEX `idx_projects_name`;
+-- reverse: create index "idx_projects_deleted_at" to table: "projects"
+DROP INDEX `idx_projects_deleted_at`;
+-- reverse: create "new_projects" table
+DROP TABLE `new_projects`;

--- a/migrations/sqlite/atlas.sum
+++ b/migrations/sqlite/atlas.sum
@@ -1,6 +1,7 @@
-h1:vslRwSwtYoUfWO7bQ4PiixPusZ023IEW4iaJtnhQrEY=
+h1:j9rIwUM/pDmw0pYJB3nvmEtchwgFtktAZleZVZro3jQ=
 20240507104228_baseline.sql h1:4B9CvzNeSNzEwATnxtK+d00ATCaSZHyr0dwmeuO06RA=
 20240508111539_secret-string-value.sql h1:dMpp/HpoRd49wXOZiPKt+Fxjns7Kc4x/aSOvBfLgU6E=
 20240515105250_trigger_opional_connection.sql h1:X1SRwT9f2BaswD0wPgqoK5E0NaEyQ4P3r94nMu4WXjA=
 20240515122617_event_optional_connection_and_integration.sql h1:ANox4SWiASzAtGp8rbE3uQ2xkcyhMc1mbZlbWH3r3po=
 20240517051309_conn-status.sql h1:SrCkbS4tTg//jxGzpYBnHzxAdVacoV8TOH0YbEqHclI=
+20240522074202_project_name_non_unique_index.sql h1:bhgBOGFczZQQKnR/Ll01YCGNDyC3uPbFKgKpc9S7nVY=


### PR DESCRIPTION
allow to recreate project with the same name.
- use hook to check whether non-deleted project exists with the same name
- return duplicated record if so
- allow if there are deleted projects
- change project:name index to be non-unique