### PR TITLE
No need to convert Jira webhook expiration to ISO-8601

### DIFF
--- a/integrations/jira/oauth.go
+++ b/integrations/jira/oauth.go
@@ -91,10 +91,9 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	expiration := t.Format("2006-01-02T15:04:05.000-0700")
 	initData := sdktypes.NewVars(data.ToVars()...).Append(res[0].toVars()...).
 		Append(sdktypes.NewVar(sdktypes.NewSymbol("webhook_id"), fmt.Sprintf("%d", id), false)).
-		Append(sdktypes.NewVar(sdktypes.NewSymbol("webhook_expiration"), expiration, false))
+		Append(sdktypes.NewVar(sdktypes.NewSymbol("webhook_expiration"), t.String(), false))
 
 	sdkintegrations.FinalizeConnectionInit(w, r, integrationID, initData)
 }


### PR DESCRIPTION
I thought this would be needed in Python, but it isn't.

Also, Python's `datetime.datetime.fromisoformat()` can handle Go's format almost without adjustments (just remove the timezone name from the end of the string).