### PR TITLE
[ENG-931] Attribute access to event data

### DIFF
--- a/runtimes/pythonrt/ak_runner.py
+++ b/runtimes/pythonrt/ak_runner.py
@@ -329,6 +329,25 @@ def module_entries(mod):
     ]
 
 
+class AttrDict(dict):
+    """Allow attribute access to dictionary keys.
+
+    >>> config = AttrDict({'server': {'port': 8080}, 'debug': True})
+    >>> config.server.port
+    8080
+    >>> config.debug
+    True
+    """
+    def __getattr__(self, name):
+        try:
+            value = self[name]
+            if isinstance(value, dict):
+                value = AttrDict(value)
+            return value
+        except KeyError:
+            raise AttributeError(name)
+
+
 if __name__ == '__main__':
     import sys
     from argparse import ArgumentParser
@@ -388,5 +407,6 @@ if __name__ == '__main__':
         except ValueError:
             pass
 
+    event = AttrDict(event)
     fn(event)
     comm.send_done()

--- a/runtimes/pythonrt/ak_runner.py
+++ b/runtimes/pythonrt/ak_runner.py
@@ -347,6 +347,11 @@ class AttrDict(dict):
         except KeyError:
             raise AttributeError(name)
 
+    def __setattr__(self, attr, value):
+        # The default __getattr__ doesn't fail but also don't change values
+        cls = self.__class__.__name__
+        raise NotImplementedError(f'{cls} does not support setting attributes')
+
 
 if __name__ == '__main__':
     import sys

--- a/runtimes/pythonrt/ak_runner_test.py
+++ b/runtimes/pythonrt/ak_runner_test.py
@@ -307,3 +307,6 @@ def test_AttrDict():
     })
     assert cfg['server']['port'] == cfg.server.port
     assert cfg['mode'] == cfg.mode
+
+    with pytest.raises(NotImplementedError):
+        cfg.server.port = 8081

--- a/runtimes/pythonrt/ak_runner_test.py
+++ b/runtimes/pythonrt/ak_runner_test.py
@@ -292,3 +292,18 @@ def test_activity():
     mod = ak_runner.load_code('testdata', lambda f: f, mod_name)
     fn = mod.phone_home
     assert getattr(fn, ak_runner.ACTIVITY_ATTR, False)
+
+
+def test_AttrDict():
+    cfg = ak_runner.AttrDict({
+        'server': {
+            'port': 8080,
+            'interface': 'localhost',
+        },
+        'mode': 'dev',
+        'logging': {
+            'level': 'info',
+        },
+    })
+    assert cfg['server']['port'] == cfg.server.port
+    assert cfg['mode'] == cfg.mode


### PR DESCRIPTION
This allows users to write `event.data.body` as well as `event['data']['body']`