### PR TITLE
fix: cant delete connections due to fk constrain

### DIFF
--- a/internal/backend/db/dbgorm/connections_test.go
+++ b/internal/backend/db/dbgorm/connections_test.go
@@ -19,7 +19,7 @@ func (f *dbFixture) createConnectionsAndAssert(t *testing.T, connections ...sche
 
 func (f *dbFixture) assertConnectionDeleted(t *testing.T, connections ...scheme.Connection) {
 	for _, connection := range connections {
-		assertDeleted(t, f, connection)
+		assertSoftDeleted(t, f, connection)
 	}
 }
 
@@ -74,4 +74,20 @@ func TestDeleteConnection(t *testing.T) {
 	// test deleteConnection
 	assert.NoError(t, f.gormdb.deleteConnection(f.ctx, c.ConnectionID))
 	f.assertConnectionDeleted(t, c)
+}
+
+func TestDeleteConnectionForeignKeys(t *testing.T) {
+	f := preConnectionTest(t)
+
+	c := f.newConnection()
+	f.createConnectionsAndAssert(t, c)
+
+	evt := f.newEvent()
+	evt.ConnectionID = &c.ConnectionID
+	f.createEventsAndAssert(t, evt)
+	// also trigger and signal are dependant on connection
+
+	// test deleteConnection
+	assert.NoError(t, f.gormdb.deleteConnection(f.ctx, c.ConnectionID))
+	f.assertConnectionDeleted(t, c) // soft deleted, dependent object won't complain
 }

--- a/internal/backend/db/dbgorm/events_test.go
+++ b/internal/backend/db/dbgorm/events_test.go
@@ -95,7 +95,7 @@ func TestListEventsDefaultOrder(t *testing.T) {
 	require.Equal(t, evs[1].ID().UUIDValue(), ev1.EventID)
 }
 
-func TestListEventsDescOrder(t *testing.T) {
+func TestListEventsOrder(t *testing.T) {
 	f := newDBFixture()
 	foreignKeys(f.gormdb, false) // no foreign keys
 
@@ -104,33 +104,29 @@ func TestListEventsDescOrder(t *testing.T) {
 	ev2 := f.newEvent()
 	f.createEventsAndAssert(t, ev1, ev2)
 
-	evs, err := f.gormdb.ListEvents(ctx, sdkservices.ListEventsFilter{Order: sdkservices.ListOrderDescending})
+	tests := []struct {
+		name  string
+		order sdkservices.ListOrder
+		ids   [2]uuid.UUID
+	}{
+		{
+			name:  "descending order",
+			order: sdkservices.ListOrderDescending,
+			ids:   [2]uuid.UUID{ev2.EventID, ev1.EventID},
+		},
+		{
+			name:  "ascending order",
+			order: sdkservices.ListOrderAscending,
+			ids:   [2]uuid.UUID{ev1.EventID, ev2.EventID},
+		},
+	}
 
-	require.NoError(t, err)
-
-	require.Equal(t, 2, len(evs), "should be 2 events in db")
-
-	// Desc order is default
-	require.Equal(t, evs[0].ID().UUIDValue(), ev2.EventID)
-	require.Equal(t, evs[1].ID().UUIDValue(), ev1.EventID)
-}
-
-func TestListEventsAscOrder(t *testing.T) {
-	f := newDBFixture()
-	foreignKeys(f.gormdb, false) // no foreign keys
-
-	ctx := context.Background()
-	ev1 := f.newEvent()
-	ev2 := f.newEvent()
-	f.createEventsAndAssert(t, ev1, ev2)
-
-	evs, err := f.gormdb.ListEvents(ctx, sdkservices.ListEventsFilter{Order: sdkservices.ListOrderAscending})
-
-	require.NoError(t, err)
-
-	require.Equal(t, 2, len(evs), "should be 2 events in db")
-
-	// Desc order is default
-	require.Equal(t, evs[0].ID().UUIDValue(), ev1.EventID)
-	require.Equal(t, evs[1].ID().UUIDValue(), ev2.EventID)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evs, err := f.gormdb.ListEvents(ctx, sdkservices.ListEventsFilter{Order: tt.order})
+			require.NoError(t, err)
+			require.Equal(t, 2, len(evs), "should be 2 events in db")
+			require.Equal(t, tt.ids, [2]uuid.UUID{evs[0].ID().UUIDValue(), evs[1].ID().UUIDValue()})
+		})
+	}
 }

--- a/internal/backend/db/dbgorm/events_test.go
+++ b/internal/backend/db/dbgorm/events_test.go
@@ -64,10 +64,9 @@ func TestCreateEventForeignKeys(t *testing.T) {
 
 func TestDeleteEvent(t *testing.T) {
 	f := newDBFixture()
-	foreignKeys(f.gormdb, false)                  // no foreign keys
 	findAndAssertCount[scheme.Event](t, f, 0, "") // no events
 
-	evt := f.newEvent()
+	evt := f.newEvent() // connection is nil
 	f.createEventsAndAssert(t, evt)
 
 	// test deleteEvent

--- a/internal/backend/db/dbgorm/scheme/scheme.go
+++ b/internal/backend/db/dbgorm/scheme/scheme.go
@@ -76,6 +76,8 @@ type Connection struct {
 	StatusCode    int32 `gorm:"index"`
 	StatusMessage string
 
+	DeletedAt gorm.DeletedAt `gorm:"index"`
+
 	// enforce foreign keys
 	// Integration *Integration FIXME: ENG-590
 	Project *Project

--- a/migrations/postgres/20240528162859_connection_soft_delete.sql
+++ b/migrations/postgres/20240528162859_connection_soft_delete.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- modify "connections" table
+ALTER TABLE "connections" ADD COLUMN "deleted_at" timestamptz NULL;
+-- create index "idx_connections_deleted_at" to table: "connections"
+CREATE INDEX "idx_connections_deleted_at" ON "connections" ("deleted_at");
+
+-- +goose Down
+-- reverse: create index "idx_connections_deleted_at" to table: "connections"
+DROP INDEX "idx_connections_deleted_at";
+-- reverse: modify "connections" table
+ALTER TABLE "connections" DROP COLUMN "deleted_at";

--- a/migrations/postgres/atlas.sum
+++ b/migrations/postgres/atlas.sum
@@ -1,4 +1,4 @@
-h1:Zd7Ps6xJIgV1P5Xs4F5fXndw+rkiwDAPcW9mPKa82To=
+h1:l+xJxD4sjq+SN8ZD6XRMpIyHILU4zkspsf7XXE7U/kw=
 20240507104234_baseline.sql h1:u+/m2oVxbl8ocxuOGDK5ZvK1FSiFFDWpyDIY9lFOXv4=
 20240508111542_secret-string-value.sql h1:LMcOKQmbE418Nmj2HwOaRv6d2X8UQnblUh79EwLsamU=
 20240515105256_trigger_opional_connection.sql h1:Yf5xwhI8IpZXfrOvbi7wwWcmggl2f5Z2shOulpxwT0M=
@@ -7,3 +7,4 @@ h1:Zd7Ps6xJIgV1P5Xs4F5fXndw+rkiwDAPcW9mPKa82To=
 20240522074209_project_name_non_unique_index.sql h1:+XwG1fO/hBGfjWfZwoXHI0MJYCoVrOzDaivQDV8VSVE=
 20240522102628_revert-trigger-optional-connection.sql h1:Ww/LjXR7+BdBzqP5Kh3MkI8Wnu681D0yB+HsE0dyiNg=
 20240526072213_reorg-event-record-primary-key.sql h1:k0g4a1R5h6TcRcDRti+wDPlHCVgYphtpGBUqEjtTHeI=
+20240528162859_connection_soft_delete.sql h1:cWy3NUSV+EBbq/2hFcyuihRVKciv2ea0zVCngvlmzY0=

--- a/migrations/sqlite/20240528162850_connection_soft_delete.sql
+++ b/migrations/sqlite/20240528162850_connection_soft_delete.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- add column "deleted_at" to table: "connections"
+ALTER TABLE `connections` ADD COLUMN `deleted_at` datetime NULL;
+-- create index "idx_connections_deleted_at" to table: "connections"
+CREATE INDEX `idx_connections_deleted_at` ON `connections` (`deleted_at`);
+
+-- +goose Down
+-- reverse: create index "idx_connections_deleted_at" to table: "connections"
+DROP INDEX `idx_connections_deleted_at`;
+-- reverse: add column "deleted_at" to table: "connections"
+ALTER TABLE `connections` DROP COLUMN `deleted_at`;

--- a/migrations/sqlite/atlas.sum
+++ b/migrations/sqlite/atlas.sum
@@ -1,4 +1,4 @@
-h1:0O/IEgGjIyRjWxNMvaGgw1sozEiME88+5iNbo+d9nFM=
+h1:XVPjI+aIM3aguhwHWHTKH5WHVAuTmWlcUN/LoOAJmqs=
 20240507104228_baseline.sql h1:4B9CvzNeSNzEwATnxtK+d00ATCaSZHyr0dwmeuO06RA=
 20240508111539_secret-string-value.sql h1:dMpp/HpoRd49wXOZiPKt+Fxjns7Kc4x/aSOvBfLgU6E=
 20240515105250_trigger_opional_connection.sql h1:X1SRwT9f2BaswD0wPgqoK5E0NaEyQ4P3r94nMu4WXjA=
@@ -7,3 +7,4 @@ h1:0O/IEgGjIyRjWxNMvaGgw1sozEiME88+5iNbo+d9nFM=
 20240522074202_project_name_non_unique_index.sql h1:bhgBOGFczZQQKnR/Ll01YCGNDyC3uPbFKgKpc9S7nVY=
 20240522102623_revert-trigger-optional-connection.sql h1:17Yoa7IVN10VE5o6G+cu+zejIu59kAoL0tXlAUMlCTs=
 20240526072209_reorg-event-record-primary-key.sql h1:0eboRyR4kgfXRBZdCYrsvJbSQTP0eOxdrXUNADz2AiA=
+20240528162850_connection_soft_delete.sql h1:70VAgkLjWYb64pA+7oX5RitQ9E22GinOb4MPq4NDT6Y=


### PR DESCRIPTION
event is dependent on connection. Since event is soft-deleted, then connection should be soft-deleted as well