### PR TITLE
ENG-894: load connection variables into env

### DIFF
--- a/cmd/ak/cmd/sessions/start.go
+++ b/cmd/ak/cmd/sessions/start.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"go.autokitteh.dev/autokitteh/cmd/ak/common"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/internal/resolver"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
@@ -64,7 +63,6 @@ func init() {
 	startCmd.MarkFlagsOneRequired("deployment-id", "build-id")
 
 	startCmd.Flags().StringVarP(&entryPoint, "entrypoint", "p", "", `entry point ("file:function")`)
-	kittehs.Must0(startCmd.MarkFlagRequired("entrypoint"))
 
 	startCmd.Flags().StringSliceVarP(&memos, "memo", "m", nil, `zero or more "key=value" pairs`)
 

--- a/internal/backend/sessions/sessionworkflows/workflow.go
+++ b/internal/backend/sessions/sessionworkflows/workflow.go
@@ -295,7 +295,7 @@ func (w *sessionWorkflow) createEventSubscription(ctx context.Context, connectio
 		return "", fmt.Errorf("get current sequence: %w", err)
 	}
 
-	signalID := uuid.New().String() // fmt.Sprintf("wid_%s_cn_%s_seq_%d", workflowID, connectionName, minSequence)
+	signalID := uuid.New().String()
 
 	_, connection := kittehs.FindFirst(w.data.Connections, func(c sdktypes.Connection) bool {
 		return c.Name().String() == connectionName

--- a/internal/backend/sessions/sessionworkflows/workflow.go
+++ b/internal/backend/sessions/sessionworkflows/workflow.go
@@ -3,6 +3,7 @@ package sessionworkflows
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -82,7 +83,9 @@ func runWorkflow(
 		signals: make(map[string]uint64),
 	}
 
-	w.initEnvModule()
+	if err = w.initEnvModule(ctx); err != nil {
+		return
+	}
 
 	if w.globals, err = w.initGlobalModules(); err != nil {
 		return
@@ -176,16 +179,35 @@ func (w *sessionWorkflow) call(ctx workflow.Context, runID sdktypes.RunID, v sdk
 	return result.ToPair()
 }
 
-func (w *sessionWorkflow) initEnvModule() {
+func (w *sessionWorkflow) initEnvModule(wctx workflow.Context) error {
+	goCtx := temporalclient.NewWorkflowContextAsGOContext(wctx)
+
+	vs := kittehs.ListToMap(w.data.Vars, func(v sdktypes.Var) (string, sdktypes.Value) {
+		return v.Name().String(), sdktypes.NewStringValue(v.Value())
+	})
+
+	for _, conn := range w.data.Connections {
+		cid, name := conn.ID(), conn.Name().String()
+
+		cvs, err := w.ws.svcs.Vars.Reveal(goCtx, sdktypes.NewVarScopeID(cid))
+		if err != nil {
+			return fmt.Errorf("get connection %v vars: %w", name, err)
+		}
+
+		maps.Copy(vs, kittehs.ListToMap(cvs, func(v sdktypes.Var) (string, sdktypes.Value) {
+			return fmt.Sprintf("%v__%v", name, v.Name()), sdktypes.NewStringValue(v.Value())
+		}))
+	}
+
 	mod := sdkexecutor.NewExecutor(
 		nil, // no calls will be ever made to env.
 		envVarsExecutorID,
-		kittehs.ListToMap(w.data.Vars, func(v sdktypes.Var) (string, sdktypes.Value) {
-			return v.Name().String(), sdktypes.NewStringValue(v.Value())
-		}),
+		vs,
 	)
 
 	kittehs.Must0(w.executors.AddExecutor(envVarsModuleName, mod))
+
+	return nil
 }
 
 func integrationModulePrefix(name string) string { return fmt.Sprintf("__%v__", name) }
@@ -273,7 +295,7 @@ func (w *sessionWorkflow) createEventSubscription(ctx context.Context, connectio
 		return "", fmt.Errorf("get current sequence: %w", err)
 	}
 
-	signalID := uuid.New().String() //fmt.Sprintf("wid_%s_cn_%s_seq_%d", workflowID, connectionName, minSequence)
+	signalID := uuid.New().String() // fmt.Sprintf("wid_%s_cn_%s_seq_%d", workflowID, connectionName, minSequence)
 
 	_, connection := kittehs.FindFirst(w.data.Connections, func(c sdktypes.Connection) bool {
 		return c.Name().String() == connectionName
@@ -359,7 +381,6 @@ func (w *sessionWorkflow) getNextEvent(ctx context.Context, signalID string) (ma
 			}
 			filter.MinSequenceNumber = evs[0].Seq() + 1
 		}
-
 	}).Get(wctx, &eventID); err != nil {
 		w.z.Panic("get signal", zap.Error(err))
 	}

--- a/tests/system/testdata/connections/vars.txtar
+++ b/tests/system/testdata/connections/vars.txtar
@@ -1,0 +1,29 @@
+
+ak deploy --manifest manifest.yaml
+return code == 0
+
+ak var set test_secret shhhh --secret --connection my_project/my_connection
+return code == 0
+
+ak session start -d dep_00000000000000000000000005 --watch --no-timestamps --entrypoint main.star
+return code == 0
+output contains 'url=test_url'
+output contains 'secret=shhhh'
+
+-- manifest.yaml --
+version: v1
+
+project:
+  name: my_project
+  connections:
+    - name: my_connection
+      integration: http
+      vars:
+        - name: url
+          value: test_url
+
+-- main.star --
+load("env", "my_connection__url", "my_connection__test_secret")
+
+print("url={}".format(my_connection__url))
+print("secret={}".format(my_connection__test_secret))

--- a/tests/system/testdata/sessions/start.txtar
+++ b/tests/system/testdata/sessions/start.txtar
@@ -6,11 +6,6 @@ ak project build my_project --file main.star
 return code == 0
 output equals 'build_id: bld_00000000000000000000000003'
 
-# Negative tests: start session without required flags.
-ak session start
-output equals 'Error: required flag(s) "entrypoint" not set'
-return code == 1
-
 ak session start --entrypoint main.star:main
 output equals 'Error: at least one of the flags in the group [deployment-id build-id] is required'
 return code == 1


### PR DESCRIPTION
Each connection's variables (which also include secrets) are loaded into env with key "{conn_name}__{var_key}". This should allow python code to load them and reuse them when initializing libraries.