### PR TITLE
bugfix: log users in http request

### DIFF
--- a/internal/backend/svc/svc.go
+++ b/internal/backend/svc/svc.go
@@ -136,7 +136,9 @@ func makeFxOpts(cfg *Config, opts RunOptions) []fx.Option {
 		Component("auth", configset.Empty, fx.Provide(authsvc.New)),
 		Component("authjwttokens", authjwttokens.Configs, fx.Provide(authjwttokens.New)),
 		Component("authsessions", authsessions.Configs, fx.Provide(authsessions.New)),
-		Component("authhttmiddleware", authhttpmiddleware.Configs, fx.Provide(authhttpmiddleware.New), fx.Provide(authhttpmiddleware.AuthorizationHeaderExtractor)),
+		Component("authhttmiddleware", authhttpmiddleware.Configs,
+			fx.Provide(authhttpmiddleware.New),
+			fx.Provide(authhttpmiddleware.AuthorizationHeaderExtractor)),
 
 		DBFxOpt(),
 		Component(

--- a/internal/backend/svc/svc.go
+++ b/internal/backend/svc/svc.go
@@ -270,8 +270,9 @@ func makeFxOpts(cfg *Config, opts RunOptions) []fx.Option {
 						varsv1connect.VarsServiceName,
 					},
 					[]httpsvc.RequestLogExtractor{
-						// Note: auth middleware is connected after interceptor, so in httpsvc and interceptor there is no user in the context.
-						// Therefore we just extract and parse user from the Authorization header.
+						// Note: auth middleware will be connected after interceptor, so in httpsvc and interceptor handler
+						// there is (still) no parsed user in the httpRequest context. So in order to log the user in the
+						// same place where httpRequest is logged we need to extract it from the header
 						func(r *http.Request) []zap.Field {
 							if user := authHdrExtractor(r); user.IsValid() {
 								return []zap.Field{zap.String("user", user.Title())}


### PR DESCRIPTION
in httpscv and interceptor func, users are not in the request context.
Auth middleware connected after the interceptor, therefore parsed user isn't present in request context before `httpServe`.
After `httpServe` user still won't be present in request context, since request will be override in auth (due to new context).
