### PR TITLE
ENG-913: compress session and event data

### DIFF
--- a/internal/backend/db/dbgorm/dbgorm_test.go
+++ b/internal/backend/db/dbgorm/dbgorm_test.go
@@ -1,0 +1,29 @@
+package dbgorm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompressJSON(t *testing.T) {
+	db := &gormdb{
+		compressionThreshold: 1024,
+	}
+
+	u, c, err := db.compressJSON("meow")
+	if assert.NoError(t, err) {
+		assert.Equal(t, string(u), `"meow"`)
+		assert.Nil(t, c)
+	}
+
+	bs := []byte(strings.Repeat("meow", 512))
+
+	u, c, err = db.compressJSON(bs)
+	if assert.NoError(t, err) {
+		assert.Nil(t, u)
+		assert.NotNil(t, c)
+		t.Logf("compressed: %d -> %d", len(bs), len(c))
+	}
+}

--- a/internal/backend/db/dbgorm/events.go
+++ b/internal/backend/db/dbgorm/events.go
@@ -22,13 +22,18 @@ func (db *gormdb) SaveEvent(ctx context.Context, event sdktypes.Event) error {
 
 	cid := event.ConnectionID() // could be invalid/zero
 
+	cdata, err := scheme.CompressJSON(event.Data())
+	if err != nil {
+		return err
+	}
+
 	e := scheme.Event{
-		EventID:      event.ID().UUIDValue(),
-		ConnectionID: scheme.UUIDOrNil(cid.UUIDValue()),
-		EventType:    event.Type(),
-		Data:         kittehs.Must1(json.Marshal(event.Data())),
-		Memo:         kittehs.Must1(json.Marshal(event.Memo())),
-		CreatedAt:    event.CreatedAt(),
+		EventID:        event.ID().UUIDValue(),
+		ConnectionID:   scheme.UUIDOrNil(cid.UUIDValue()),
+		EventType:      event.Type(),
+		CompressedData: cdata,
+		Memo:           kittehs.Must1(json.Marshal(event.Memo())),
+		CreatedAt:      event.CreatedAt(),
 	}
 
 	if cid.IsValid() { // only if exists

--- a/internal/backend/db/dbgorm/events.go
+++ b/internal/backend/db/dbgorm/events.go
@@ -22,7 +22,7 @@ func (db *gormdb) SaveEvent(ctx context.Context, event sdktypes.Event) error {
 
 	cid := event.ConnectionID() // could be invalid/zero
 
-	cdata, err := scheme.CompressJSON(event.Data())
+	data, cdata, err := db.compressJSON(event.Data())
 	if err != nil {
 		return err
 	}
@@ -31,6 +31,7 @@ func (db *gormdb) SaveEvent(ctx context.Context, event sdktypes.Event) error {
 		EventID:        event.ID().UUIDValue(),
 		ConnectionID:   scheme.UUIDOrNil(cid.UUIDValue()),
 		EventType:      event.Type(),
+		Data:           data,
 		CompressedData: cdata,
 		Memo:           kittehs.Must1(json.Marshal(event.Memo())),
 		CreatedAt:      event.CreatedAt(),

--- a/internal/backend/db/dbgorm/scheme/scheme.go
+++ b/internal/backend/db/dbgorm/scheme/scheme.go
@@ -67,25 +67,6 @@ func unmarshalData(dst any, j datatypes.JSON, c []byte) error {
 	return json.Unmarshal(j, dst)
 }
 
-func CompressJSON(data any) (datatypes.JSON, error) {
-	j, err := json.Marshal(data)
-	if err != nil {
-		return nil, fmt.Errorf("json: %w", err)
-	}
-
-	var b bytes.Buffer
-	w := gzip.NewWriter(&b)
-	if _, err = w.Write(j); err != nil {
-		return nil, fmt.Errorf("compress: %w", err)
-	}
-
-	if err = w.Close(); err != nil {
-		return nil, fmt.Errorf("compress: %w", err)
-	}
-
-	return datatypes.JSON(b.Bytes()), nil
-}
-
 type Build struct {
 	BuildID   sdktypes.UUID `gorm:"primaryKey;type:uuid;not null"`
 	Data      []byte

--- a/internal/backend/gormkitteh/config.go
+++ b/internal/backend/gormkitteh/config.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"strings"
 	"time"
+
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
 )
 
 const RequireExplicitDSNType = "require"
@@ -25,6 +27,18 @@ type Config struct {
 	// If false, the server will fail to start if a migration is required,
 	// and the user has to run 'ak server migrate' explicitly.
 	AutoMigrate bool `koanf:"auto_migrate"`
+
+	Options string `koanf:"options"`
+}
+
+func (c Config) ParseOptions() map[string]string {
+	opts := make(map[string]string)
+	parts := kittehs.Transform(strings.Split(c.Options, ","), strings.TrimSpace)
+	for _, part := range parts {
+		k, v, _ := strings.Cut(part, "=")
+		opts[k] = v
+	}
+	return opts
 }
 
 func (c Config) Explicit() (*Config, error) {

--- a/migrations/postgres/20240527045144_compressed-data.sql
+++ b/migrations/postgres/20240527045144_compressed-data.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- modify "events" table
+ALTER TABLE "events" ADD COLUMN "compressed_data" bytea NULL;
+-- modify "session_call_attempts" table
+ALTER TABLE "session_call_attempts" ADD COLUMN "compressed_complete" bytea NULL;
+-- modify "session_call_specs" table
+ALTER TABLE "session_call_specs" ADD COLUMN "compressed_data" bytea NULL;
+-- modify "sessions" table
+ALTER TABLE "sessions" ADD COLUMN "compressed_inputs" bytea NULL;
+
+-- +goose Down
+-- reverse: modify "sessions" table
+ALTER TABLE "sessions" DROP COLUMN "compressed_inputs";
+-- reverse: modify "session_call_specs" table
+ALTER TABLE "session_call_specs" DROP COLUMN "compressed_data";
+-- reverse: modify "session_call_attempts" table
+ALTER TABLE "session_call_attempts" DROP COLUMN "compressed_complete";
+-- reverse: modify "events" table
+ALTER TABLE "events" DROP COLUMN "compressed_data";

--- a/migrations/postgres/atlas.sum
+++ b/migrations/postgres/atlas.sum
@@ -1,4 +1,4 @@
-h1:Zd7Ps6xJIgV1P5Xs4F5fXndw+rkiwDAPcW9mPKa82To=
+h1:tqcvvYN+xMhTrsdQ4Im6SUYGX8s3CjGuta5MZM2ivsw=
 20240507104234_baseline.sql h1:u+/m2oVxbl8ocxuOGDK5ZvK1FSiFFDWpyDIY9lFOXv4=
 20240508111542_secret-string-value.sql h1:LMcOKQmbE418Nmj2HwOaRv6d2X8UQnblUh79EwLsamU=
 20240515105256_trigger_opional_connection.sql h1:Yf5xwhI8IpZXfrOvbi7wwWcmggl2f5Z2shOulpxwT0M=
@@ -7,3 +7,4 @@ h1:Zd7Ps6xJIgV1P5Xs4F5fXndw+rkiwDAPcW9mPKa82To=
 20240522074209_project_name_non_unique_index.sql h1:+XwG1fO/hBGfjWfZwoXHI0MJYCoVrOzDaivQDV8VSVE=
 20240522102628_revert-trigger-optional-connection.sql h1:Ww/LjXR7+BdBzqP5Kh3MkI8Wnu681D0yB+HsE0dyiNg=
 20240526072213_reorg-event-record-primary-key.sql h1:k0g4a1R5h6TcRcDRti+wDPlHCVgYphtpGBUqEjtTHeI=
+20240527045144_compressed-data.sql h1:wiDpUkeH+qaXtrC0tWm1c1HaJIx6t0to0MPAcVSZOmA=

--- a/migrations/sqlite/20240527045140_compressed-data.sql
+++ b/migrations/sqlite/20240527045140_compressed-data.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- add column "compressed_inputs" to table: "sessions"
+ALTER TABLE `sessions` ADD COLUMN `compressed_inputs` blob NULL;
+-- add column "compressed_complete" to table: "session_call_attempts"
+ALTER TABLE `session_call_attempts` ADD COLUMN `compressed_complete` blob NULL;
+-- add column "compressed_data" to table: "session_call_specs"
+ALTER TABLE `session_call_specs` ADD COLUMN `compressed_data` blob NULL;
+-- add column "compressed_data" to table: "events"
+ALTER TABLE `events` ADD COLUMN `compressed_data` blob NULL;
+
+-- +goose Down
+-- reverse: add column "compressed_data" to table: "events"
+ALTER TABLE `events` DROP COLUMN `compressed_data`;
+-- reverse: add column "compressed_data" to table: "session_call_specs"
+ALTER TABLE `session_call_specs` DROP COLUMN `compressed_data`;
+-- reverse: add column "compressed_complete" to table: "session_call_attempts"
+ALTER TABLE `session_call_attempts` DROP COLUMN `compressed_complete`;
+-- reverse: add column "compressed_inputs" to table: "sessions"
+ALTER TABLE `sessions` DROP COLUMN `compressed_inputs`;

--- a/migrations/sqlite/atlas.sum
+++ b/migrations/sqlite/atlas.sum
@@ -1,4 +1,4 @@
-h1:0O/IEgGjIyRjWxNMvaGgw1sozEiME88+5iNbo+d9nFM=
+h1:0sooyk3bwj+rggHjoEZ0ygQiZK4IMf4ifgtU4vBOeKg=
 20240507104228_baseline.sql h1:4B9CvzNeSNzEwATnxtK+d00ATCaSZHyr0dwmeuO06RA=
 20240508111539_secret-string-value.sql h1:dMpp/HpoRd49wXOZiPKt+Fxjns7Kc4x/aSOvBfLgU6E=
 20240515105250_trigger_opional_connection.sql h1:X1SRwT9f2BaswD0wPgqoK5E0NaEyQ4P3r94nMu4WXjA=
@@ -7,3 +7,4 @@ h1:0O/IEgGjIyRjWxNMvaGgw1sozEiME88+5iNbo+d9nFM=
 20240522074202_project_name_non_unique_index.sql h1:bhgBOGFczZQQKnR/Ll01YCGNDyC3uPbFKgKpc9S7nVY=
 20240522102623_revert-trigger-optional-connection.sql h1:17Yoa7IVN10VE5o6G+cu+zejIu59kAoL0tXlAUMlCTs=
 20240526072209_reorg-event-record-primary-key.sql h1:0eboRyR4kgfXRBZdCYrsvJbSQTP0eOxdrXUNADz2AiA=
+20240527045140_compressed-data.sql h1:9Iz6KM76tu6iZiIN47tF9R6dUbEszk8Bno4/whkPwuM=


### PR DESCRIPTION
compress session and event data in order to save db space. this is backward compatible as it can read non-compress data as well.

compression happens only if payload is bigger than configured threshold. threshold is configured by supplying an extra option in configuration. default is 4k.