### PR TITLE
sdktypes: make NewInteger and NewFloat easier to use

### DIFF
--- a/integrations/http/http.go
+++ b/integrations/http/http.go
@@ -349,7 +349,7 @@ func toStruct(r *http.Response) (sdktypes.Value, error) {
 		sdktypes.NewStringValue("http_response"),
 		map[string]sdktypes.Value{
 			"url":         sdktypes.NewStringValue(r.Request.URL.String()),
-			"status_code": sdktypes.NewIntegerValue(int64(r.StatusCode)),
+			"status_code": sdktypes.NewIntegerValue(r.StatusCode),
 			"headers": kittehs.Must1(sdktypes.NewDictValue(
 				kittehs.TransformMapToList(r.Header, func(k string, vs []string) sdktypes.DictItem {
 					return sdktypes.DictItem{

--- a/internal/backend/akmodules/os/os.go
+++ b/internal/backend/akmodules/os/os.go
@@ -121,7 +121,7 @@ func execute(ctx context.Context, name string, args []string, write map[string]a
 		retCtor,
 		map[string]sdktypes.Value{
 			"output":   sdktypes.NewStringValue(string(out)),
-			"exitcode": sdktypes.NewIntegerValue(int64(rc)),
+			"exitcode": sdktypes.NewIntegerValue(rc),
 			"files":    sdktypes.NewDictValueFromStringMap(files),
 		},
 	)

--- a/internal/backend/akmodules/time/time.go
+++ b/internal/backend/akmodules/time/time.go
@@ -20,12 +20,12 @@ var ExecutorID = sdktypes.NewExecutorID(fixtures.NewBuiltinIntegrationID("time")
 func New() sdkexecutor.Executor {
 	return fixtures.NewBuiltinExecutor(
 		ExecutorID,
-		sdkmodule.ExportValue("nanosecond", sdkmodule.WithValue(sdktypes.NewIntegerValue(int64(time.Nanosecond)))),
-		sdkmodule.ExportValue("microsecond", sdkmodule.WithValue(sdktypes.NewIntegerValue(int64(time.Microsecond)))),
-		sdkmodule.ExportValue("millisecond", sdkmodule.WithValue(sdktypes.NewIntegerValue(int64(time.Millisecond)))),
-		sdkmodule.ExportValue("second", sdkmodule.WithValue(sdktypes.NewIntegerValue(int64(time.Second)))),
-		sdkmodule.ExportValue("minute", sdkmodule.WithValue(sdktypes.NewIntegerValue(int64(time.Minute)))),
-		sdkmodule.ExportValue("hour", sdkmodule.WithValue(sdktypes.NewIntegerValue(int64(time.Hour)))),
+		sdkmodule.ExportValue("nanosecond", sdkmodule.WithValue(sdktypes.NewIntegerValue(time.Nanosecond))),
+		sdkmodule.ExportValue("microsecond", sdkmodule.WithValue(sdktypes.NewIntegerValue(time.Microsecond))),
+		sdkmodule.ExportValue("millisecond", sdkmodule.WithValue(sdktypes.NewIntegerValue(time.Millisecond))),
+		sdkmodule.ExportValue("second", sdkmodule.WithValue(sdktypes.NewIntegerValue(time.Second))),
+		sdkmodule.ExportValue("minute", sdkmodule.WithValue(sdktypes.NewIntegerValue(time.Minute))),
+		sdkmodule.ExportValue("hour", sdkmodule.WithValue(sdktypes.NewIntegerValue(time.Hour))),
 
 		sdkmodule.ExportFunction("time", newTime, sdkmodule.WithArgs("year?", "month?", "day?", "hour?", "minute?", "second?", "nanosecond?", "location?"), sdkmodule.WithFlag(sdktypes.PureFunctionFlag)),
 		sdkmodule.ExportFunction("parse_time", parseTime, sdkmodule.WithArgs("s", "format?", "location?"), sdkmodule.WithFlag(sdktypes.PureFunctionFlag)),

--- a/runtimes/starlarkrt/internal/values/convert.go
+++ b/runtimes/starlarkrt/internal/values/convert.go
@@ -129,7 +129,7 @@ func (vctx *Context) FromStarlarkValue(v starlark.Value) (sdktypes.Value, error)
 		// TODO: Not sure that starlark's assumption that string and bytes are the same in go.
 		return sdktypes.NewBytesValue([]byte(v)), nil
 	case starlark.Float:
-		return sdktypes.NewFloatValue(float64(v)), nil
+		return sdktypes.NewFloatValue(v), nil
 	case *Symbol:
 		s, err := sdktypes.ParseSymbol(string(*v))
 		if err != nil {

--- a/sdk/sdktypes/value_scalar.go
+++ b/sdk/sdktypes/value_scalar.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"time"
 
+	"golang.org/x/exp/constraints"
+
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -118,8 +120,8 @@ func (IntegerValue) isConcreteValue() {}
 
 func (s IntegerValue) Value() int64 { return s.read().V }
 
-func NewIntegerValue(v int64) Value {
-	return forceFromProto[Value](&ValuePB{Integer: &IntegerValuePB{V: v}})
+func NewIntegerValue[T constraints.Integer](v T) Value {
+	return forceFromProto[Value](&ValuePB{Integer: &IntegerValuePB{V: int64(v)}})
 }
 
 func (v Value) IsInteger() bool          { return v.read().Integer != nil }
@@ -174,8 +176,8 @@ func (FloatValue) isConcreteValue() {}
 
 func (s FloatValue) Value() float64 { return s.read().V }
 
-func NewFloatValue(v float64) Value {
-	return forceFromProto[Value](&ValuePB{Float: &FloatValuePB{V: v}})
+func NewFloatValue[T constraints.Float](v T) Value {
+	return forceFromProto[Value](&ValuePB{Float: &FloatValuePB{V: float64(v)}})
 }
 
 func (v Value) IsFloat() bool        { return v.read().Float != nil }


### PR DESCRIPTION
now accept any integer or flow, no need for explicit casting