### PR TITLE
fix (sdk): unwrapping embedded time.Time

### DIFF
--- a/sdk/sdktypes/value_wrap.go
+++ b/sdk/sdktypes/value_wrap.go
@@ -84,6 +84,7 @@ func (w ValueWrapper) Wrap(v any) (Value, error) {
 
 		for _, vfs := range reflect.VisibleFields(vt) {
 			if !vfs.IsExported() || vfs.Anonymous {
+				// allow to wrap embedded unexported time.Time field
 				if vfs.Type != reflect.TypeOf(time.Time{}) {
 					continue
 				}

--- a/sdk/sdktypes/value_wrap.go
+++ b/sdk/sdktypes/value_wrap.go
@@ -84,7 +84,9 @@ func (w ValueWrapper) Wrap(v any) (Value, error) {
 
 		for _, vfs := range reflect.VisibleFields(vt) {
 			if !vfs.IsExported() || vfs.Anonymous {
-				continue
+				if vfs.Type != reflect.TypeOf(time.Time{}) {
+					continue
+				}
 			}
 
 			fv := vv.FieldByIndex(vfs.Index)

--- a/sdk/sdktypes/value_wrap_test.go
+++ b/sdk/sdktypes/value_wrap_test.go
@@ -422,36 +422,3 @@ func TestUnwrapNothing(t *testing.T) {
 	var i int
 	assert.Error(t, sdktypes.UnwrapValueInto(&i, sdktypes.Nothing))
 }
-
-func TestUnwrapIntoKitchenSink1(t *testing.T) {
-	type Y struct {
-		Z string
-	}
-	type Timestamp struct {
-		time.Time
-	}
-
-	type X struct {
-		//D   time.Duration
-		//InS struct {
-		//	T time.Time
-		//}
-		T Timestamp
-	}
-
-	in := X{
-		// D:   time.Hour,
-		// InS: struct{ T time.Time }{T: time.Date(2023, time.January, 1, 18, 32, 0, 0, time.UTC)},
-		T: Timestamp{time.Date(2023, time.January, 1, 18, 32, 0, 0, time.UTC)},
-	}
-
-	w := sdktypes.DefaultValueWrapper
-
-	var x X
-
-	wx := kittehs.Must1(w.Wrap(in))
-
-	if assert.NoError(t, w.UnwrapInto(&x, wx)) {
-		assert.Equal(t, in, x)
-	}
-}

--- a/sdk/sdktypes/value_wrap_test.go
+++ b/sdk/sdktypes/value_wrap_test.go
@@ -361,6 +361,10 @@ func TestUnwrapIntoKitchenSink(t *testing.T) {
 		Z string
 	}
 
+	type Timestamp struct {
+		time.Time // embedded, not-exported
+	}
+
 	type X struct {
 		I64       int64
 		S         string
@@ -381,26 +385,30 @@ func TestUnwrapIntoKitchenSink(t *testing.T) {
 		InS       struct {
 			T time.Time
 		}
+		Timestamp struct {
+			time.Time // embeeded, unnnamed, non-exported
+		}
 	}
 
 	True := true
 
 	in := X{
-		I64:   42,
-		S:     "meow",
-		B:     true,
-		F:     4.2,
-		A2:    [2]string{"meow", "woof"},
-		M:     map[int]string{1: "one", 7: "seven"},
-		Set:   map[string]bool{"one": true, "two": false},
-		Sl:    []float32{1.2, 3.4},
-		StsA:  [3]Y{{Z: "first"}, {Z: "second"}, {Z: "third"}},
-		StsS:  []Y{{Z: "uno"}, {Z: "dos"}, {Z: "tres"}},
-		Bptr:  &True,
-		Sptr:  &Y{Z: "neo"},
-		SptrS: []*Y{{Z: "meow"}, nil, {Z: "woof"}},
-		D:     time.Hour,
-		InS:   struct{ T time.Time }{T: time.Date(2023, time.January, 1, 18, 32, 0, 0, time.UTC)},
+		I64:       42,
+		S:         "meow",
+		B:         true,
+		F:         4.2,
+		A2:        [2]string{"meow", "woof"},
+		M:         map[int]string{1: "one", 7: "seven"},
+		Set:       map[string]bool{"one": true, "two": false},
+		Sl:        []float32{1.2, 3.4},
+		StsA:      [3]Y{{Z: "first"}, {Z: "second"}, {Z: "third"}},
+		StsS:      []Y{{Z: "uno"}, {Z: "dos"}, {Z: "tres"}},
+		Bptr:      &True,
+		Sptr:      &Y{Z: "neo"},
+		SptrS:     []*Y{{Z: "meow"}, nil, {Z: "woof"}},
+		D:         time.Hour,
+		InS:       struct{ T time.Time }{T: time.Date(2023, time.January, 1, 18, 32, 0, 0, time.UTC)},
+		Timestamp: struct{ time.Time }{time.Date(2023, time.January, 1, 18, 32, 0, 0, time.UTC)},
 	}
 
 	w := sdktypes.DefaultValueWrapper
@@ -417,4 +425,37 @@ func TestUnwrapIntoKitchenSink(t *testing.T) {
 func TestUnwrapNothing(t *testing.T) {
 	var i int
 	assert.Error(t, sdktypes.UnwrapValueInto(&i, sdktypes.Nothing))
+}
+
+func TestUnwrapIntoKitchenSink1(t *testing.T) {
+	type Y struct {
+		Z string
+	}
+	type Timestamp struct {
+		time.Time
+	}
+
+	type X struct {
+		//D   time.Duration
+		//InS struct {
+		//	T time.Time
+		//}
+		T Timestamp
+	}
+
+	in := X{
+		// D:   time.Hour,
+		// InS: struct{ T time.Time }{T: time.Date(2023, time.January, 1, 18, 32, 0, 0, time.UTC)},
+		T: Timestamp{time.Date(2023, time.January, 1, 18, 32, 0, 0, time.UTC)},
+	}
+
+	w := sdktypes.DefaultValueWrapper
+
+	var x X
+
+	wx := kittehs.Must1(w.Wrap(in))
+
+	if assert.NoError(t, w.UnwrapInto(&x, wx)) {
+		assert.Equal(t, in, x)
+	}
 }

--- a/sdk/sdktypes/value_wrap_test.go
+++ b/sdk/sdktypes/value_wrap_test.go
@@ -361,10 +361,6 @@ func TestUnwrapIntoKitchenSink(t *testing.T) {
 		Z string
 	}
 
-	type Timestamp struct {
-		time.Time // embedded, not-exported
-	}
-
 	type X struct {
 		I64       int64
 		S         string


### PR DESCRIPTION
embedded anonymous time.Time struct isn't wrapped.
This prevents us to work with github Timestamps