### PR TITLE
github: wrap timestamp as time

### DIFF
--- a/integrations/github/actions.go
+++ b/integrations/github/actions.go
@@ -42,5 +42,5 @@ func (i integration) listWorkflowRuns(ctx context.Context, args []sdktypes.Value
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(c)
+	return valueWrapper.Wrap(c)
 }

--- a/integrations/github/checks.go
+++ b/integrations/github/checks.go
@@ -34,7 +34,7 @@ func (i integration) createCheckRun(ctx context.Context, args []sdktypes.Value, 
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(resp)
+	return valueWrapper.Wrap(resp)
 }
 
 func (i integration) updateCheckRun(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
@@ -64,5 +64,5 @@ func (i integration) updateCheckRun(ctx context.Context, args []sdktypes.Value, 
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(resp)
+	return valueWrapper.Wrap(resp)
 }

--- a/integrations/github/commits.go
+++ b/integrations/github/commits.go
@@ -36,5 +36,5 @@ func (i integration) listCommits(ctx context.Context, args []sdktypes.Value, kwa
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(resp)
+	return valueWrapper.Wrap(resp)
 }

--- a/integrations/github/copilot.go
+++ b/integrations/github/copilot.go
@@ -26,7 +26,7 @@ func (i integration) getCopilotBilling(ctx context.Context, args []sdktypes.Valu
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(resp)
+	return valueWrapper.Wrap(resp)
 }
 
 func (i integration) listCopilotSeats(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
@@ -49,7 +49,7 @@ func (i integration) listCopilotSeats(ctx context.Context, args []sdktypes.Value
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(resp)
+	return valueWrapper.Wrap(resp)
 }
 
 func (i integration) addCopilotTeams(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
@@ -72,7 +72,7 @@ func (i integration) addCopilotTeams(ctx context.Context, args []sdktypes.Value,
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(resp)
+	return valueWrapper.Wrap(resp)
 }
 
 func (i integration) removeCopilotTeams(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
@@ -95,7 +95,7 @@ func (i integration) removeCopilotTeams(ctx context.Context, args []sdktypes.Val
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(resp)
+	return valueWrapper.Wrap(resp)
 }
 
 func (i integration) addCopilotUsers(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
@@ -118,7 +118,7 @@ func (i integration) addCopilotUsers(ctx context.Context, args []sdktypes.Value,
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(resp)
+	return valueWrapper.Wrap(resp)
 }
 
 func (i integration) removeCopilotUsers(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
@@ -141,7 +141,7 @@ func (i integration) removeCopilotUsers(ctx context.Context, args []sdktypes.Val
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(resp)
+	return valueWrapper.Wrap(resp)
 }
 
 func (i integration) getCopilotSeatDetails(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
@@ -161,5 +161,5 @@ func (i integration) getCopilotSeatDetails(ctx context.Context, args []sdktypes.
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(resp)
+	return valueWrapper.Wrap(resp)
 }

--- a/integrations/github/git_refs.go
+++ b/integrations/github/git_refs.go
@@ -41,7 +41,7 @@ func (i integration) createRef(ctx context.Context, args []sdktypes.Value, kwarg
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(c)
+	return valueWrapper.Wrap(c)
 }
 
 // https://docs.github.com/en/rest/git/refs#get-a-reference
@@ -68,5 +68,5 @@ func (i integration) getRef(ctx context.Context, args []sdktypes.Value, kwargs m
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(c)
+	return valueWrapper.Wrap(c)
 }

--- a/integrations/github/issue_comments.go
+++ b/integrations/github/issue_comments.go
@@ -40,5 +40,5 @@ func (i integration) createIssueComment(ctx context.Context, args []sdktypes.Val
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(c)
+	return valueWrapper.Wrap(c)
 }

--- a/integrations/github/issue_labels.go
+++ b/integrations/github/issue_labels.go
@@ -33,7 +33,7 @@ func (i integration) addIssueLabels(ctx context.Context, args []sdktypes.Value, 
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(c)
+	return valueWrapper.Wrap(c)
 }
 
 func (i integration) removeIssueLabel(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
@@ -61,5 +61,5 @@ func (i integration) removeIssueLabel(ctx context.Context, args []sdktypes.Value
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(c)
+	return valueWrapper.Wrap(c)
 }

--- a/integrations/github/issues.go
+++ b/integrations/github/issues.go
@@ -39,7 +39,7 @@ func (i integration) createIssue(ctx context.Context, args []sdktypes.Value, kwa
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(resp)
+	return valueWrapper.Wrap(resp)
 }
 
 // https://docs.github.com/en/rest/issues/issues#get-an-issue
@@ -68,7 +68,7 @@ func (i integration) getIssue(ctx context.Context, args []sdktypes.Value, kwargs
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(resp)
+	return valueWrapper.Wrap(resp)
 }
 
 // https://docs.github.com/en/rest/issues/issues#update-an-issue
@@ -107,7 +107,7 @@ func (i integration) updateIssue(ctx context.Context, args []sdktypes.Value, kwa
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(resp)
+	return valueWrapper.Wrap(resp)
 }
 
 // https://docs.github.com/en/rest/issues/issues#list-repository-issues
@@ -146,5 +146,5 @@ func (i integration) listRepositoryIssues(ctx context.Context, args []sdktypes.V
 	}
 
 	// Parse and return the response.
-	return sdktypes.WrapValue(is)
+	return valueWrapper.Wrap(is)
 }

--- a/integrations/github/pulls.go
+++ b/integrations/github/pulls.go
@@ -58,7 +58,7 @@ func (i integration) createPullRequest(ctx context.Context, args []sdktypes.Valu
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(pr)
+	return valueWrapper.Wrap(pr)
 }
 
 // https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
@@ -89,7 +89,7 @@ func (i integration) getPullRequest(ctx context.Context, args []sdktypes.Value, 
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(pr)
+	return valueWrapper.Wrap(pr)
 }
 
 // https://docs.github.com/en/rest/pulls/pulls#list-pull-requests
@@ -128,7 +128,7 @@ func (i integration) listPullRequests(ctx context.Context, args []sdktypes.Value
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(prs)
+	return valueWrapper.Wrap(prs)
 }
 
 // https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files
@@ -164,7 +164,7 @@ func (i integration) listPullRequestFiles(ctx context.Context, args []sdktypes.V
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(files)
+	return valueWrapper.Wrap(files)
 }
 
 // https://docs.github.com/en/rest/pulls/review-requests#request-reviewers-for-a-pull-request
@@ -200,5 +200,5 @@ func (i integration) requestReview(ctx context.Context, args []sdktypes.Value, k
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(pr)
+	return valueWrapper.Wrap(pr)
 }

--- a/integrations/github/reactions.go
+++ b/integrations/github/reactions.go
@@ -34,7 +34,7 @@ func (i integration) createReactionForCommitComment(ctx context.Context, args []
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(r)
+	return valueWrapper.Wrap(r)
 }
 
 // https://docs.github.com/en/rest/reactions/reactions#create-reaction-for-an-issue
@@ -64,7 +64,7 @@ func (i integration) createReactionForIssue(ctx context.Context, args []sdktypes
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(r)
+	return valueWrapper.Wrap(r)
 }
 
 // https://docs.github.com/en/rest/reactions/reactions#create-reaction-for-an-issue-comment
@@ -93,7 +93,7 @@ func (i integration) createReactionForIssueComment(ctx context.Context, args []s
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(r)
+	return valueWrapper.Wrap(r)
 }
 
 // https://docs.github.com/en/rest/reactions/reactions#create-reaction-for-a-pull-request-review-comment
@@ -123,5 +123,5 @@ func (i integration) createReactionForPullRequestReviewComment(ctx context.Conte
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(r)
+	return valueWrapper.Wrap(r)
 }

--- a/integrations/github/repo.go
+++ b/integrations/github/repo.go
@@ -36,5 +36,5 @@ func (i integration) listCollaborators(ctx context.Context, args []sdktypes.Valu
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(c)
+	return valueWrapper.Wrap(c)
 }

--- a/integrations/github/repository_content.go
+++ b/integrations/github/repository_content.go
@@ -65,7 +65,7 @@ func (i integration) createOrUpdateFile(ctx context.Context, args []sdktypes.Val
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(c)
+	return valueWrapper.Wrap(c)
 }
 
 // https://docs.github.com/en/rest/repos/contents#get-repository-content
@@ -102,5 +102,5 @@ func (i integration) getContents(ctx context.Context, args []sdktypes.Value, kwa
 		directoryContent = []*github.RepositoryContent{fileContent}
 	}
 
-	return sdktypes.WrapValue(directoryContent)
+	return valueWrapper.Wrap(directoryContent)
 }

--- a/integrations/github/review_comments.go
+++ b/integrations/github/review_comments.go
@@ -50,7 +50,7 @@ func (i integration) createReviewComment(ctx context.Context, args []sdktypes.Va
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(comment)
+	return valueWrapper.Wrap(comment)
 }
 
 // https://docs.github.com/en/rest/pulls/comments#create-a-reply-for-a-review-comment
@@ -83,7 +83,7 @@ func (i integration) createReviewCommentReply(ctx context.Context, args []sdktyp
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(comment)
+	return valueWrapper.Wrap(comment)
 }
 
 // https://docs.github.com/en/rest/pulls/comments#delete-a-review-comment-for-a-pull-request
@@ -145,7 +145,7 @@ func (i integration) getReviewComment(ctx context.Context, args []sdktypes.Value
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(comment)
+	return valueWrapper.Wrap(comment)
 }
 
 // https://docs.github.com/en/rest/pulls/comments#list-review-comments-on-a-pull-request
@@ -206,7 +206,7 @@ func (i integration) listPullRequestReviewComments(ctx context.Context, args []s
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(comments)
+	return valueWrapper.Wrap(comments)
 }
 
 // https://docs.github.com/en/rest/pulls/comments#update-a-review-comment-for-a-pull-request
@@ -243,5 +243,5 @@ func (i integration) updateReviewComment(ctx context.Context, args []sdktypes.Va
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(comment)
+	return valueWrapper.Wrap(comment)
 }

--- a/integrations/github/reviews.go
+++ b/integrations/github/reviews.go
@@ -50,7 +50,7 @@ func (i integration) createReview(ctx context.Context, args []sdktypes.Value, kw
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(review)
+	return valueWrapper.Wrap(review)
 }
 
 // https://docs.github.com/en/rest/pulls/reviews#delete-a-pending-review-for-a-pull-request
@@ -83,7 +83,7 @@ func (i integration) deletePendingReview(ctx context.Context, args []sdktypes.Va
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(review)
+	return valueWrapper.Wrap(review)
 }
 
 // https://docs.github.com/en/rest/pulls/reviews#dismiss-a-review-for-a-pull-request
@@ -122,7 +122,7 @@ func (i integration) dismissReview(ctx context.Context, args []sdktypes.Value, k
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(review)
+	return valueWrapper.Wrap(review)
 }
 
 // https://docs.github.com/en/rest/pulls/reviews#get-a-review-for-a-pull-request
@@ -155,7 +155,7 @@ func (i integration) getReview(ctx context.Context, args []sdktypes.Value, kwarg
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(review)
+	return valueWrapper.Wrap(review)
 }
 
 // https://docs.github.com/en/rest/pulls/reviews#list-reviews-for-a-pull-request
@@ -199,7 +199,7 @@ func (i integration) listReviews(ctx context.Context, args []sdktypes.Value, kwa
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(reviews)
+	return valueWrapper.Wrap(reviews)
 }
 
 // https://docs.github.com/en/rest/pulls/reviews#list-comments-for-a-pull-request-review
@@ -245,7 +245,7 @@ func (i integration) listReviewComments(ctx context.Context, args []sdktypes.Val
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(comments)
+	return valueWrapper.Wrap(comments)
 }
 
 // https://docs.github.com/en/rest/pulls/reviews#submit-a-review-for-a-pull-request
@@ -289,7 +289,7 @@ func (i integration) submitReview(ctx context.Context, args []sdktypes.Value, kw
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(review)
+	return valueWrapper.Wrap(review)
 }
 
 // https://docs.github.com/en/rest/pulls/reviews#update-a-review-for-a-pull-request
@@ -322,5 +322,5 @@ func (i integration) updateReview(ctx context.Context, args []sdktypes.Value, kw
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(review)
+	return valueWrapper.Wrap(review)
 }

--- a/integrations/github/users.go
+++ b/integrations/github/users.go
@@ -38,7 +38,7 @@ func (i integration) getUser(ctx context.Context, args []sdktypes.Value, kwargs 
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(resp)
+	return valueWrapper.Wrap(resp)
 }
 
 // https://docs.github.com/en/rest/search/search#search-users
@@ -78,5 +78,5 @@ func (i integration) searchUsers(ctx context.Context, args []sdktypes.Value, kwa
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(resp)
+	return valueWrapper.Wrap(resp)
 }

--- a/integrations/github/values.go
+++ b/integrations/github/values.go
@@ -1,0 +1,18 @@
+package github
+
+import (
+	"github.com/google/go-github/v60/github"
+
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+var valueWrapper = sdktypes.ValueWrapper{
+	Prewrap: func(v any) (any, error) {
+		switch v := v.(type) {
+		case github.Timestamp:
+			return v.Time, nil
+		}
+
+		return v, nil
+	},
+}

--- a/integrations/github/workflows.go
+++ b/integrations/github/workflows.go
@@ -67,5 +67,5 @@ func (i integration) listWorkflows(ctx context.Context, args []sdktypes.Value, k
 		return sdktypes.InvalidValue, err
 	}
 
-	return sdktypes.WrapValue(workflows)
+	return valueWrapper.Wrap(workflows)
 }

--- a/sdk/sdktypes/value_wrap.go
+++ b/sdk/sdktypes/value_wrap.go
@@ -15,6 +15,13 @@ func WrapValue[T any](v T) (Value, error) { return DefaultValueWrapper.Wrap(v) }
 
 // Wraps a native go type in a Value.
 func (w ValueWrapper) Wrap(v any) (Value, error) {
+	if w.Prewrap != nil {
+		var err error
+		if v, err = w.Prewrap(v); err != nil {
+			return InvalidValue, fmt.Errorf("prewrap: %w", err)
+		}
+	}
+
 	if v, ok := v.(Value); ok {
 		return v, nil
 	}

--- a/sdk/sdktypes/value_wrap_test.go
+++ b/sdk/sdktypes/value_wrap_test.go
@@ -428,3 +428,33 @@ func TestUnwrapNothing(t *testing.T) {
 	var i int
 	assert.Error(t, sdktypes.UnwrapValueInto(&i, sdktypes.Nothing))
 }
+
+func TestPrewrap(t *testing.T) {
+	w := sdktypes.ValueWrapper{
+		Prewrap: func(v any) (any, error) {
+			switch v.(type) {
+			case int:
+				return fmt.Sprintf("%d", v), nil
+			case string:
+				return nil, nil
+			default:
+				return v, nil
+			}
+		},
+	}
+
+	v, err := w.Wrap(42)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "42", v.GetString().Value())
+	}
+
+	v, err = w.Wrap("42")
+	if assert.NoError(t, err) {
+		assert.True(t, v.IsNothing())
+	}
+
+	v, err = w.Wrap(42.0)
+	if assert.NoError(t, err) {
+		assert.Equal(t, 42.0, v.GetFloat().Value())
+	}
+}

--- a/sdk/sdktypes/value_wrapper.go
+++ b/sdk/sdktypes/value_wrapper.go
@@ -45,6 +45,9 @@ type ValueWrapper struct {
 	// Unwrap: Tranform value before unwrapping. If returns InvalidValue, ignore value.
 	Preunwrap func(Value) (Value, error)
 
+	// Wrap: Transform value before wrapping.
+	Prewrap func(any) (any, error)
+
 	// Unwrap: if not handled, use this unwrapper.
 	UnwrapUnknown func(Value) (any, error)
 }


### PR DESCRIPTION
github lib returns a weird timestamp value. we need to convert it to a more useful timestamp. this introduces a Prewrap function for value wrapper to do that.