### PR TITLE
Improve usability of GitHub integration

### DIFF
--- a/integrations/github/client.go
+++ b/integrations/github/client.go
@@ -331,17 +331,6 @@ func funcs(i *integration) []sdkmodule.Optfn {
 			sdkmodule.WithArgs("owner", "repo", "ref"),
 		),
 
-		// Actions
-		sdkmodule.ExportFunction(
-			"list_workflow_runs",
-			i.listWorkflowRuns,
-			sdkmodule.WithFuncDoc("https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository"),
-			sdkmodule.WithArgs(
-				"owner", "repo", "branch=?", "event=?", "actor=?", "status=?", "created=?",
-				"head_sha=?", "exclude_pull_requests=?", "check_suite_id=?",
-			),
-		),
-
 		// Repo
 		sdkmodule.ExportFunction(
 			"list_collaborators",
@@ -382,11 +371,21 @@ func funcs(i *integration) []sdkmodule.Optfn {
 			sdkmodule.WithArgs("owner", "repo"),
 		),
 		sdkmodule.ExportFunction(
+			"list_workflow_runs",
+			i.listWorkflowRuns,
+			sdkmodule.WithFuncDoc("https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository"),
+			sdkmodule.WithArgs(
+				"owner", "repo", "branch=?", "event=?", "actor=?", "status=?", "created=?",
+				"head_sha=?", "exclude_pull_requests=?", "check_suite_id=?",
+			),
+		),
+		sdkmodule.ExportFunction(
 			"trigger_workflow",
 			i.triggerWorkflow,
 			sdkmodule.WithFuncDoc("https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event"),
-			sdkmodule.WithArgs("owner", "repo", "ref", "workflow_name", "inputs?"),
+			sdkmodule.WithArgs("owner", "repo", "ref", "workflow_file_name", "inputs?"),
 		),
+
 		// Checks
 		sdkmodule.ExportFunction(
 			"create_check_run",

--- a/integrations/github/jwt.go
+++ b/integrations/github/jwt.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -48,14 +49,24 @@ func (i integration) NewClient(ctx context.Context, user string) (*github.Client
 // uses a newly-generated GitHub app installation JWT.
 func (i integration) newClientWithInstallJWT(data sdktypes.Vars, user string) (*github.Client, error) {
 	// Initialize and return a GitHub client with a JWT.
-	aid, err := strconv.ParseInt(data.GetValue(vars.UserAppID(user)), 10, 64)
-	if err != nil {
-		return nil, err
+	s := data.GetValue(vars.UserAppID(user))
+	if s == "" {
+		return nil, fmt.Errorf("app ID not found for owner %q", user)
 	}
-	iid, err := strconv.ParseInt(data.GetValue(vars.UserInstallID(user)), 10, 64)
+	aid, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid app ID %q for owner %q", s, user)
 	}
+
+	s = data.GetValue(vars.UserInstallID(user))
+	if s == "" {
+		return nil, fmt.Errorf("install ID not found for owner %q", user)
+	}
+	iid, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid nstall ID %q for owner %q", s, user)
+	}
+
 	return i.newClientWithInstallJWTFromGitHubIDs(aid, iid)
 }
 

--- a/integrations/github/workflows.go
+++ b/integrations/github/workflows.go
@@ -20,7 +20,7 @@ func (i integration) triggerWorkflow(ctx context.Context, args []sdktypes.Value,
 		"owner", &owner,
 		"repo", &repo,
 		"ref", &req.Ref,
-		"workflow_name", &workflowName,
+		"workflow_file_name", &workflowName,
 		"inputs?", &req.Inputs,
 	); err != nil {
 		return sdktypes.InvalidValue, err


### PR DESCRIPTION
1. Improve error messages if app/install IDs are missing/invalid when initializing a GH client for sending API calls
2. Clarify parameter name in `trigger_workflow`

This is a UX follow-up for a session with an external user.

Tested manually the effect: from a Go-internal error to a message that clarifies what's actually the problem.