### PR TITLE
ENG-965 follow-up: Implement webhooks

### DIFF
--- a/integrations/jira/client.go
+++ b/integrations/jira/client.go
@@ -23,9 +23,9 @@ var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.Integrati
 	Description:   "Atlassian Jira is an issue tracking and project management system.",
 	LogoUrl:       "/static/images/jira.svg",
 	UserLinks: map[string]string{
-		"1 REST API":          "https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/",
-		"2 Go client API":     "https://pkg.go.dev/github.com/andygrunwald/go-jira",
-		"3 Python client API": "https://jira.readthedocs.io/",
+		"1 REST API":             "https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/",
+		"2 Atlassian Python API": "https://atlassian-python-api.readthedocs.io/",
+		"3 Python Jira API":      "https://jira.readthedocs.io/",
 	},
 	ConnectionUrl: "/jira/connect/",
 	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{

--- a/integrations/jira/event.go
+++ b/integrations/jira/event.go
@@ -1,0 +1,101 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+
+	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+const (
+	headerContentType   = "Content-Type"
+	headerAuthorization = "Authorization"
+	contentTypeJSON     = "application/json"
+)
+
+// Default HTTP client with a timeout for short-lived HTTP requests.
+var httpClient = http.Client{Timeout: 3 * time.Second}
+
+// handler is an autokitteh webhook which implements [http.Handler]
+// to receive and dispatch asynchronous event notifications.
+type handler struct {
+	logger     *zap.Logger
+	oauth      sdkservices.OAuth
+	vars       sdkservices.Vars
+	dispatcher sdkservices.Dispatcher
+}
+
+func NewHTTPHandler(l *zap.Logger, o sdkservices.OAuth, v sdkservices.Vars, d sdkservices.Dispatcher) handler {
+	return handler{logger: l, oauth: o, vars: v, dispatcher: d}
+}
+
+type event struct {
+	MatchedWebhookIDs []int `json:"matchedWebhookIds"`
+}
+
+// handleEvent receives from Jira asynchronous events,
+// and dispatches them to one or more AutoKitteh connections.
+// Note 1: By default, AutoKitteh creates webhooks automatically,
+// subscribing to all events - see "webhooks.go" for more details.
+// TODO(ENG-965):
+// Note 2: Dynamic (i.e. auto-created) webhooks expire after 30 days.
+// This functions extends this deadline at the 20-day mark.
+func (h handler) handleEvent(w http.ResponseWriter, r *http.Request) {
+	l := h.logger.With(zap.String("urlPath", r.URL.Path))
+
+	// Check the "Content-Type" header.
+	header := r.Header.Get(headerContentType)
+	if !strings.HasPrefix(header, contentTypeJSON) {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	// Parse the event's JSON content, specifically the webhook ID(s).
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	var e event
+	if err := json.Unmarshal(body, &e); err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	ctx := context.Background()
+	key := sdktypes.NewSymbol("webhook_id")
+	for _, id := range e.MatchedWebhookIDs {
+		l.Warn("Webhook ID", zap.Int("id", id)) // TODO: REMOVE THIS LINE!
+
+		// TODO: Check the "Authorization" header.
+		header = r.Header.Get(headerAuthorization)
+		l.Warn("Authorization header", zap.String("header", header)) // TODO: REMOVE THIS LINE!
+
+		// Retrieve all the relevant connections for this event.
+		value := fmt.Sprintf("%d", id)
+		cs, err := h.vars.FindConnectionIDs(ctx, integrationID, key, value)
+		if err != nil {
+			l.Warn("Failed to find connection IDs",
+				zap.String("jiraWebHookID", value),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		// TODO: Dispatch the event to all of them, for asynchronous handling.
+		for _, c := range cs {
+			l.Warn("Connection ID", zap.String("cid", c.String())) // TODO: REMOVE THIS LINE!
+		}
+	}
+
+	// Returning immediately without an error = acknowledgement of receipt.
+}

--- a/integrations/jira/server.go
+++ b/integrations/jira/server.go
@@ -12,14 +12,18 @@ import (
 const (
 	// oauthPath is the URL path for our handler to save new OAuth-based connections.
 	oauthPath = "/jira/oauth"
+
+	// WebhookPath is the URL path for our webhook to handle asynchronous events.
+	webhookPath = "/jira/webhook"
 )
 
 func Start(l *zap.Logger, mux *http.ServeMux, vars sdkservices.Vars, o sdkservices.OAuth, d sdkservices.Dispatcher) {
 	// Connection UI + handlers.
 	mux.Handle(desc.ConnectionURL().Path, http.FileServer(http.FS(static.JiraWebContent)))
 
-	h := NewHTTPHandler(l, o)
+	h := NewHTTPHandler(l, o, d)
 	mux.HandleFunc(oauthPath, h.handleOAuth)
 
-	// TODO(ENG-965): Event webhooks.
+	// Event webhook.
+	mux.HandleFunc(webhookPath, h.handleEvent)
 }

--- a/integrations/jira/server.go
+++ b/integrations/jira/server.go
@@ -21,7 +21,7 @@ func Start(l *zap.Logger, mux *http.ServeMux, vars sdkservices.Vars, o sdkservic
 	// Connection UI + handlers.
 	mux.Handle(desc.ConnectionURL().Path, http.FileServer(http.FS(static.JiraWebContent)))
 
-	h := NewHTTPHandler(l, o, d)
+	h := NewHTTPHandler(l, o, vars, d)
 	mux.HandleFunc(oauthPath, h.handleOAuth)
 
 	// Event webhook.

--- a/integrations/jira/webhooks.go
+++ b/integrations/jira/webhooks.go
@@ -1,0 +1,293 @@
+package jira
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
+)
+
+// https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-webhooks/
+type webhook struct {
+	ID int `json:"id,omitempty"`
+	// Events is the Jira events that trigger the webhook. Valid values:
+	// "jira:issue_created", "jira:issue_updated", "jira:issue_deleted",
+	// "comment_created", "comment_updated", "comment_deleted",
+	// "issue_property_set", "issue_property_deleted".
+	Events         []string `json:"events"`
+	ExpirationDate string   `json:"expirationDate,omitempty"`
+	// FieldIDsFilter is a list of field IDs. When the issue changelog
+	// contains any of the fields, the webhook "jira:issue_updated" is sent.
+	// If this parameter is not present, the app is notified about all field updates.
+	FieldIDsFilter []string `json:"fieldIdsFilter,omitempty"`
+	// IssuePropertyKeysFilter is a list of issue property keys.
+	// A change of those issue properties triggers the "issue_property_set" or
+	// "issue_property_deleted webhooks". If this parameter is not present,
+	// the app is notified about all issue property updates.
+	IssuePropertyKeysFilter []string `json:"issuePropertyKeysFilter,omitempty"`
+	// The JQL filter that specifies which issues the webhook is sent for.
+	// Only a subset of JQL can be used. The supported elements are:
+	// * Fields: "issueKey", "project", "issuetype", "status", "assignee",
+	//   "reporter", "issue.property", and "cf[id]". For custom fields
+	//   ("cf[id]"), only the epic label custom field is supported.
+	// * Operators: "=", "!=", "IN", and "NOT IN".
+	JQLFilter string `json:"jqlFilter"`
+}
+
+// checkWebhookPermissions verifies that the OAuth token has the
+// necessary Jira permission scopes to manage webhooks. Based on:
+// https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-webhooks/
+func checkWebhookPermissions(scopes []string) bool {
+	classic := []string{
+		"read:jira-work", "manage:jira-webhook",
+	}
+	granular := []string{
+		"read:webhook:jira", "read:jql:jira",
+		"read:field:jira", "read:project:jira", "write:webhook:jira",
+	}
+
+	allFound := kittehs.All(kittehs.Transform(classic, func(s string) bool {
+		return slices.Contains(scopes, s)
+	})...)
+	if allFound {
+		return true
+	}
+
+	return kittehs.All(kittehs.Transform(granular, func(s string) bool {
+		return slices.Contains(scopes, s)
+	})...)
+}
+
+type webhookListResponse struct {
+	StartAt    int       `json:"startAt"`
+	MaxResults int       `json:"maxResults"`
+	Total      int       `json:"total"`
+	IsLast     bool      `json:"isLast"`
+	NextPage   string    `json:"nextPage,omitempty"`
+	Values     []webhook `json:"values"`
+}
+
+// getWebhook checks whether the given Jira domain already has a
+// registered dynamic webhook for this AutoKitteh server. Based on:
+// https://developer.atlassian.com/cloud/jira/platform/webhooks/
+// https://developer.atlassian.com/server/jira/platform/webhooks/
+// https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-webhooks/
+func getWebhook(l *zap.Logger, baseURL, oauthToken string) (int, bool) {
+	// TODO(ENG-965): Support pagination.
+	req, err := http.NewRequest("GET", baseURL+"/rest/api/3/webhook", nil)
+	if err != nil {
+		l.Warn("Failed to construct HTTP request to list Jira webhooks", zap.Error(err))
+		return 0, false
+	}
+
+	req.Header.Set("Authorization", "Bearer "+oauthToken)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		l.Warn("Failed to list Jira webhooks", zap.Error(err))
+		return 0, false
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		l.Warn("Failed to read Jira webhooks list response", zap.Error(err))
+		return 0, false
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		l.Warn("Unexpected response to Jira webhooks list request",
+			zap.Int("status", resp.StatusCode),
+			zap.ByteString("body", body),
+		)
+		return 0, false
+	}
+
+	var list webhookListResponse
+	if err := json.Unmarshal(body, &list); err != nil {
+		l.Warn("Failed to unmarshal Jira webhooks list from JSON",
+			zap.ByteString("body", body),
+			zap.Error(err),
+		)
+		return 0, false
+	}
+
+	// Finally, filter the results based on the AutoKitteh server address
+	// ("GET .../webhook" doesn't show webhook URLs in the response, so we
+	// use a trick: we specify the AutoKitteh server address in the JQL
+	// filter, without affecting the actual event filtering).
+	addr := os.Getenv("WEBHOOK_ADDRESS")
+	for _, v := range list.Values {
+		if strings.HasSuffix(v.JQLFilter, addr) {
+			return v.ID, true
+		}
+	}
+
+	// No webhook found for this AutoKitteh server.
+	return 0, false
+}
+
+type webhookRegisterRequest struct {
+	URL      string    `json:"url"`
+	Webhooks []webhook `json:"webhooks"`
+}
+
+type webhookRegisterResponse struct {
+	Result []webhookRegistrationResult `json:"webhookRegistrationResult"`
+}
+
+type webhookRegistrationResult struct {
+	CreatedWebhookID int      `json:"createdWebhookId,omitempty"`
+	Errors           []string `json:"errors,omitempty"`
+}
+
+// registerWebhook creates a new dynamic webhook,
+// for 30 days, in the given Jira domain. Based on:
+// https://developer.atlassian.com/cloud/jira/platform/webhooks/
+// https://developer.atlassian.com/server/jira/platform/webhooks/
+// https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-webhooks/
+func registerWebhook(l *zap.Logger, baseURL, oauthToken string) (int, bool) {
+	addr := os.Getenv("WEBHOOK_ADDRESS")
+	r := webhookRegisterRequest{
+		URL: fmt.Sprintf("https://%s/jira/webhook", addr),
+		Webhooks: []webhook{
+			{
+				Events: []string{
+					"jira:issue_created", "jira:issue_updated", "jira:issue_deleted",
+					"comment_created", "comment_updated", "comment_deleted",
+					"issue_property_set", "issue_property_deleted",
+				},
+				JQLFilter: "project != " + addr,
+			},
+		},
+	}
+
+	body, err := json.Marshal(r)
+	if err != nil {
+		l.Warn("Failed to marshal Jira webhook registration request",
+			zap.Any("request", r),
+			zap.Error(err),
+		)
+	}
+
+	jsonReader := bytes.NewReader(body)
+	req, err := http.NewRequest("POST", baseURL+"/rest/api/3/webhook", jsonReader)
+	if err != nil {
+		l.Warn("Failed to construct HTTP request to register Jira webhook", zap.Error(err))
+		return 0, false
+	}
+
+	req.Header.Set("Authorization", "Bearer "+oauthToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		l.Warn("Failed to register Jira webhook", zap.Error(err))
+		return 0, false
+	}
+	defer resp.Body.Close()
+
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		l.Warn("Failed to read Jira webhook registration response", zap.Error(err))
+		return 0, false
+	}
+
+	// Error mode 1: based on HTTP status code.
+	if resp.StatusCode != http.StatusOK {
+		l.Warn("Unexpected response to Jira webhook registration request",
+			zap.Int("status", resp.StatusCode),
+			zap.ByteString("body", body),
+		)
+		return 0, false
+	}
+
+	var reg webhookRegisterResponse
+	if err := json.Unmarshal(body, &reg); err != nil {
+		l.Warn("Failed to unmarshal Jira webhook registration result from JSON",
+			zap.ByteString("body", body),
+			zap.Error(err),
+		)
+		return 0, false
+	}
+
+	// Error mode 2: based on error messages in the parsed JSON response.
+	if len(reg.Result) == 0 {
+		l.Warn("Jira webhook registration result not found", zap.ByteString("body", body))
+	}
+	if len(reg.Result[0].Errors) > 0 {
+		l.Warn("Jira webhook registration errors", zap.Strings("errors", reg.Result[0].Errors))
+		return 0, false
+	}
+
+	return reg.Result[0].CreatedWebhookID, true
+}
+
+type webhookRefreshResponse struct {
+	ExpirationDate string `json:"expirationDate,omitempty"`
+}
+
+// extendWebhookLife extends the expiration date of the given webhook ID by 30 days.
+func extendWebhookLife(l *zap.Logger, baseURL, oauthToken string, id int) (time.Time, bool) {
+	jsonReader := bytes.NewReader([]byte(fmt.Sprintf(`{"webhookIds": [%d]}`, id)))
+	req, err := http.NewRequest("PUT", baseURL+"/rest/api/3/webhook/refresh", jsonReader)
+	if err != nil {
+		l.Warn("Failed to construct HTTP request to refresh Jira webhook", zap.Error(err))
+		return time.Time{}, false
+	}
+
+	req.Header.Set("Authorization", "Bearer "+oauthToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		l.Warn("Failed to refresh Jira webhook", zap.Error(err))
+		return time.Time{}, false
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		l.Warn("Failed to read Jira webhook refresh response", zap.Error(err))
+		return time.Time{}, false
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		l.Warn("Unexpected response to Jira webhook refresh request",
+			zap.Int("status", resp.StatusCode),
+			zap.ByteString("body", body),
+		)
+		return time.Time{}, false
+	}
+
+	var ref webhookRefreshResponse
+	if err := json.Unmarshal(body, &ref); err != nil {
+		l.Warn("Failed to unmarshal Jira webhook refresh result from JSON",
+			zap.ByteString("body", body),
+			zap.Error(err),
+		)
+		return time.Time{}, false
+	}
+
+	t, err := time.Parse("2006-01-02T15:04:05.000-0700", ref.ExpirationDate)
+	if err != nil {
+		l.Warn("Failed to parse Jira webhook expiration date",
+			zap.String("time", ref.ExpirationDate),
+		)
+		return utc30Days(), true
+	}
+	return t, true
+}
+
+func utc30Days() time.Time {
+	return time.Now().UTC().Add(30 * 24 * time.Hour)
+}

--- a/internal/backend/oauth/oauth.go
+++ b/internal/backend/oauth/oauth.go
@@ -255,8 +255,7 @@ func New(l *zap.Logger) sdkservices.OAuth {
 				RedirectURL: redirectURL + "jira",
 				// https://developer.atlassian.com/cloud/jira/platform/scopes-for-oauth-2-3LO-and-forge-apps/
 				Scopes: []string{
-					"read:me",      // TODO(ENG-965): Really needed?
-					"read:account", // TODO(ENG-965): Really needed?
+					"read:account",
 					"read:jira-work",
 					"read:jira-user",
 					"write:jira-work",

--- a/internal/backend/oauth/oauth.go
+++ b/internal/backend/oauth/oauth.go
@@ -246,9 +246,11 @@ func New(l *zap.Logger) sdkservices.OAuth {
 				ClientID:     os.Getenv("JIRA_CLIENT_ID"),
 				ClientSecret: os.Getenv("JIRA_CLIENT_SECRET"),
 				// https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/
+				// https://auth.atlassian.com/.well-known/openid-configuration
 				Endpoint: oauth2.Endpoint{
-					AuthURL:  fmt.Sprintf("%s/authorize", jiraBaseURL),
-					TokenURL: fmt.Sprintf("%s/oauth/token", jiraBaseURL),
+					AuthURL:       fmt.Sprintf("%s/authorize", jiraBaseURL),
+					TokenURL:      fmt.Sprintf("%s/oauth/token", jiraBaseURL),
+					DeviceAuthURL: fmt.Sprintf("%s/oauth/device/code", jiraBaseURL),
 				},
 				RedirectURL: redirectURL + "jira",
 				// https://developer.atlassian.com/cloud/jira/platform/scopes-for-oauth-2-3LO-and-forge-apps/

--- a/web/static/jira/connect/error.html
+++ b/web/static/jira/connect/error.html
@@ -31,7 +31,7 @@
     </a>
 
     <table class="title">
-      <td><img class="logo" src="/static/images/jira.png" alt="Logo" /></td>
+      <td><img class="logo" src="/static/images/jira.svg" alt="Logo" /></td>
       <td><h1>Atlassian Jira - Connection Error</h1></td>
     </table>
 


### PR DESCRIPTION
* Save extra info in the connection secrets
* Auto-create a webhook for AK, or refresh it if it already exists
* Dispatch webhook events
* Verify JWTs of incoming events

TODO in subsequent PR:

1. `event.go`: auto extend a webhook when it receives an event, and has <= 20 days left
2. Configure Jira OAuth details per connection, not per server
3. UI + webhook: Support API keys / PATs