### PR TITLE
better args splitting for ak tests

### DIFF
--- a/tests/system/actions.go
+++ b/tests/system/actions.go
@@ -2,6 +2,7 @@ package systest
 
 import (
 	"errors"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -13,13 +14,24 @@ type akResult struct {
 	returnCode int
 }
 
+func splitToArgs(cmdArgs string) []string {
+	re := regexp.MustCompile(`\w+=".*?"|\w+=[\w.:]+|"[^"]+"|[\w-.:/]+`)
+	args := re.FindAllString(cmdArgs, -1)
+	for i, arg := range args {
+		if len(arg) >= 1 && arg[0] == '"' && arg[len(arg)-1] == '"' {
+			args[i] = strings.Trim(arg, "\"")
+		}
+	}
+	return args
+}
+
 func runAction(t *testing.T, akPath, akAddr, step string) (any, error) {
 	match := actions.FindStringSubmatch(step)
 	switch match[1] {
 	case "setenv":
 		return nil, setEnv(strings.TrimSpace(strings.TrimPrefix(step, match[1])))
 	case "ak":
-		args := append(config.ServiceUrlArg(akAddr), strings.Fields(match[3])...)
+		args := append(config.ServiceUrlArg(akAddr), splitToArgs(match[3])...)
 		return runClient(akPath, args)
 	case "http get", "http post":
 		method := strings.ToUpper(match[2])

--- a/tests/system/actions.go
+++ b/tests/system/actions.go
@@ -14,8 +14,16 @@ type akResult struct {
 	returnCode int
 }
 
+// \w+=".*?"       # Match key-value pairs with double quotes
+//
+// \w+=[\w.:]+     # Match key-value pairs without double quotes
+//
+// "[^"]+"         # Match double quoted strings
+//
+// [\w-.:/]+       # Match other words containing alphanumeric, hyphen, dot, colon, or slash characters
+var re = regexp.MustCompile(`\w+=".*?"|\w+=[\w.:]+|"[^"]+"|[\w-.:/]+`)
+
 func splitToArgs(cmdArgs string) []string {
-	re := regexp.MustCompile(`\w+=".*?"|\w+=[\w.:]+|"[^"]+"|[\w-.:/]+`)
 	args := re.FindAllString(cmdArgs, -1)
 	for i, arg := range args {
 		if len(arg) >= 1 && arg[0] == '"' && arg[len(arg)-1] == '"' {

--- a/tests/system/actions.go
+++ b/tests/system/actions.go
@@ -15,6 +15,7 @@ type akResult struct {
 }
 
 func splitToArgs(cmdArgs string) []string {
+	cmdArgs = strings.TrimSpace(cmdArgs)
 	r := csv.NewReader(strings.NewReader(cmdArgs))
 	r.Comma = ' '       // space
 	r.LazyQuotes = true // allow quotes to appear in string

--- a/tests/system/actions.go
+++ b/tests/system/actions.go
@@ -1,8 +1,8 @@
 package systest
 
 import (
+	"encoding/csv"
 	"errors"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -14,23 +14,12 @@ type akResult struct {
 	returnCode int
 }
 
-// \w+=".*?"       # Match key-value pairs with double quotes
-//
-// \w+=[\w.:]+     # Match key-value pairs without double quotes
-//
-// "[^"]+"         # Match double quoted strings
-//
-// [\w-.:/]+       # Match other words containing alphanumeric, hyphen, dot, colon, or slash characters
-var re = regexp.MustCompile(`\w+=".*?"|\w+=[\w.:]+|"[^"]+"|[\w-.:/]+`)
-
 func splitToArgs(cmdArgs string) []string {
-	args := re.FindAllString(cmdArgs, -1)
-	for i, arg := range args {
-		if len(arg) >= 1 && arg[0] == '"' && arg[len(arg)-1] == '"' {
-			args[i] = strings.Trim(arg, "\"")
-		}
-	}
-	return args
+	r := csv.NewReader(strings.NewReader(cmdArgs))
+	r.Comma = ' '       // space
+	r.LazyQuotes = true // allow quotes to appear in string
+	fields, _ := r.Read()
+	return fields
 }
 
 func runAction(t *testing.T, akPath, akAddr, step string) (any, error) {

--- a/tests/system/actions_test.go
+++ b/tests/system/actions_test.go
@@ -1,0 +1,41 @@
+package systest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitToArgs(t *testing.T) {
+	testCases := []struct {
+		cmdArgs  string
+		expected []string
+	}{
+		{
+			cmdArgs:  `simple args1 x 1`,
+			expected: []string{"simple", "args1", "x", "1"},
+		},
+		{
+			// test [.:]
+			cmdArgs:  `session start --build-id bld_03 --entrypoint main.star:main "`,
+			expected: []string{"session", "start", "--build-id", "bld_03", "--entrypoint", "main.star:main"},
+		},
+		{
+			// test x=y, with int, dot, quotes
+			cmdArgs:  `pass --input a=1 --input b=2.3 --input c="meow"`,
+			expected: []string{"pass", "--input", "a=1", "--input", "b=2.3", "--input", `c="meow"`},
+		},
+		{
+			// test schedule
+			cmdArgs:  `--schedule1 "* * * * *" --schedule2 "0 0 */1 * *" --schedule3 "@every 1h3m2s"`,
+			expected: []string{"--schedule1", "* * * * *", "--schedule2", "0 0 */1 * *", "--schedule3", "@every 1h3m2s"},
+		},
+	}
+
+	for _, tc := range testCases {
+		result := splitToArgs(tc.cmdArgs)
+
+		assert.Equal(t, len(tc.expected), len(result))
+		assert.Equal(t, tc.expected, result)
+	}
+}

--- a/tests/system/actions_test.go
+++ b/tests/system/actions_test.go
@@ -17,7 +17,7 @@ func TestSplitToArgs(t *testing.T) {
 		},
 		{
 			// test [.:]
-			cmdArgs:  `session start --build-id bld_03 --entrypoint main.star:main "`,
+			cmdArgs:  `session start --build-id bld_03 --entrypoint main.star:main`,
 			expected: []string{"session", "start", "--build-id", "bld_03", "--entrypoint", "main.star:main"},
 		},
 		{
@@ -29,6 +29,11 @@ func TestSplitToArgs(t *testing.T) {
 			// test schedule
 			cmdArgs:  `--schedule1 "* * * * *" --schedule2 "0 0 */1 * *" --schedule3 "@every 1h3m2s"`,
 			expected: []string{"--schedule1", "* * * * *", "--schedule2", "0 0 */1 * *", "--schedule3", "@every 1h3m2s"},
+		},
+		{
+			// scv reader would return additional space as a field. Trim spaces
+			cmdArgs:  ` aaa bb `,
+			expected: []string{"aaa", "bb"},
 		},
 	}
 

--- a/tests/system/testdata/connections/create.txtar
+++ b/tests/system/testdata/connections/create.txtar
@@ -17,11 +17,11 @@ ak connection create my_connection --project my_project
 output equals 'Error: required flag(s) "integration" not set'
 return code == 1
 
-ak connection create my_connection --integration http 
+ak connection create my_connection --integration http
 output equals 'Error: required flag(s) "project" not set'
 return code == 1
 
-ak connection create my_connection --project my_project 
+ak connection create my_connection --project my_project
 output equals 'Error: required flag(s) "integration" not set'
 return code == 1
 


### PR DESCRIPTION
fix splitting args for ak tests
- previously args were extracted by splitting by whitespace. Which prevents us to pass schedule (e.g. "* * * * *") as an arg
- now args splitting respects quotes. 
- handles
  - single word alphanumeric + [-.:/] args, e.g. `[\w-.:/]+`
  - quoted args, e.g. "* * * * *"
  - var=value args, e.g. `\w+=".*?"` and `\w+=[\w.:]+`