### PR TITLE
reorder event_record primary key

### DIFF
--- a/internal/backend/db/dbgorm/scheme/scheme.go
+++ b/internal/backend/db/dbgorm/scheme/scheme.go
@@ -248,8 +248,8 @@ func ParseEvent(e Event) (sdktypes.Event, error) {
 }
 
 type EventRecord struct {
-	Seq       uint32        `gorm:"primaryKey"`
 	EventID   sdktypes.UUID `gorm:"primaryKey;type:uuid;not null"`
+	Seq       uint32        `gorm:"primaryKey"`
 	State     int32         `gorm:"index"`
 	CreatedAt time.Time
 

--- a/migrations/postgres/20240526072213_reorg-event-record-primary-key.sql
+++ b/migrations/postgres/20240526072213_reorg-event-record-primary-key.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+-- modify "event_records" table
+ALTER TABLE "event_records" DROP CONSTRAINT "event_records_pkey", ADD PRIMARY KEY ("event_id", "seq");
+
+-- +goose Down
+-- reverse: modify "event_records" table
+ALTER TABLE "event_records" DROP CONSTRAINT "event_records_pkey", ADD PRIMARY KEY ("seq", "event_id");

--- a/migrations/postgres/atlas.sum
+++ b/migrations/postgres/atlas.sum
@@ -1,4 +1,4 @@
-h1:NrklNkDu+OS2QvtC0nGnprI5gtKaljnd16Bj31Z7oYo=
+h1:Zd7Ps6xJIgV1P5Xs4F5fXndw+rkiwDAPcW9mPKa82To=
 20240507104234_baseline.sql h1:u+/m2oVxbl8ocxuOGDK5ZvK1FSiFFDWpyDIY9lFOXv4=
 20240508111542_secret-string-value.sql h1:LMcOKQmbE418Nmj2HwOaRv6d2X8UQnblUh79EwLsamU=
 20240515105256_trigger_opional_connection.sql h1:Yf5xwhI8IpZXfrOvbi7wwWcmggl2f5Z2shOulpxwT0M=
@@ -6,3 +6,4 @@ h1:NrklNkDu+OS2QvtC0nGnprI5gtKaljnd16Bj31Z7oYo=
 20240517051313_conn-status.sql h1:Znc5Lu8rusof/IfieCDf/TvW8tG1LyGCGwfjKrkF/Mw=
 20240522074209_project_name_non_unique_index.sql h1:+XwG1fO/hBGfjWfZwoXHI0MJYCoVrOzDaivQDV8VSVE=
 20240522102628_revert-trigger-optional-connection.sql h1:Ww/LjXR7+BdBzqP5Kh3MkI8Wnu681D0yB+HsE0dyiNg=
+20240526072213_reorg-event-record-primary-key.sql h1:k0g4a1R5h6TcRcDRti+wDPlHCVgYphtpGBUqEjtTHeI=

--- a/migrations/sqlite/20240526072209_reorg-event-record-primary-key.sql
+++ b/migrations/sqlite/20240526072209_reorg-event-record-primary-key.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+-- disable the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = off;
+-- create "new_event_records" table
+CREATE TABLE `new_event_records` (
+  `event_id` uuid NOT NULL,
+  `seq` integer NULL,
+  `state` integer NULL,
+  `created_at` datetime NULL,
+  PRIMARY KEY (`event_id`, `seq`),
+  CONSTRAINT `fk_event_records_event` FOREIGN KEY (`event_id`) REFERENCES `events` (`event_id`) ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+-- copy rows from old table "event_records" to new temporary table "new_event_records"
+INSERT INTO `new_event_records` (`event_id`, `seq`, `state`, `created_at`) SELECT `event_id`, `seq`, `state`, `created_at` FROM `event_records`;
+-- drop "event_records" table after copying rows
+DROP TABLE `event_records`;
+-- rename temporary table "new_event_records" to "event_records"
+ALTER TABLE `new_event_records` RENAME TO `event_records`;
+-- create index "idx_event_records_state" to table: "event_records"
+CREATE INDEX `idx_event_records_state` ON `event_records` (`state`);
+-- enable back the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = on;
+
+-- +goose Down
+-- reverse: create index "idx_event_records_state" to table: "event_records"
+DROP INDEX `idx_event_records_state`;
+-- reverse: create "new_event_records" table
+DROP TABLE `new_event_records`;

--- a/migrations/sqlite/atlas.sum
+++ b/migrations/sqlite/atlas.sum
@@ -1,4 +1,4 @@
-h1:ihpFvXAd7t6WvVGqbgXm/lP2SnkiIFrugKROl4HFCwQ=
+h1:0O/IEgGjIyRjWxNMvaGgw1sozEiME88+5iNbo+d9nFM=
 20240507104228_baseline.sql h1:4B9CvzNeSNzEwATnxtK+d00ATCaSZHyr0dwmeuO06RA=
 20240508111539_secret-string-value.sql h1:dMpp/HpoRd49wXOZiPKt+Fxjns7Kc4x/aSOvBfLgU6E=
 20240515105250_trigger_opional_connection.sql h1:X1SRwT9f2BaswD0wPgqoK5E0NaEyQ4P3r94nMu4WXjA=
@@ -6,3 +6,4 @@ h1:ihpFvXAd7t6WvVGqbgXm/lP2SnkiIFrugKROl4HFCwQ=
 20240517051309_conn-status.sql h1:SrCkbS4tTg//jxGzpYBnHzxAdVacoV8TOH0YbEqHclI=
 20240522074202_project_name_non_unique_index.sql h1:bhgBOGFczZQQKnR/Ll01YCGNDyC3uPbFKgKpc9S7nVY=
 20240522102623_revert-trigger-optional-connection.sql h1:17Yoa7IVN10VE5o6G+cu+zejIu59kAoL0tXlAUMlCTs=
+20240526072209_reorg-event-record-primary-key.sql h1:0eboRyR4kgfXRBZdCYrsvJbSQTP0eOxdrXUNADz2AiA=


### PR DESCRIPTION
we query for event records by event id
current primary key was (seq, event_id) causing
query by event_id to be slow
since we never query by seq first, primary key is now (event_id, seq), allowing to query by event id only