### PR TITLE
Refactor integrations based on recent work and reviews on Jira integration

### DIFF
--- a/integrations/chatgpt/client.go
+++ b/integrations/chatgpt/client.go
@@ -23,6 +23,9 @@ var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.Integrati
 		"2 Go client API":             "https://pkg.go.dev/github.com/sashabaranov/go-openai",
 	},
 	ConnectionUrl: "/chatgpt/connect",
+	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
+		RequiresConnectionInit: true,
+	},
 }))
 
 func New(vars sdkservices.Vars) sdkservices.Integration {

--- a/integrations/chatgpt/save.go
+++ b/integrations/chatgpt/save.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -12,8 +13,8 @@ import (
 )
 
 const (
-	HeaderContentType = "Content-Type"
-	ContentTypeForm   = "application/x-www-form-urlencoded"
+	headerContentType = "Content-Type"
+	contentTypeForm   = "application/x-www-form-urlencoded"
 )
 
 var apiKeyVar = sdktypes.NewSymbol("api_key")
@@ -32,32 +33,27 @@ func NewHTTPHandler(l *zap.Logger) http.Handler {
 func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	l := h.logger.With(zap.String("urlPath", r.URL.Path))
 
-	// Check "Content-Type" header.
-	ct := r.Header.Get(HeaderContentType)
-	if ct != ContentTypeForm {
-		l.Warn("Unexpected header value",
-			zap.String("header", HeaderContentType),
-			zap.String("got", ct),
-			zap.String("want", ContentTypeForm),
-		)
-		e := fmt.Sprintf("Unexpected Content-Type header: %q", ct)
-		u := fmt.Sprintf("%serror.html?error=%s", uiPath, url.QueryEscape(e))
-		http.Redirect(w, r, u, http.StatusFound)
+	// Check the "Content-Type" header.
+	contentType := r.Header.Get(headerContentType)
+	if !strings.HasPrefix(contentType, contentTypeForm) {
+		// This is probably an attack, so no user-friendliness.
+		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}
 
 	// Read and parse POST request body.
 	err := r.ParseForm()
 	if err != nil {
-		l.Warn("Failed to parse inbound HTTP request",
-			zap.Error(err),
-		)
-		e := "Form parsing error: " + err.Error()
-		u := fmt.Sprintf("%serror.html?error=%s", uiPath, url.QueryEscape(e))
-		http.Redirect(w, r, u, http.StatusFound)
+		l.Warn("Failed to parse inbound HTTP request", zap.Error(err))
+		redirectToErrorPage(w, r, "form parsing error: "+err.Error())
 		return
 	}
 	apiKey := r.Form.Get("key")
 
 	sdkintegrations.FinalizeConnectionInit(w, r, integrationID, sdktypes.NewVars().Set(apiKeyVar, apiKey, true))
+}
+
+func redirectToErrorPage(w http.ResponseWriter, r *http.Request, err string) {
+	u := fmt.Sprintf("%s/error.html?error=%s", desc.ConnectionURL().Path, url.QueryEscape(err))
+	http.Redirect(w, r, u, http.StatusFound)
 }

--- a/integrations/chatgpt/server.go
+++ b/integrations/chatgpt/server.go
@@ -9,9 +9,6 @@ import (
 )
 
 const (
-	// uiPath is the URL root path of a simple web UI to interact with users.
-	uiPath = "/chatgpt/connect/"
-
 	// savePath is the URL path for our handler to save a new autokitteh
 	// connection, after the user submits its details via a web form.
 	savePath = "/chatgpt/save"
@@ -19,6 +16,8 @@ const (
 
 func Start(l *zap.Logger, mux *http.ServeMux) {
 	// New connection UI + form submission handler.
+	uiPath := "GET " + desc.ConnectionURL().Path + "/"
 	mux.Handle(uiPath, http.FileServer(http.FS(static.ChatGPTWebContent)))
-	mux.Handle(savePath, NewHTTPHandler(l))
+
+	mux.Handle("POST "+savePath, NewHTTPHandler(l))
 }

--- a/integrations/github/client.go
+++ b/integrations/github/client.go
@@ -28,7 +28,7 @@ var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.Integrati
 		"2 Go client API":     "https://pkg.go.dev/github.com/google/go-github/v57/github",
 		"3 Python client API": "https://pygithub.readthedocs.io/en/stable/",
 	},
-	ConnectionUrl: "/github/connect/",
+	ConnectionUrl: "/github/connect",
 	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
 		RequiresConnectionInit: true,
 	},

--- a/integrations/github/client.go
+++ b/integrations/github/client.go
@@ -2,8 +2,6 @@ package github
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"go.autokitteh.dev/autokitteh/integrations/github/internal/vars"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
@@ -26,10 +24,11 @@ var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.Integrati
 	Description:   "GitHub is a development platform with distributed version control, issue tracking, continuous integration, and more.",
 	LogoUrl:       "/static/images/github.svg",
 	UserLinks: map[string]string{
-		"1 REST API":      "https://docs.github.com/rest",
-		"2 Go client API": "https://pkg.go.dev/github.com/google/go-github/v57/github",
+		"1 REST API":          "https://docs.github.com/rest",
+		"2 Go client API":     "https://pkg.go.dev/github.com/google/go-github/v57/github",
+		"3 Python client API": "https://pygithub.readthedocs.io/en/stable/",
 	},
-	ConnectionUrl: "/github/connect",
+	ConnectionUrl: "/github/connect/",
 	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
 		RequiresConnectionInit: true,
 	},
@@ -53,12 +52,14 @@ func connTest(*integration) sdkintegrations.OptFn {
 	})
 }
 
+// connStatus is an optional connection status check provided by the
+// integration to AutoKitteh. The possible results are "init required"
+// (the connection is not usable yet) and "using X" (where "X" is the
+// authentication method: OAuth 2.0, Cloud API token, or on-prem PAT).
 func connStatus(i *integration) sdkintegrations.OptFn {
 	return sdkintegrations.WithConnectionStatus(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
-		initReq := sdktypes.NewStatus(sdktypes.StatusCodeWarning, "init required")
-
 		if !cid.IsValid() {
-			return initReq, nil
+			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "init required"), nil
 		}
 
 		vs, err := i.vars.Get(ctx, sdktypes.NewVarScopeID(cid))
@@ -68,17 +69,9 @@ func connStatus(i *integration) sdkintegrations.OptFn {
 
 		if vs.Has(vars.PAT) {
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using PAT"), nil
+		} else {
+			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using OAuth 2.0"), nil
 		}
-
-		n := len(kittehs.Filter(vs, func(v sdktypes.Var) bool {
-			return strings.HasPrefix(v.Name().String(), "app_id__")
-		}))
-
-		if n == 0 {
-			return initReq, nil
-		}
-
-		return sdktypes.NewStatus(sdktypes.StatusCodeOK, fmt.Sprintf("%d installations", n)), nil
 	})
 }
 

--- a/integrations/github/oauth.go
+++ b/integrations/github/oauth.go
@@ -18,11 +18,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-const (
-	// oauthPath is the URL path for our handler to save new OAuth-based connections.
-	oauthPath = "/github/oauth"
-)
-
 // handler is an autokitteh webhook which implements [http.Handler]
 // to receive and dispatch asynchronous event notifications.
 type handler struct {

--- a/integrations/github/pat.go
+++ b/integrations/github/pat.go
@@ -30,6 +30,7 @@ func (h handler) handlePAT(w http.ResponseWriter, r *http.Request) {
 	// Check the "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
 	if !strings.HasPrefix(contentType, contentTypeForm) {
+		// This is probably an attack, so no user-friendliness.
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}

--- a/integrations/github/pat.go
+++ b/integrations/github/pat.go
@@ -15,10 +15,6 @@ import (
 )
 
 const (
-	// patPath is the URL path for our webhook to save a new autokitteh
-	// PAT-based connection, after the user submits it via a web form.
-	patPath = "/github/save"
-
 	headerContentType = "Content-Type"
 	contentTypeForm   = "application/x-www-form-urlencoded"
 )

--- a/integrations/github/server.go
+++ b/integrations/github/server.go
@@ -11,6 +11,15 @@ import (
 	"go.autokitteh.dev/autokitteh/web/static"
 )
 
+const(
+	// oauthPath is the URL path for our handler to save new OAuth-based connections.
+	oauthPath = "/github/oauth"
+
+	// patPath is the URL path for our webhook to save a new autokitteh
+	// PAT-based connection, after the user submits it via a web form.
+	patPath = "/github/save"
+)
+
 func Start(l *zap.Logger, mux *http.ServeMux, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.Dispatcher) {
 	// Connection UI + handlers.
 	uiPath := "GET " + desc.ConnectionURL().Path + "/"

--- a/integrations/github/server.go
+++ b/integrations/github/server.go
@@ -13,22 +13,22 @@ import (
 	"go.autokitteh.dev/autokitteh/web/static"
 )
 
-func Start(l *zap.Logger, mux *http.ServeMux, vars sdkservices.Vars, o sdkservices.OAuth, d sdkservices.Dispatcher) {
-	// Connection UI + handler.
+func Start(l *zap.Logger, mux *http.ServeMux, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.Dispatcher) {
+	// Connection UI + handlers.
+	uiPath := desc.ConnectionURL().Path
 	mux.HandleFunc(uiPath, connect.ServeHTTP)
 	staticFiles := http.FileServer(http.FS(static.GitHubWebContent))
 	mux.Handle(kittehs.Must1(url.JoinPath(uiPath, "error.html")), staticFiles)
 	mux.Handle(kittehs.Must1(url.JoinPath(uiPath, "error.js")), staticFiles)
 	mux.Handle(kittehs.Must1(url.JoinPath(uiPath, "form.js")), staticFiles)
 	mux.Handle(kittehs.Must1(url.JoinPath(uiPath, "styles.css")), staticFiles)
-	mux.Handle(kittehs.Must1(url.JoinPath(uiPath, "success.html")), staticFiles)
-	mux.Handle(kittehs.Must1(url.JoinPath(uiPath, "success.js")), staticFiles)
+
 	h := NewHandler(l, o)
 	mux.HandleFunc(patPath, h.handlePAT)
 	mux.HandleFunc(oauthPath, h.handleOAuth)
 
 	// Event webhooks.
-	eventHandler := webhooks.NewHandler(l, vars, d, integrationID)
+	eventHandler := webhooks.NewHandler(l, v, d, integrationID)
 	mux.Handle(webhooks.WebhookPath+"/", eventHandler) // User events.
 	mux.Handle(webhooks.WebhookPath, eventHandler)     // App events.
 }

--- a/integrations/github/server.go
+++ b/integrations/github/server.go
@@ -11,7 +11,7 @@ import (
 	"go.autokitteh.dev/autokitteh/web/static"
 )
 
-const(
+const (
 	// oauthPath is the URL path for our handler to save new OAuth-based connections.
 	oauthPath = "/github/oauth"
 

--- a/integrations/github/webhooks/webhook.go
+++ b/integrations/github/webhooks/webhook.go
@@ -17,8 +17,6 @@ import (
 	valuesv1 "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/values/v1"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-
-	"go.autokitteh.dev/autokitteh/integrations/internal/extrazap"
 )
 
 const (
@@ -65,9 +63,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// and a valid signature header, and if so parse the received event.
 		payload, err = github.ValidatePayload(r, []byte(os.Getenv(webhookSecretEnvVar)))
 		if err != nil {
-			l.Warn("Received invalid app event payload",
-				zap.Error(err),
-			)
+			l.Warn("Received invalid app event payload", zap.Error(err))
 			http.Error(w, "Bad Request", http.StatusBadRequest)
 			return
 		}
@@ -75,44 +71,33 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// This event is for a user-defined webhook, not an app.
 		path := strings.Split(r.URL.Path, "/")
 		suffix := path[len(path)-1]
+		ctx := r.Context()
 
-		cids, err := h.vars.FindConnectionIDs(r.Context(), h.integrationID, vars.PATKey, suffix)
+		cids, err := h.vars.FindConnectionIDs(ctx, h.integrationID, vars.PATKey, suffix)
 		if err != nil {
-			l.Warn("Unrecognized user event payload",
-				zap.Error(err),
-			)
-			http.Error(w, "Bad Request", http.StatusBadRequest)
-			return
-		}
-		if len(cids) != 1 {
-			l.Warn("Unexpected number of connection tokens for user event",
-				zap.String("suffix", suffix),
-				zap.Int("n", len(cids)),
-			)
-			http.Error(w, "Internal Server error", http.StatusInternalServerError)
+			l.Error("Failed to find connection IDs", zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
 
-		userCID = cids[0]
+		for _, cid := range cids {
+			data, err := h.vars.Reveal(ctx, sdktypes.NewVarScopeID(cid), vars.PATSecret)
+			if err != nil {
+				l.Warn("Unrecognized connection for user event payload",
+					zap.String("suffix", suffix),
+					zap.String("cid", cid.String()),
+					zap.Error(err),
+				)
+				http.Error(w, "Internal Server error", http.StatusInternalServerError)
+				return
+			}
 
-		data, err := h.vars.Reveal(r.Context(), sdktypes.NewVarScopeID(userCID), vars.PATSecret)
-		if err != nil {
-			l.Warn("Unrecognized connection for user event payload",
-				zap.String("suffix", suffix),
-				zap.String("cid", userCID.String()),
-				zap.Error(err),
-			)
-			http.Error(w, "Internal Server error", http.StatusInternalServerError)
-			return
-		}
-
-		payload, err = github.ValidatePayload(r, []byte(data.GetValue(vars.PATSecret)))
-		if err != nil {
-			l.Warn("Received invalid user event payload",
-				zap.Error(err),
-			)
-			http.Error(w, "Bad Request", http.StatusBadRequest)
-			return
+			payload, err = github.ValidatePayload(r, []byte(data.GetValue(vars.PATSecret)))
+			if err != nil {
+				l.Warn("Received invalid user event payload", zap.Error(err))
+				http.Error(w, "Bad Request", http.StatusBadRequest)
+				return
+			}
 		}
 	}
 
@@ -120,8 +105,8 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ghEvent, err := github.ParseWebHook(eventType, payload)
 	if err != nil {
 		l.Warn("Received unrecognized event type",
-			zap.Error(err),
 			zap.ByteString("payload", payload),
+			zap.Error(err),
 		)
 		http.Error(w, "Not Implemented", http.StatusNotImplemented)
 		return
@@ -154,16 +139,13 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		cids = append(cids, userCID) // User-defined webhook.
 	}
 
+	ctx := r.Context()
+
 	if installID != "" {
 		// App webhook.
-		icids, err := h.vars.FindConnectionIDs(
-			r.Context(),
-			h.integrationID,
-			vars.InstallKey(appID, installID),
-			"",
-		)
+		icids, err := h.vars.FindConnectionIDs(ctx, h.integrationID, vars.InstallKey(appID, installID), "")
 		if err != nil {
-			l.Error("Failed to retrieve connection tokens", zap.Error(err))
+			l.Error("Failed to find connection IDs", zap.Error(err))
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
@@ -172,7 +154,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Dispatch the event to all of them, for asynchronous handling.
-	dispatchAsyncEventsToConnections(l, cids, akEvent, h.dispatcher)
+	dispatchAsyncEventsToConnections(ctx, l, cids, akEvent, h.dispatcher)
 
 	// Returning immediately without an error = acknowledgement of receipt.
 }
@@ -203,38 +185,40 @@ func extractInstallationID(event any) (inst string, err error) {
 func transformEvent(l *zap.Logger, w http.ResponseWriter, event any) (map[string]*valuesv1.Value, error) {
 	wrapped, err := sdktypes.DefaultValueWrapper.Wrap(event)
 	if err != nil {
-		l.Error("Failed to wrap GitHub event",
-			zap.Error(err),
-			zap.Any("event", event),
-		)
+		l.Error("Failed to wrap GitHub event", zap.Any("event", event), zap.Error(err))
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return nil, err
 	}
 	data, err := wrapped.ToStringValuesMap()
 	if err != nil {
-		l.Error("Failed to convert wrapped GitHub event",
-			zap.Error(err),
-			zap.Any("event", event),
-		)
+		l.Error("Failed to convert wrapped GitHub event", zap.Any("event", event), zap.Error(err))
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return nil, err
 	}
 	return kittehs.TransformMapValues(data, sdktypes.ToProto), nil
 }
 
-func dispatchAsyncEventsToConnections(l *zap.Logger, cids []sdktypes.ConnectionID, event *eventsv1.Event, d sdkservices.Dispatcher) {
-	ctx := extrazap.AttachLoggerToContext(l, context.Background())
+func dispatchAsyncEventsToConnections(ctx context.Context, l *zap.Logger, cids []sdktypes.ConnectionID, event *eventsv1.Event, d sdkservices.Dispatcher) {
 	for _, cid := range cids {
-		l := l.With(zap.String("cid", cid.String()))
-
 		event.ConnectionId = cid.String()
-
-		e := kittehs.Must1(sdktypes.EventFromProto(event))
-		eventID, err := d.Dispatch(ctx, e, nil)
+		e, err := sdktypes.EventFromProto(event)
 		if err != nil {
-			l.Error("Dispatch failed", zap.Error(err))
+			l.Error("Failed to convert protocol buffer to SDK event", zap.Error(err))
 			return
 		}
-		l.Debug("Dispatched", zap.String("eventID", eventID.String()))
+
+		eventID, err := d.Dispatch(ctx, e, nil)
+		if err != nil {
+			l.Error("Event dispatch failed",
+				zap.String("eventID", eventID.String()),
+				zap.String("connectionID", cid.String()),
+				zap.Error(err),
+			)
+			return
+		}
+		l.Debug("Event dispatched",
+			zap.String("eventID", eventID.String()),
+			zap.String("connectionID", cid.String()),
+		)
 	}
 }

--- a/integrations/google/client.go
+++ b/integrations/google/client.go
@@ -22,8 +22,12 @@ var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.Integrati
 	UserLinks: map[string]string{
 		"1 REST API reference": "https://developers.google.com/apis-explorer",
 		"2 Go client API":      "https://pkg.go.dev/google.golang.org/api",
+		"3 Python samples":     "https://github.com/googleworkspace/python-samples",
 	},
 	ConnectionUrl: "/google/connect",
+	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
+		RequiresConnectionInit: true,
+	},
 }))
 
 func New(cvars sdkservices.Vars) sdkservices.Integration {

--- a/integrations/google/creds.go
+++ b/integrations/google/creds.go
@@ -1,9 +1,8 @@
 package google
 
 import (
-	"fmt"
 	"net/http"
-	"net/url"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -17,37 +16,27 @@ const (
 	// credentials-based connection, after the user submits it via a web form.
 	credsPath = "/google/save"
 
-	HeaderContentType = "Content-Type"
-	ContentTypeForm   = "application/x-www-form-urlencoded"
+	headerContentType = "Content-Type"
+	contentTypeForm   = "application/x-www-form-urlencoded"
 )
 
 // HandleCreds saves a new autokitteh connection with a user-submitted token.
 func (h handler) HandleCreds(w http.ResponseWriter, r *http.Request) {
 	l := h.logger.With(zap.String("urlPath", r.URL.Path))
 
-	// Check "Content-Type" header.
-	ct := r.Header.Get(HeaderContentType)
-	if ct != ContentTypeForm {
-		l.Warn("Unexpected header value",
-			zap.String("header", HeaderContentType),
-			zap.String("got", ct),
-			zap.String("want", ContentTypeForm),
-		)
-		e := fmt.Sprintf("Unexpected Content-Type header: %q", ct)
-		u := fmt.Sprintf("%serror.html?error=%s", uiPath, url.QueryEscape(e))
-		http.Redirect(w, r, u, http.StatusFound)
+	// Check the "Content-Type" header.
+	contentType := r.Header.Get(headerContentType)
+	if !strings.HasPrefix(contentType, contentTypeForm) {
+		// This is probably an attack, so no user-friendliness.
+		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}
 
 	// Read and parse POST request body.
 	err := r.ParseForm()
 	if err != nil {
-		l.Warn("Failed to parse inbound HTTP request",
-			zap.Error(err),
-		)
-		e := "Form parsing error: " + err.Error()
-		u := fmt.Sprintf("%serror.html?error=%s", uiPath, url.QueryEscape(e))
-		http.Redirect(w, r, u, http.StatusFound)
+		l.Warn("Failed to parse inbound HTTP request", zap.Error(err))
+		redirectToErrorPage(w, r, "form parsing error: "+err.Error())
 		return
 	}
 

--- a/integrations/google/creds.go
+++ b/integrations/google/creds.go
@@ -12,10 +12,6 @@ import (
 )
 
 const (
-	// credsPath is the URL path for our handler to save a new autokitteh
-	// credentials-based connection, after the user submits it via a web form.
-	credsPath = "/google/save"
-
 	headerContentType = "Content-Type"
 	contentTypeForm   = "application/x-www-form-urlencoded"
 )

--- a/integrations/google/gmail/client.go
+++ b/integrations/google/gmail/client.go
@@ -40,8 +40,13 @@ var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.Integrati
 		"1 API overview":       "https://developers.google.com/gmail/api/guides",
 		"2 REST API reference": "https://developers.google.com/gmail/api/reference/rest",
 		"3 Go client API":      "https://pkg.go.dev/google.golang.org/api/gmail/v1",
+		"4 Python client API":  "https://developers.google.com/resources/api-libraries/documentation/gmail/v1/python/latest/gmail_v1.users.html",
+		"5 Python samples":     "https://github.com/googleworkspace/python-samples/tree/main/gmail",
 	},
 	ConnectionUrl: "/gmail/connect",
+	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
+		RequiresConnectionInit: true,
+	},
 }))
 
 func New(sec sdkservices.Vars) sdkservices.Integration {

--- a/integrations/google/oauth.go
+++ b/integrations/google/oauth.go
@@ -91,7 +91,7 @@ func (h handler) HandleOAuth(w http.ResponseWriter, r *http.Request) {
 }
 
 func redirectToErrorPage(w http.ResponseWriter, r *http.Request, err string) {
-	u := fmt.Sprintf("%serror.html?error=%s", desc.ConnectionURL().Path, url.QueryEscape(err))
+	u := fmt.Sprintf("%s/error.html?error=%s", desc.ConnectionURL().Path, url.QueryEscape(err))
 	http.Redirect(w, r, u, http.StatusFound)
 }
 

--- a/integrations/google/oauth.go
+++ b/integrations/google/oauth.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
@@ -18,10 +19,6 @@ import (
 )
 
 const (
-	// uiPath is the URL root path of a simple web UI to interact with users at
-	// the beginning and the end of their 3-legged OAuth v2 flow with Google.
-	uiPath = "/google/connect/"
-
 	// oauthPath is the URL path for our handler to save new OAuth-based connections.
 	oauthPath = "/google/oauth"
 )
@@ -50,40 +47,52 @@ func (h handler) HandleOAuth(w http.ResponseWriter, r *http.Request) {
 	e := r.FormValue("error")
 	if e != "" {
 		l.Warn("OAuth redirect request reported an error", zap.Error(errors.New(e)))
-		u := fmt.Sprintf("%serror.html?error=%s", uiPath, e)
-		http.Redirect(w, r, u, http.StatusFound)
+		redirectToErrorPage(w, r, e)
 		return
 	}
 
-	rawOAuthData, oauthData, err := sdkintegrations.GetOAuthDataFromURL(r.URL)
+	raw, data, err := sdkintegrations.GetOAuthDataFromURL(r.URL)
 	if err != nil {
-		l.Warn("Failed to decode OAuth data", zap.Error(err))
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		l.Warn("Invalid data in OAuth redirect request", zap.Error(err))
+		redirectToErrorPage(w, r, "invalid data parameter")
 		return
 
+	}
+
+	oauthToken := data.Token
+	if oauthToken == nil {
+		l.Warn("Missing token in OAuth redirect request", zap.Any("data", data))
+		redirectToErrorPage(w, r, "missing OAuth token")
+		return
 	}
 
 	// Test the OAuth token's usability and get authoritative installation details.
-	src := h.tokenSource(r.Context(), oauthData.Token)
-	svc, err := googleoauth2.NewService(r.Context(), option.WithTokenSource(src))
+	ctx := r.Context()
+	src := h.tokenSource(ctx, oauthToken)
+	svc, err := googleoauth2.NewService(ctx, option.WithTokenSource(src))
 	if err != nil {
 		l.Warn("OAuth user token error", zap.Error(err))
-		http.Error(w, "Internal Server Error: token source", http.StatusInternalServerError)
+		redirectToErrorPage(w, r, "token source")
 		return
 	}
 
-	uvars, err := h.getUserDetails(svc)
+	user, err := h.getUserDetails(l, svc)
 	if err != nil {
 		l.Warn("OAuth user details error", zap.Error(err))
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		redirectToErrorPage(w, r, "Google user details error")
 		return
 	}
 
-	initData := sdktypes.EncodeVars(&vars.Vars{OAuthData: rawOAuthData}).
-		Append(oauthData.ToVars()...).
-		Append(uvars...)
+	initData := sdktypes.EncodeVars(&vars.Vars{OAuthData: raw}).
+		Append(data.ToVars()...).
+		Append(user...)
 
 	sdkintegrations.FinalizeConnectionInit(w, r, integrationID, initData)
+}
+
+func redirectToErrorPage(w http.ResponseWriter, r *http.Request, err string) {
+	u := fmt.Sprintf("%serror.html?error=%s", desc.ConnectionURL().Path, url.QueryEscape(err))
+	http.Redirect(w, r, u, http.StatusFound)
 }
 
 func (h handler) tokenSource(ctx context.Context, t *oauth2.Token) oauth2.TokenSource {
@@ -94,16 +103,14 @@ func (h handler) tokenSource(ctx context.Context, t *oauth2.Token) oauth2.TokenS
 	return cfg.TokenSource(ctx, t)
 }
 
-func (h handler) getUserDetails(svc *googleoauth2.Service) (sdktypes.Vars, error) {
+func (h handler) getUserDetails(l *zap.Logger, svc *googleoauth2.Service) (sdktypes.Vars, error) {
 	ui, err := svc.Userinfo.V2.Me.Get().Do()
 	if err != nil {
-		h.logger.Warn("OAuth user info retrieval error",
-			zap.Error(err),
-		)
+		l.Warn("OAuth user info retrieval error", zap.Error(err))
 		return nil, err
 	}
 	if ui.Email == "" || !*ui.VerifiedEmail {
-		h.logger.Warn("OAuth user info is bad",
+		l.Warn("OAuth user info is bad",
 			zap.Any("userInfo", ui),
 			zap.Error(err),
 		)
@@ -112,14 +119,14 @@ func (h handler) getUserDetails(svc *googleoauth2.Service) (sdktypes.Vars, error
 
 	ti, err := svc.Tokeninfo().Do()
 	if err != nil {
-		h.logger.Warn("OAuth token info retrieval error",
+		l.Warn("OAuth token info retrieval error",
 			zap.Any("userInfo", ui),
 			zap.Error(err),
 		)
 		return nil, err
 	}
 	if ti.Email != ui.Email {
-		h.logger.Warn("OAuth token info is bad",
+		l.Warn("OAuth token info is bad",
 			zap.Any("userInfo", ui),
 			zap.Any("tokenInfo", ti),
 			zap.Error(err),

--- a/integrations/google/oauth.go
+++ b/integrations/google/oauth.go
@@ -18,11 +18,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-const (
-	// oauthPath is the URL path for our handler to save new OAuth-based connections.
-	oauthPath = "/google/oauth"
-)
-
 // handler is an autokitteh webhook which implements [http.Handler]
 // to receive and dispatch asynchronous event notifications.
 type handler struct {

--- a/integrations/google/server.go
+++ b/integrations/google/server.go
@@ -11,11 +11,13 @@ import (
 )
 
 func Start(l *zap.Logger, mux *http.ServeMux, o sdkservices.OAuth, d sdkservices.Dispatcher) {
+	uiPath := "GET " + desc.ConnectionURL().Path + "/"
+
 	// New connection UIs + handlers.
 	h := NewHTTPHandler(l, o)
 	mux.Handle(uiPath, http.FileServer(http.FS(static.GoogleWebContent)))
-	mux.HandleFunc(oauthPath, h.HandleOAuth)
-	mux.HandleFunc(credsPath, h.HandleCreds)
+	mux.HandleFunc("GET "+oauthPath, h.HandleOAuth)
+	mux.HandleFunc("POST "+credsPath, h.HandleCreds)
 
 	urlPath := strings.ReplaceAll(uiPath, "google", "gmail")
 	mux.Handle(urlPath, http.FileServer(http.FS(static.GmailWebContent)))

--- a/integrations/google/server.go
+++ b/integrations/google/server.go
@@ -25,8 +25,6 @@ func Start(l *zap.Logger, mux *http.ServeMux, o sdkservices.OAuth, d sdkservices
 	// New connection UIs + handlers.
 	h := NewHTTPHandler(l, o)
 	mux.Handle(uiPath, http.FileServer(http.FS(static.GoogleWebContent)))
-	mux.HandleFunc("GET "+oauthPath, h.HandleOAuth)
-	mux.HandleFunc("POST "+credsPath, h.HandleCreds)
 
 	urlPath := strings.ReplaceAll(uiPath, "google", "gmail")
 	mux.Handle(urlPath, http.FileServer(http.FS(static.GmailWebContent)))
@@ -45,6 +43,9 @@ func Start(l *zap.Logger, mux *http.ServeMux, o sdkservices.OAuth, d sdkservices
 
 	urlPath = strings.ReplaceAll(uiPath, "google", "googlesheets")
 	mux.Handle(urlPath, http.FileServer(http.FS(static.GoogleSheetsWebContent)))
+
+	mux.HandleFunc("GET "+oauthPath, h.HandleOAuth)
+	mux.HandleFunc("POST "+credsPath, h.HandleCreds)
 
 	// TODO: Event webhooks.
 }

--- a/integrations/google/server.go
+++ b/integrations/google/server.go
@@ -10,6 +10,15 @@ import (
 	"go.autokitteh.dev/autokitteh/web/static"
 )
 
+const (
+	// credsPath is the URL path for our handler to save a new autokitteh
+	// credentials-based connection, after the user submits it via a web form.
+	credsPath = "/google/save"
+
+	// oauthPath is the URL path for our handler to save new OAuth-based connections.
+	oauthPath = "/google/oauth"
+)
+
 func Start(l *zap.Logger, mux *http.ServeMux, o sdkservices.OAuth, d sdkservices.Dispatcher) {
 	uiPath := "GET " + desc.ConnectionURL().Path + "/"
 

--- a/integrations/google/sheets/client.go
+++ b/integrations/google/sheets/client.go
@@ -39,8 +39,13 @@ var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.Integrati
 	UserLinks: map[string]string{
 		"1 REST API reference": "https://developers.google.com/sheets/api/reference/rest",
 		"2 Go client API":      "https://pkg.go.dev/google.golang.org/api/sheets/v4",
+		"3 Python client API":  "https://developers.google.com/resources/api-libraries/documentation/sheets/v4/python/latest/sheets_v4.spreadsheets.html",
+		"4 Python samples":     "https://github.com/googleworkspace/python-samples/tree/main/sheets",
 	},
 	ConnectionUrl: "/googlesheets/connect",
+	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
+		RequiresConnectionInit: true,
+	},
 }))
 
 func New(sec sdkservices.Vars) sdkservices.Integration {

--- a/integrations/http/save.go
+++ b/integrations/http/save.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -13,8 +14,7 @@ import (
 )
 
 const (
-	HeaderContentType = "Content-Type"
-	ContentTypeForm   = "application/x-www-form-urlencoded"
+	headerContentType = "Content-Type"
 )
 
 var authVar = sdktypes.NewSymbol("auth")
@@ -23,31 +23,23 @@ var authVar = sdktypes.NewSymbol("auth")
 func (h handler) handleAuth(w http.ResponseWriter, r *http.Request) {
 	l := h.logger.With(zap.String("urlPath", r.URL.Path))
 
-	// Check "Content-Type" header.
-	ct := r.Header.Get(HeaderContentType)
-	if ct != ContentTypeForm {
-		l.Warn("Unexpected header value",
-			zap.String("header", HeaderContentType),
-			zap.String("got", ct),
-			zap.String("want", ContentTypeForm),
-		)
-		e := fmt.Sprintf("Unexpected Content-Type header: %q", ct)
-		u := fmt.Sprintf("%serror.html?error=%s", uiPath, url.QueryEscape(e))
-		http.Redirect(w, r, u, http.StatusFound)
+	// Check the "Content-Type" header.
+	contentType := r.Header.Get(headerContentType)
+	if !strings.HasPrefix(contentType, contentTypeForm) {
+		// This is probably an attack, so no user-friendliness.
+		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}
 
 	// Read and parse POST request body.
-	err := r.ParseForm()
-	if err != nil {
-		l.Warn("Failed to parse inbound HTTP request",
-			zap.Error(err),
-		)
-		e := "Form parsing error: " + err.Error()
-		u := fmt.Sprintf("%serror.html?error=%s", uiPath, url.QueryEscape(e))
+	if err := r.ParseForm(); err != nil {
+		l.Warn("Failed to parse inbound HTTP request", zap.Error(err))
+		msg := url.QueryEscape(err.Error())
+		u := fmt.Sprintf("%s/error.html?error=%s", desc.ConnectionURL().Path, msg)
 		http.Redirect(w, r, u, http.StatusFound)
 		return
 	}
+
 	basic := r.Form.Get("basic_username") + ":" + r.Form.Get("basic_password")
 	bearer := r.Form.Get("bearer_access_token")
 

--- a/integrations/http/save.go
+++ b/integrations/http/save.go
@@ -26,7 +26,7 @@ func (h handler) handleAuth(w http.ResponseWriter, r *http.Request) {
 	// Check the "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
 	if !strings.HasPrefix(contentType, contentTypeForm) {
-		// This is probably an attack, so no user-friendliness.
+		// Probably an attack, so no need for user-friendliness.
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}

--- a/integrations/http/server.go
+++ b/integrations/http/server.go
@@ -143,8 +143,6 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Dispatch the event to all of them, for asynchronous handling.
 	h.dispatchAsyncEventsToConnections(ctx, conns, env, event)
-
-	// Returning immediately without an error = acknowledgement of receipt.
 }
 
 func (h handler) dispatchAsyncEventsToConnections(ctx context.Context, cs []sdktypes.Connection, env string, event sdktypes.Event) {

--- a/integrations/http/server.go
+++ b/integrations/http/server.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/internal/extrazap"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
@@ -16,9 +18,6 @@ import (
 )
 
 const (
-	// Save new autokitteh connections with user-submitted secrets.
-	uiPath = "/i/http/connect/"
-
 	// savePath is the URL path for our handler to save a new autokitteh
 	// connection, after the user submits its details via a web form.
 	savePath = "/i/http/save"
@@ -45,14 +44,13 @@ func Start(l *zap.Logger, mux *http.ServeMux, d sdkservices.Dispatcher, c sdkser
 	mux.Handle(routePrefix("{ns}")+"*", h)
 
 	// Save new autokitteh connections with user-submitted HTTP secrets.
-	mux.Handle(uiPath, http.FileServer(http.FS(static.HTTPWebContent)))
+	mux.Handle(desc.ConnectionURL().Path, http.FileServer(http.FS(static.HTTPWebContent)))
 	mux.HandleFunc(savePath, h.handleAuth)
 }
 
 func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	l := h.logger.With(zap.String("url", r.URL.String()))
-
-	l.Info("incoming request")
+	l := h.logger.With(zap.String("urlPath", r.URL.Path))
+	l.Info("Incoming HTTP request")
 
 	ns := r.PathValue("ns")
 	env := strings.ReplaceAll(ns, ".", "/")
@@ -109,11 +107,16 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Data:      kittehs.TransformMapValues(data, sdktypes.ToProto),
 	})
 	if err != nil {
-		l.Error("create event error", zap.Error(err))
+		l.Error("Failed to convert protocol buffer to SDK event",
+			zap.String("eventType", strings.ToLower(r.Method)),
+			zap.Any("data", data),
+			zap.Error(err),
+		)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 
-	ctx := r.Context()
+	ctx := extrazap.AttachLoggerToContext(l, r.Context())
 
 	pname, err := sdktypes.StrictParseSymbol(strings.SplitN(env, "/", 2)[0])
 	if err != nil {
@@ -127,23 +130,37 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Retrieve all the relevant connections for this event.
 	conns, err := h.conns.List(ctx, sdkservices.ListConnectionsFilter{
 		IntegrationID: IntegrationID,
 		ProjectID:     p.ID(),
 	})
 	if err != nil {
-		l.Error("list connections error", zap.Error(err))
+		l.Error("Failed to find connection IDs", zap.Error(err))
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 
-	for _, c := range conns {
-		cid := c.ID()
-		l := l.With(zap.String("cid", cid.String()))
-		eid, err := h.dispatcher.Dispatch(ctx, event.WithConnectionID(cid), &sdkservices.DispatchOptions{Env: env})
-		if err != nil {
-			l.Error("dispatch error", zap.Error(err))
-		}
+	// Dispatch the event to all of them, for asynchronous handling.
+	h.dispatchAsyncEventsToConnections(ctx, conns, env, event)
 
-		l.Info("dispatched", zap.String("event_id", eid.String()))
+	// Returning immediately without an error = acknowledgement of receipt.
+}
+
+func (h handler) dispatchAsyncEventsToConnections(ctx context.Context, cs []sdktypes.Connection, env string, event sdktypes.Event) {
+	l := extrazap.ExtractLoggerFromContext(ctx)
+	for _, c := range cs {
+		cid := c.ID()
+		opts := &sdkservices.DispatchOptions{Env: env}
+		eid, err := h.dispatcher.Dispatch(ctx, event.WithConnectionID(cid), opts)
+		l := l.With(
+			zap.String("connectionID", cid.String()),
+			zap.String("eventID", eid.String()),
+		)
+		if err != nil {
+			l.Error("Event dispatch failed", zap.Error(err))
+			return
+		}
+		l.Debug("Event dispatched")
 	}
 }

--- a/integrations/jira/client.go
+++ b/integrations/jira/client.go
@@ -29,7 +29,7 @@ var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.Integrati
 		"4 Python Jira API":           "https://jira.readthedocs.io/",
 		"5 Python Jira examples":      "https://github.com/pycontribs/jira/tree/main/examples",
 	},
-	ConnectionUrl: "/jira/connect/",
+	ConnectionUrl: "/jira/connect",
 	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
 		RequiresConnectionInit: true,
 	},

--- a/integrations/jira/event.go
+++ b/integrations/jira/event.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/internal/extrazap"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
@@ -94,7 +95,7 @@ func (h handler) handleEvent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Iterate through all the relevant connections for this event.
-	ctx := r.Context()
+	ctx := extrazap.AttachLoggerToContext(l, r.Context())
 	key := sdktypes.NewSymbol("webhook_id")
 	for _, id := range e.MatchedWebhookIDs {
 		value := fmt.Sprintf("%d", id)
@@ -105,7 +106,7 @@ func (h handler) handleEvent(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Dispatch the event to all of them, for asynchronous handling.
-		h.dispatchAsyncEventsToConnections(ctx, l, cids, event)
+		h.dispatchAsyncEventsToConnections(ctx, cids, event)
 	}
 
 	// Returning immediately without an error = acknowledgement of receipt.
@@ -128,47 +129,50 @@ func verifyJWT(l *zap.Logger, authz string) bool {
 	return token.Valid
 }
 
-func constructEvent(l *zap.Logger, body []byte, e event) (*sdktypes.EventPB, error) {
+func constructEvent(l *zap.Logger, body []byte, e event) (sdktypes.Event, error) {
+	l = l.With(zap.Any("event", body))
+
 	m := map[string]string{"json": string(body)}
 	wrapped, err := sdktypes.DefaultValueWrapper.Wrap(m)
 	if err != nil {
-		l.Error("Failed to wrap Jira event", zap.Any("event", body), zap.Error(err))
-		return nil, err
+		l.Error("Failed to wrap Jira event", zap.Error(err))
+		return sdktypes.InvalidEvent, err
 	}
 
 	data, err := wrapped.ToStringValuesMap()
 	if err != nil {
-		l.Error("Failed to convert wrapped Jira event", zap.Any("event", body), zap.Error(err))
-		return nil, err
+		l.Error("Failed to convert wrapped Jira event", zap.Error(err))
+		return sdktypes.InvalidEvent, err
 	}
 
-	return &sdktypes.EventPB{
+	event, err := sdktypes.EventFromProto(&sdktypes.EventPB{
 		EventType: strings.TrimPrefix(e.WebhookEvent, "jira:"),
 		Data:      kittehs.TransformMapValues(data, sdktypes.ToProto),
-	}, nil
+	})
+	if err != nil {
+		l.Error("Failed to convert protocol buffer to SDK event",
+			zap.String("eventType", strings.TrimPrefix(e.WebhookEvent, "jira:")),
+			zap.Any("data", data),
+			zap.Error(err),
+		)
+		return sdktypes.InvalidEvent, err
+	}
+
+	return event, nil
 }
 
-func (h handler) dispatchAsyncEventsToConnections(ctx context.Context, l *zap.Logger, cids []sdktypes.ConnectionID, event *sdktypes.EventPB) {
+func (h handler) dispatchAsyncEventsToConnections(ctx context.Context, cids []sdktypes.ConnectionID, e sdktypes.Event) {
+	l := extrazap.ExtractLoggerFromContext(ctx)
 	for _, cid := range cids {
-		event.ConnectionId = cid.String()
-		e, err := sdktypes.EventFromProto(event)
-		if err != nil {
-			l.Error("Failed to convert protocol buffer to SDK event", zap.Error(err))
-			return
-		}
-
-		eventID, err := h.dispatcher.Dispatch(ctx, e, nil)
-		if err != nil {
-			l.Error("Event dispatch failed",
-				zap.String("eventID", eventID.String()),
-				zap.String("connectionID", cid.String()),
-				zap.Error(err),
-			)
-			return
-		}
-		l.Debug("Event dispatched",
-			zap.String("eventID", eventID.String()),
+		eid, err := h.dispatcher.Dispatch(ctx, e.WithConnectionID(cid), nil)
+		l := l.With(
 			zap.String("connectionID", cid.String()),
+			zap.String("eventID", eid.String()),
 		)
+		if err != nil {
+			l.Error("Event dispatch failed", zap.Error(err))
+			return
+		}
+		l.Debug("Event dispatched")
 	}
 }

--- a/integrations/jira/event.go
+++ b/integrations/jira/event.go
@@ -59,6 +59,7 @@ func (h handler) handleEvent(w http.ResponseWriter, r *http.Request) {
 	// Verify the JWT in the event's "Authorization" header.
 	token := r.Header.Get(headerAuthorization)
 	if !verifyJWT(l, strings.TrimPrefix(token, "Bearer ")) {
+		// This is probably an attack, so no user-friendliness.
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
@@ -66,6 +67,7 @@ func (h handler) handleEvent(w http.ResponseWriter, r *http.Request) {
 	// Check the "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
 	if !strings.HasPrefix(contentType, contentTypeJSON) {
+		// This is probably an attack, so no user-friendliness.
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}
@@ -73,12 +75,14 @@ func (h handler) handleEvent(w http.ResponseWriter, r *http.Request) {
 	// Parse some of the metadata in the Jira event's JSON content.
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		// This is probably an attack, so no user-friendliness.
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}
 
 	var e event
 	if err := json.Unmarshal(body, &e); err != nil {
+		// This is probably an attack, so no user-friendliness.
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}

--- a/integrations/jira/event.go
+++ b/integrations/jira/event.go
@@ -60,7 +60,7 @@ func (h handler) handleEvent(w http.ResponseWriter, r *http.Request) {
 	// Verify the JWT in the event's "Authorization" header.
 	token := r.Header.Get(headerAuthorization)
 	if !verifyJWT(l, strings.TrimPrefix(token, "Bearer ")) {
-		// This is probably an attack, so no user-friendliness.
+		// Attack or network loss, so no need for user-friendliness.
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
@@ -68,7 +68,7 @@ func (h handler) handleEvent(w http.ResponseWriter, r *http.Request) {
 	// Check the "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
 	if !strings.HasPrefix(contentType, contentTypeJSON) {
-		// This is probably an attack, so no user-friendliness.
+		// Probably an attack, so no need for user-friendliness.
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}
@@ -76,14 +76,14 @@ func (h handler) handleEvent(w http.ResponseWriter, r *http.Request) {
 	// Parse some of the metadata in the Jira event's JSON content.
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		// This is probably an attack, so no user-friendliness.
+		// Attack or network loss, so no need for user-friendliness.
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}
 
 	var e event
 	if err := json.Unmarshal(body, &e); err != nil {
-		// This is probably an attack, so no user-friendliness.
+		// Probably an attack, so no need for user-friendliness.
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}

--- a/integrations/jira/oauth.go
+++ b/integrations/jira/oauth.go
@@ -99,7 +99,7 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 }
 
 func redirectToErrorPage(w http.ResponseWriter, r *http.Request, err string) {
-	u := fmt.Sprintf("%serror.html?error=%s", desc.ConnectionURL().Path, url.QueryEscape(err))
+	u := fmt.Sprintf("%s/error.html?error=%s", desc.ConnectionURL().Path, url.QueryEscape(err))
 	http.Redirect(w, r, u, http.StatusFound)
 }
 

--- a/integrations/jira/server.go
+++ b/integrations/jira/server.go
@@ -19,11 +19,12 @@ const (
 
 func Start(l *zap.Logger, mux *http.ServeMux, vars sdkservices.Vars, o sdkservices.OAuth, d sdkservices.Dispatcher) {
 	// Connection UI + handlers.
-	mux.Handle(desc.ConnectionURL().Path, http.FileServer(http.FS(static.JiraWebContent)))
+	uiPath := "GET " + desc.ConnectionURL().Path + "/"
+	mux.Handle(uiPath, http.FileServer(http.FS(static.JiraWebContent)))
 
 	h := NewHTTPHandler(l, o, vars, d)
-	mux.HandleFunc(oauthPath, h.handleOAuth)
+	mux.HandleFunc("GET "+oauthPath, h.handleOAuth)
 
 	// Event webhook.
-	mux.HandleFunc(webhookPath, h.handleEvent)
+	mux.HandleFunc("POST "+webhookPath, h.handleEvent)
 }

--- a/integrations/slack/client.go
+++ b/integrations/slack/client.go
@@ -26,6 +26,7 @@ var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.Integrati
 	UserLinks: map[string]string{
 		"1 Web API reference":    "https://api.slack.com/methods",
 		"2 Events API reference": "https://api.slack.com/events?filter=Events",
+		"3 Python client API":    "https://slack.dev/python-slack-sdk/api-docs/slack_sdk/",
 	},
 	ConnectionUrl: "/slack/connect",
 	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{

--- a/integrations/slack/oauth.go
+++ b/integrations/slack/oauth.go
@@ -2,28 +2,17 @@ package slack
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 
 	"go.uber.org/zap"
 
-	"go.autokitteh.dev/autokitteh/integrations/internal/extrazap"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/auth"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/bots"
 	"go.autokitteh.dev/autokitteh/integrations/slack/internal/vars"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-)
-
-const (
-	// uiPath is the URL root path of a simple web UI to interact with
-	// users at the beginning and the end of their 3-legged OAuth v2
-	// flow to install a Slack app.
-	uiPath = "/slack/connect/"
-
-	// oauthPath is the URL path for our handler to save
-	// new OAuth-based connections.
-	oauthPath = "/slack/oauth"
 )
 
 // handler is an autokitteh webhook which implements [http.Handler]
@@ -48,43 +37,38 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// https://developers.google.com/identity/protocols/oauth2/web-server#handlingresponse
 	e := r.FormValue("error")
 	if e != "" {
-		l.Warn("OAuth redirect request reported an error",
-			zap.Error(errors.New(e)),
-		)
-		u := uiPath + "error.html?error=" + url.QueryEscape(e)
-		http.Redirect(w, r, u, http.StatusFound)
+		l.Warn("OAuth redirect request reported an error", zap.Error(errors.New(e)))
+		redirectToErrorPage(w, r, e)
 		return
 	}
 
-	oauthDataString, oauthData, err := sdkintegrations.GetOAuthDataFromURL(r.URL)
+	raw, data, err := sdkintegrations.GetOAuthDataFromURL(r.URL)
 	if err != nil {
-		l.Warn("Failed to decode OAuth data", zap.Error(err))
-		http.Error(w, "Bad request: invalid OAuth data", http.StatusBadRequest)
+		l.Warn("Invalid data in OAuth redirect request", zap.Error(err))
+		redirectToErrorPage(w, r, "invalid data parameter")
 		return
 	}
 
-	oauthToken := oauthData.Token
+	oauthToken := data.Token
 	if oauthToken == nil {
-		l.Warn("OAuth data missing token")
-		http.Error(w, "Bad request: missing OAuth token", http.StatusBadRequest)
+		l.Warn("Missing token in OAuth redirect request", zap.Any("data", data))
+		redirectToErrorPage(w, r, "missing OAuth token")
 		return
 	}
 
 	// Test the OAuth token's usability and get authoritative installation details.
-	ctx := extrazap.AttachLoggerToContext(l, r.Context())
+	ctx := r.Context()
 	authTest, err := auth.TestWithToken(ctx, oauthToken.AccessToken)
 	if err != nil {
-		e := "OAuth token test failed: " + err.Error()
-		u := uiPath + "error.html?error=" + url.QueryEscape(e)
-		http.Redirect(w, r, u, http.StatusFound)
+		l.Warn("Slack OAuth token test failed", zap.Error(err))
+		redirectToErrorPage(w, r, "OAuth token test failed: "+err.Error())
 		return
 	}
 
 	botInfo, err := bots.InfoWithToken(ctx, oauthToken.AccessToken, authTest)
 	if err != nil {
-		e := "Bot info request failed: " + err.Error()
-		u := uiPath + "error.html?error=" + url.QueryEscape(e)
-		http.Redirect(w, r, u, http.StatusFound)
+		l.Warn("Slack bot info request failed", zap.Error(err))
+		redirectToErrorPage(w, r, "Bot info request failed: "+err.Error())
 		return
 	}
 
@@ -97,8 +81,13 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		},
 	).
 		Set(vars.KeyName, key, false).
-		Set(vars.OAuthDataName, oauthDataString, true).
-		Append(oauthData.ToVars()...)
+		Set(vars.OAuthDataName, raw, true).
+		Append(data.ToVars()...)
 
 	sdkintegrations.FinalizeConnectionInit(w, r, integrationID, initData)
+}
+
+func redirectToErrorPage(w http.ResponseWriter, r *http.Request, err string) {
+	u := fmt.Sprintf("%s/error.html?error=%s", desc.ConnectionURL().Path, url.QueryEscape(err))
+	http.Redirect(w, r, u, http.StatusFound)
 }

--- a/integrations/slack/oauth.go
+++ b/integrations/slack/oauth.go
@@ -8,6 +8,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/internal/extrazap"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/auth"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/bots"
 	"go.autokitteh.dev/autokitteh/integrations/slack/internal/vars"
@@ -57,18 +58,18 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Test the OAuth token's usability and get authoritative installation details.
-	ctx := r.Context()
+	ctx := extrazap.AttachLoggerToContext(l, r.Context())
 	authTest, err := auth.TestWithToken(ctx, oauthToken.AccessToken)
 	if err != nil {
 		l.Warn("Slack OAuth token test failed", zap.Error(err))
-		redirectToErrorPage(w, r, "OAuth token test failed: "+err.Error())
+		redirectToErrorPage(w, r, "token auth test failed: "+err.Error())
 		return
 	}
 
 	botInfo, err := bots.InfoWithToken(ctx, oauthToken.AccessToken, authTest)
 	if err != nil {
 		l.Warn("Slack bot info request failed", zap.Error(err))
-		redirectToErrorPage(w, r, "Bot info request failed: "+err.Error())
+		redirectToErrorPage(w, r, "bot info request failed: "+err.Error())
 		return
 	}
 

--- a/integrations/slack/webhooks/bot_events.go
+++ b/integrations/slack/webhooks/bot_events.go
@@ -9,7 +9,6 @@ import (
 	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 	"go.autokitteh.dev/autokitteh/integrations/slack/events"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
-	valuesv1 "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/values/v1"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
@@ -71,8 +70,8 @@ func (h handler) HandleBotEvent(w http.ResponseWriter, r *http.Request) {
 	cb := &events.Callback{}
 	if err := json.Unmarshal(body, cb); err != nil {
 		l.Error("Failed to parse bot event's JSON payload",
-			zap.Error(err),
 			zap.ByteString("json", body),
+			zap.Error(err),
 		)
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
@@ -109,29 +108,28 @@ func (h handler) HandleBotEvent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Retrieve all the relevant connections for this event.
+	ctx := r.Context()
 	enterpriseID := "" // TODO: Support enterprise IDs.
-	cids, err := h.listConnectionIDs(r.Context(), cb.APIAppID, enterpriseID, cb.TeamID)
+	cids, err := h.listConnectionIDs(ctx, cb.APIAppID, enterpriseID, cb.TeamID)
 	if err != nil {
-		l.Error("Failed to retrieve connection tokens",
-			zap.Error(err),
-		)
+		l.Error("Failed to find connection IDs", zap.Error(err))
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 
 	// Dispatch the event to all of them, for asynchronous handling.
-	h.dispatchAsyncEventsToConnections(l, cids, akEvent)
+	h.dispatchAsyncEventsToConnections(ctx, l, cids, akEvent)
 
 	// Returning immediately without an error = acknowledgement of receipt.
 }
 
 // transformEvent transforms a received Slack event into an autokitteh event.
-func transformEvent(l *zap.Logger, w http.ResponseWriter, event any) (map[string]*valuesv1.Value, error) {
+func transformEvent(l *zap.Logger, w http.ResponseWriter, event any) (map[string]*sdktypes.ValuePB, error) {
 	wrapped, err := sdktypes.DefaultValueWrapper.Wrap(event)
 	if err != nil {
 		l.Error("Failed to wrap Slack event",
-			zap.Error(err),
 			zap.Any("innerEvent", event),
+			zap.Error(err),
 		)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return nil, err
@@ -139,8 +137,8 @@ func transformEvent(l *zap.Logger, w http.ResponseWriter, event any) (map[string
 	data, err := wrapped.ToStringValuesMap()
 	if err != nil {
 		l.Error("Failed to convert wrapped Slack event",
-			zap.Error(err),
 			zap.Any("innerEvent", event),
+			zap.Error(err),
 		)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return nil, err

--- a/integrations/slack/webhooks/interaction.go
+++ b/integrations/slack/webhooks/interaction.go
@@ -17,7 +17,6 @@ import (
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/conversations"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/users"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
-	valuesv1 "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/values/v1"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
@@ -129,8 +128,8 @@ func (h handler) HandleInteraction(w http.ResponseWriter, r *http.Request) {
 	j, err := url.QueryUnescape(string(body))
 	if err != nil {
 		l.Error("Failed to URL-decode interaction callback",
-			zap.Error(err),
 			zap.ByteString("body", body),
+			zap.Error(err),
 		)
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
@@ -139,8 +138,8 @@ func (h handler) HandleInteraction(w http.ResponseWriter, r *http.Request) {
 	payload := &BlockActionsPayload{}
 	if err := json.Unmarshal([]byte(j), payload); err != nil {
 		l.Error("Failed to parse URL-decoded JSON payload",
-			zap.Error(err),
 			zap.String("json", j),
+			zap.Error(err),
 		)
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
@@ -157,21 +156,20 @@ func (h handler) HandleInteraction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Retrieve all the relevant connections for this event.
+	ctx := r.Context()
 	enterpriseID := ""
 	if payload.IsEnterpriseInstall {
 		enterpriseID = payload.User.EnterpriseUser.EnterpriseID
 	}
-	cids, err := h.listConnectionIDs(r.Context(), payload.APIAppID, enterpriseID, payload.Team.ID)
+	cids, err := h.listConnectionIDs(ctx, payload.APIAppID, enterpriseID, payload.Team.ID)
 	if err != nil {
-		l.Error("Failed to retrieve connection tokens",
-			zap.Error(err),
-		)
+		l.Error("Failed to find connection IDs", zap.Error(err))
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 
 	// Dispatch the event to all of them, for asynchronous handling.
-	h.dispatchAsyncEventsToConnections(l, cids, akEvent)
+	h.dispatchAsyncEventsToConnections(ctx, l, cids, akEvent)
 
 	// It's a Slack best practice to update an interactive message after the interaction,
 	// to prevent further interaction with the same message, and to reflect the user actions.
@@ -180,12 +178,12 @@ func (h handler) HandleInteraction(w http.ResponseWriter, r *http.Request) {
 }
 
 // transformPayload transforms a received Slack event into an autokitteh event.
-func transformPayload(l *zap.Logger, w http.ResponseWriter, payload *BlockActionsPayload) (map[string]*valuesv1.Value, error) {
+func transformPayload(l *zap.Logger, w http.ResponseWriter, payload *BlockActionsPayload) (map[string]*sdktypes.ValuePB, error) {
 	wrapped, err := sdktypes.DefaultValueWrapper.Wrap(payload)
 	if err != nil {
 		l.Error("Failed to wrap Slack event",
-			zap.Error(err),
 			zap.Any("payload", payload),
+			zap.Error(err),
 		)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return nil, err
@@ -193,8 +191,8 @@ func transformPayload(l *zap.Logger, w http.ResponseWriter, payload *BlockAction
 	data, err := wrapped.ToStringValuesMap()
 	if err != nil {
 		l.Error("Failed to convert wrapped Slack event",
-			zap.Error(err),
 			zap.Any("payload", payload),
+			zap.Error(err),
 		)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return nil, err

--- a/integrations/slack/webhooks/webhook.go
+++ b/integrations/slack/webhooks/webhook.go
@@ -14,8 +14,10 @@ import (
 
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/internal/extrazap"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 	"go.autokitteh.dev/autokitteh/integrations/slack/internal/vars"
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
@@ -139,34 +141,57 @@ func verifySignature(signingSecret, ts, want string, body []byte) bool {
 	return hmac.Equal([]byte(got), []byte(want))
 }
 
+// Transform the received Slack event into an AutoKitteh event.
+func transformEvent(l *zap.Logger, slackEvent any, eventType string) (sdktypes.Event, error) {
+	l = l.With(
+		zap.String("eventType", eventType),
+		zap.Any("event", slackEvent),
+	)
+
+	wrapped, err := sdktypes.DefaultValueWrapper.Wrap(slackEvent)
+	if err != nil {
+		l.Error("Failed to wrap Slack event", zap.Error(err))
+		return sdktypes.InvalidEvent, err
+	}
+
+	data, err := wrapped.ToStringValuesMap()
+	if err != nil {
+		l.Error("Failed to convert wrapped Slack event", zap.Error(err))
+		return sdktypes.InvalidEvent, err
+	}
+
+	akEvent, err := sdktypes.EventFromProto(&sdktypes.EventPB{
+		EventType: eventType,
+		Data:      kittehs.TransformMapValues(data, sdktypes.ToProto),
+	})
+	if err != nil {
+		l.Error("Failed to convert protocol buffer to SDK event",
+			zap.Any("data", data),
+			zap.Error(err),
+		)
+		return sdktypes.InvalidEvent, err
+	}
+
+	return akEvent, nil
+}
+
 func (h handler) listConnectionIDs(ctx context.Context, appID, enterpriseID, teamID string) ([]sdktypes.ConnectionID, error) {
 	key := vars.KeyValue(appID, enterpriseID, teamID)
 	return h.vars.FindConnectionIDs(ctx, h.integrationID, vars.KeyName, key)
 }
 
-func (h handler) dispatchAsyncEventsToConnections(ctx context.Context, l *zap.Logger, cids []sdktypes.ConnectionID, event *sdktypes.EventPB) {
+func (h handler) dispatchAsyncEventsToConnections(ctx context.Context, cids []sdktypes.ConnectionID, e sdktypes.Event) {
+	l := extrazap.ExtractLoggerFromContext(ctx)
 	for _, cid := range cids {
-		l := l.With(zap.String("cid", cid.String()))
-
-		event.ConnectionId = cid.String()
-		event, err := sdktypes.EventFromProto(event)
-		if err != nil {
-			h.logger.Error("Failed to convert protocol buffer to SDK event", zap.Error(err))
-			return
-		}
-
-		eventID, err := h.dispatcher.Dispatch(ctx, event, nil)
-		if err != nil {
-			l.Error("Event dispatch failed",
-				zap.String("eventID", eventID.String()),
-				zap.String("connectionID", cid.String()),
-				zap.Error(err),
-			)
-			return
-		}
-		l.Debug("Event dispatched",
-			zap.String("eventID", eventID.String()),
+		eid, err := h.dispatcher.Dispatch(ctx, e.WithConnectionID(cid), nil)
+		l := l.With(
 			zap.String("connectionID", cid.String()),
+			zap.String("eventID", eid.String()),
 		)
+		if err != nil {
+			l.Error("Event dispatch failed", zap.Error(err))
+			return
+		}
+		l.Debug("Event dispatched")
 	}
 }

--- a/integrations/slack/websockets/form.go
+++ b/integrations/slack/websockets/form.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -19,39 +20,31 @@ import (
 const (
 	// uiPath is the URL root path of a simple web UI to interact
 	// with users to install a Slack Socket Mode app.
-	uiPath = "/slack/connect/"
+	uiPath = "/slack/connect"
 
-	HeaderContentType = "Content-Type"
-	ContentTypeForm   = "application/x-www-form-urlencoded"
+	headerContentType = "Content-Type"
+	contentTypeForm   = "application/x-www-form-urlencoded"
 )
 
 // HandleForm saves a new autokitteh connection, based on a user-submitted form.
 func (h handler) HandleForm(w http.ResponseWriter, r *http.Request) {
 	l := h.logger.With(zap.String("urlPath", r.URL.Path))
 
-	// Check "Content-Type" header.
-	ct := r.Header.Get(HeaderContentType)
-	if ct != ContentTypeForm {
-		l.Warn("Unexpected header value",
-			zap.String("header", HeaderContentType),
-			zap.String("got", ct),
-			zap.String("want", ContentTypeForm),
-		)
-		e := fmt.Sprintf("Unexpected Content-Type header: %q", ct)
-		u := uiPath + "error.html?error=" + url.QueryEscape(e)
-		http.Redirect(w, r, u, http.StatusFound)
+	// Check the "Content-Type" header.
+	contentType := r.Header.Get(headerContentType)
+	if !strings.HasPrefix(contentType, contentTypeForm) {
+		// This is probably an attack, so no user-friendliness.
+		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}
 
 	// Read and parse POST request body.
-	err := r.ParseForm()
-	if err != nil {
+	if err := r.ParseForm(); err != nil {
 		l.Warn("Failed to parse inbound HTTP request", zap.Error(err))
-		e := "Form parsing error: " + err.Error()
-		u := uiPath + "error.html?error=" + url.QueryEscape(e)
-		http.Redirect(w, r, u, http.StatusFound)
+		redirectToErrorPage(w, r, "form parsing error: "+err.Error())
 		return
 	}
+
 	botToken := r.Form.Get("bot_token")
 	appToken := r.Form.Get("app_token")
 
@@ -59,25 +52,22 @@ func (h handler) HandleForm(w http.ResponseWriter, r *http.Request) {
 	ctx := extrazap.AttachLoggerToContext(l, r.Context())
 	authTest, err := auth.TestWithToken(ctx, botToken)
 	if err != nil {
-		e := "Bot token test failed: " + err.Error()
-		u := uiPath + "error.html?error=" + url.QueryEscape(e)
-		http.Redirect(w, r, u, http.StatusFound)
+		l.Warn("Slack OAuth token test failed", zap.Error(err))
+		redirectToErrorPage(w, r, "token auth test failed: "+err.Error())
 		return
 	}
 
 	botInfo, err := bots.InfoWithToken(ctx, botToken, authTest)
 	if err != nil {
-		e := "Bot info request failed: " + err.Error()
-		u := uiPath + "error.html?error=" + url.QueryEscape(e)
-		http.Redirect(w, r, u, http.StatusFound)
+		l.Warn("Slack bot info request failed", zap.Error(err))
+		redirectToErrorPage(w, r, "bot info request failed: "+err.Error())
 		return
 	}
 
 	_, err = apps.ConnectionsOpenWithToken(ctx, h.vars, appToken)
 	if err != nil {
-		e := "Socket connection test failed: " + err.Error()
-		u := uiPath + "error.html?error=" + url.QueryEscape(e)
-		http.Redirect(w, r, u, http.StatusFound)
+		l.Warn("Slack websocket connection error", zap.Error(err))
+		redirectToErrorPage(w, r, "websocket connection error: "+err.Error())
 		return
 	}
 
@@ -95,4 +85,9 @@ func (h handler) HandleForm(w http.ResponseWriter, r *http.Request) {
 	h.OpenSocketModeConnection(botInfo.Bot.AppID, botToken, appToken)
 
 	sdkintegrations.FinalizeConnectionInit(w, r, h.integrationID, initData)
+}
+
+func redirectToErrorPage(w http.ResponseWriter, r *http.Request, err string) {
+	u := fmt.Sprintf("%s/error.html?error=%s", uiPath, url.QueryEscape(err))
+	http.Redirect(w, r, u, http.StatusFound)
 }

--- a/integrations/slack/websockets/form.go
+++ b/integrations/slack/websockets/form.go
@@ -33,7 +33,7 @@ func (h handler) HandleForm(w http.ResponseWriter, r *http.Request) {
 	// Check the "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
 	if !strings.HasPrefix(contentType, contentTypeForm) {
-		// This is probably an attack, so no user-friendliness.
+		// Probably an attack, so no need for user-friendliness.
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}

--- a/integrations/twilio/client.go
+++ b/integrations/twilio/client.go
@@ -23,6 +23,9 @@ var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.Integrati
 		"2 Voice API overview":     "https://www.twilio.com/docs/voice/api",
 	},
 	ConnectionUrl: "/twilio/connect",
+	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
+		RequiresConnectionInit: true,
+	},
 }))
 
 func New(vars sdkservices.Vars) sdkservices.Integration {

--- a/integrations/twilio/server.go
+++ b/integrations/twilio/server.go
@@ -10,16 +10,13 @@ import (
 	"go.autokitteh.dev/autokitteh/web/static"
 )
 
-const (
-	// Save new autokitteh connections with user-submitted Twilio secrets.
-	uiPath = "/twilio/connect/"
-)
-
 func Start(l *zap.Logger, mux *http.ServeMux, vars sdkservices.Vars, d sdkservices.Dispatcher) {
 	h := webhooks.NewHandler(l, vars, d, "twilio", integrationID)
 
 	// Save new autokitteh connections with user-submitted Twilio secrets.
+	uiPath := "GET " + desc.ConnectionURL().Path + "/"
 	mux.Handle(uiPath, http.FileServer(http.FS(static.TwilioWebContent)))
+
 	mux.HandleFunc(webhooks.AuthPath, h.HandleAuth)
 
 	// Event webhooks.

--- a/integrations/twilio/webhooks/message.go
+++ b/integrations/twilio/webhooks/message.go
@@ -47,15 +47,14 @@ func (h handler) HandleMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Retrieve all the relevant connections for this event.
-	cids, err := h.vars.FindConnectionIDs(r.Context(), h.integrationID, sdktypes.NewSymbol("account_sid"), aid)
+	ctx := r.Context()
+	cids, err := h.vars.FindConnectionIDs(ctx, h.integrationID, sdktypes.NewSymbol("account_sid"), aid)
 	if err != nil {
-		l.Error("Failed to retrieve connection tokens",
-			zap.Error(err),
-		)
+		l.Error("Failed to find connection IDs", zap.Error(err))
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 
 	// Dispatch the event to all of them, for asynchronous handling.
-	h.dispatchAsyncEventsToConnections(l, cids, akEvent)
+	h.dispatchAsyncEventsToConnections(ctx, l, cids, akEvent)
 }

--- a/integrations/twilio/webhooks/webhook.go
+++ b/integrations/twilio/webhooks/webhook.go
@@ -5,12 +5,8 @@ import (
 
 	"go.uber.org/zap"
 
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
-	eventsv1 "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/events/v1"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-
-	"go.autokitteh.dev/autokitteh/integrations/internal/extrazap"
 )
 
 // handler is an autokitteh webhook which implements [http.Handler] to
@@ -48,20 +44,29 @@ func NewHandler(l *zap.Logger, vars sdkservices.Vars, d sdkservices.Dispatcher, 
 // https://www.twilio.com/docs/usage/api/usage-trigger
 // https://www.twilio.com/docs/usage/troubleshooting/alarms
 
-func (h handler) dispatchAsyncEventsToConnections(l *zap.Logger, cids []sdktypes.ConnectionID, event *eventsv1.Event) {
-	ctx := extrazap.AttachLoggerToContext(l, context.Background())
+func (h handler) dispatchAsyncEventsToConnections(ctx context.Context, l *zap.Logger, cids []sdktypes.ConnectionID, event *sdktypes.EventPB) {
 	for _, cid := range cids {
 		event.ConnectionId = cid.String()
-		event := kittehs.Must1(sdktypes.EventFromProto(event))
-		eventID, err := h.dispatcher.Dispatch(ctx, event, nil)
 
-		l := l.With(zap.String("connection_id", cid.String()))
-
+		event, err := sdktypes.EventFromProto(event)
 		if err != nil {
-			l.Error("Dispatch failed", zap.Error(err))
+			l.Error("Failed to convert protocol buffer to SDK event", zap.Error(err))
 			return
 		}
 
-		l.Debug("Dispatched", zap.String("eventID", eventID.String()))
+		eventID, err := h.dispatcher.Dispatch(ctx, event, nil)
+		if err != nil {
+			l.Error("Event dispatch failed",
+				zap.String("eventID", eventID.String()),
+				zap.String("connectionID", cid.String()),
+				zap.Error(err),
+			)
+			return
+		}
+		l.Debug("Event dispatched",
+			zap.String("eventID", eventID.String()),
+			zap.String("connectionID", cid.String()),
+		)
+
 	}
 }

--- a/web/static/gmail/connect/form.js
+++ b/web/static/gmail/connect/form.js
@@ -1,5 +1,5 @@
 // Switch between 2 available modes: user impersonation (using
-// OAuth v2), and a GCP service account (using a JSON key).
+// OAuth 2.0), and a GCP service account (using a JSON key).
 
 function toggleTab(id) {
   // Update the toggle buttons.

--- a/web/static/gmail/connect/index.html
+++ b/web/static/gmail/connect/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>autokitteh Gmail Integration</title>
+    <title>AutoKitteh Gmail Integration</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -27,7 +27,7 @@
 
   <body>
     <a href="/" target="_self">
-      <img class="banner" src="/static/banner.svg" alt="autokitteh" />
+      <img class="banner" src="/static/banner.svg" alt="AutoKitteh" />
     </a>
 
     <table class="title">
@@ -39,7 +39,7 @@
 
     <div class="toggle-container">
       <button class="toggle" id="toggletab1" onclick="toggleTab('tab1')">
-        User (OAuth v2)
+        User (OAuth 2.0)
       </button>
       <span class="toggle-sep"></span>
       <button class="toggle" id="toggletab2" onclick="toggleTab('tab2')">
@@ -72,7 +72,7 @@
 
       <p class="info">
         Click the button below to sign-in and authorize the
-        <strong>autokitteh</strong> service
+        <strong>AutoKitteh</strong> service
       </p>
       <!-- TODO(ENG-799): remove ID once its unused -->
       <a id="oauth-link" href="/oauth/start/gmail" class="clickable"

--- a/web/static/google/connect/form.js
+++ b/web/static/google/connect/form.js
@@ -1,5 +1,5 @@
 // Switch between 2 available modes: user impersonation (using
-// OAuth v2), and a GCP service account (using a JSON key).
+// OAuth 2.0), and a GCP service account (using a JSON key).
 
 function toggleTab(id) {
   // Update the toggle buttons.

--- a/web/static/google/connect/index.html
+++ b/web/static/google/connect/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>autokitteh Google Integration</title>
+    <title>AutoKitteh Google Integration</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -27,7 +27,7 @@
 
   <body>
     <a href="/" target="_self">
-      <img class="banner" src="/static/banner.svg" alt="autokitteh" />
+      <img class="banner" src="/static/banner.svg" alt="AutoKitteh" />
     </a>
 
     <table class="title">
@@ -39,7 +39,7 @@
 
     <div class="toggle-container">
       <button class="toggle" id="toggletab1" onclick="toggleTab('tab1')">
-        User (OAuth v2)
+        User (OAuth 2.0)
       </button>
       <span class="toggle-sep"></span>
       <button class="toggle" id="toggletab2" onclick="toggleTab('tab2')">
@@ -72,7 +72,7 @@
 
       <p class="info">
         Click the button below to sign-in and authorize the
-        <strong>autokitteh</strong> service
+        <strong>AutoKitteh</strong> service
       </p>
       <!-- TODO(ENG-799): remove ID once its unused -->
       <a id="oauth-link" href="/oauth/start/google" class="clickable"

--- a/web/static/googlesheets/connect/form.js
+++ b/web/static/googlesheets/connect/form.js
@@ -1,5 +1,5 @@
 // Switch between 2 available modes: user impersonation (using
-// OAuth v2), and a GCP service account (using a JSON key).
+// OAuth 2.0), and a GCP service account (using a JSON key).
 
 function toggleTab(id) {
   // Update the toggle buttons.

--- a/web/static/googlesheets/connect/index.html
+++ b/web/static/googlesheets/connect/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>autokitteh Google Sheets Integration</title>
+    <title>AutoKitteh Google Sheets Integration</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -27,7 +27,7 @@
 
   <body>
     <a href="/" target="_self">
-      <img class="banner" src="/static/banner.svg" alt="autokitteh" />
+      <img class="banner" src="/static/banner.svg" alt="AutoKitteh" />
     </a>
 
     <table class="title">
@@ -41,7 +41,7 @@
 
     <div class="toggle-container">
       <button class="toggle" id="toggletab1" onclick="toggleTab('tab1')">
-        User (OAuth v2)
+        User (OAuth 2.0)
       </button>
       <span class="toggle-sep"></span>
       <button class="toggle" id="toggletab2" onclick="toggleTab('tab2')">
@@ -74,7 +74,7 @@
 
       <p class="info">
         Click the button below to sign-in and authorize the
-        <strong>autokitteh</strong> service
+        <strong>AutoKitteh</strong> service
       </p>
       <!-- TODO(ENG-799): remove ID once its unused -->
       <a id="oauth-link" href="/oauth/start/googlesheets" class="clickable"

--- a/web/static/slack/connect/styles.css
+++ b/web/static/slack/connect/styles.css
@@ -31,7 +31,7 @@ h1 {
 }
 
 div.toggle-container {
-  max-width: 350px;
+  max-width: 450px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -108,7 +108,7 @@ a.info:hover {
 }
 
 .form-group input {
-  width: 335px;
+  width: 435px;
   padding: 8px;
   border: 1px solid #ccc;
   border-radius: 5px;


### PR DESCRIPTION
Sorry for lumping these together, but there was no way to split them cleanly.

* Add `ConnectionCapabilities` to integrations that require initialization by the user
* Simplification of content-type check
* `redirectToErrorPage` function, instead of many `fmt.Sprintf` calls
* Replace all instances of `uiPath` consts with `desc.ConnectionURL().Path`
* Add link to Python client API
* GitHub: simplify `connStatus` function, multiple installs for a single connection are no longer possible, since we're not using tokens anymore

New additions:

* GitHub: fix ENG-991
* HTTP mux paths: add Go 1.22's HTTP method specification
* GitHub: replace per-file URL paths with Go 1.22's pattern wildcard
* Move all URL path consts to `server.go` - where their primary usage is
* Reduce multiple calls to `r.Context()` with a helper var `ctx`
* Replace references to `valuesv1.Value` with `sdktypes.ValuePB`
* Construct SDK event objects before, not during, dispatches
* Better code reused in Slack event handlers