### PR TITLE
Add munch to Python requirements

### DIFF
--- a/runtimes/pythonrt/requirements.txt
+++ b/runtimes/pythonrt/requirements.txt
@@ -14,5 +14,6 @@ twilio ~= 9.0
 
 # General
 
+munch ~= 4.0
 PyYAML ~= 6.0
 requests ~= 2.31


### PR DESCRIPTION
Add https://github.com/Infinidat/munch to our Python requirements list.

Munch allows scripts to convert JSON-based dictionaries with arbitrary structure into struct-like objects, i.e. dynamically convert dict keys into object attributes.

See example usage in https://github.com/autokitteh/samples/pull/82