### PR TITLE
ENG-802: Slack interaction - fix message update

### DIFF
--- a/integrations/slack/api/post.go
+++ b/integrations/slack/api/post.go
@@ -208,7 +208,6 @@ func getConnection(ctx context.Context, varsSvc sdkservices.Vars) (*oauth2.Token
 	}
 
 	if varsSvc == nil {
-		// test.
 		return &oauth2.Token{}, nil
 	}
 
@@ -228,11 +227,16 @@ func getConnection(ctx context.Context, varsSvc sdkservices.Vars) (*oauth2.Token
 		return &oauth2.Token{AccessToken: bt}, nil
 	}
 
-	// OAuth connection.
+	// Not Socket mode, so maybe OAuth?
 	oauthData, err := sdkintegrations.DecodeOAuthData(vs.GetValue(vars.OAuthDataName))
 	if err != nil {
-		return nil, err
+		// No, we are using a temporary URL which was provided by Slack
+		// (https://hooks.slack.com/actions/...), so we don't have to attach
+		// an AutoKitteh connection's OAuth token to our outgoing request.
+		return &oauth2.Token{}, nil
 	}
 
+	// Yes, we are sending a regular Slack API request
+	// on behalf of an OAuth-based AutoKitteh connection.
 	return oauthData.Token, nil
 }

--- a/integrations/slack/api/post.go
+++ b/integrations/slack/api/post.go
@@ -38,7 +38,9 @@ const (
 // slackURL is a var and not a const for unit-testing purposes.
 var slackURL = "https://slack.com/api/"
 
-var OAuthTokenContextKey = struct{}{}
+type ctxKey string
+
+var OAuthTokenContextKey = ctxKey("OAuthTokenContext")
 
 // PostForm sends a short-lived HTTP POST request with an OAuth bearer token and
 // URL-encoded key/value payload, and then receives and parses the JSON response.

--- a/integrations/slack/webhooks/interaction.go
+++ b/integrations/slack/webhooks/interaction.go
@@ -169,9 +169,6 @@ func (h handler) HandleInteraction(w http.ResponseWriter, r *http.Request) {
 	// It's a Slack best practice to update an interactive message after the interaction,
 	// to prevent further interaction with the same message, and to reflect the user actions.
 	// See: https://api.slack.com/interactivity/handling#updating_message_response.
-	if len(cids) > 0 {
-		ctx = context.WithValue(ctx, api.OAuthTokenContextKey, cids[0].String())
-	}
 	h.updateMessage(ctx, payload)
 }
 

--- a/integrations/slack/webhooks/interaction.go
+++ b/integrations/slack/webhooks/interaction.go
@@ -169,13 +169,16 @@ func (h handler) HandleInteraction(w http.ResponseWriter, r *http.Request) {
 	// It's a Slack best practice to update an interactive message after the interaction,
 	// to prevent further interaction with the same message, and to reflect the user actions.
 	// See: https://api.slack.com/interactivity/handling#updating_message_response.
-	h.updateMessage(l, payload)
+	if len(cids) > 0 {
+		ctx = context.WithValue(ctx, api.OAuthTokenContextKey, cids[0].String())
+	}
+	h.updateMessage(ctx, payload)
 }
 
 // updateMessage updates an interactive message after the interaction, to prevent
 // further interaction with the same message, and to reflect the user actions.
 // See: https://api.slack.com/interactivity/handling#updating_message_response.
-func (h handler) updateMessage(l *zap.Logger, payload *BlockActionsPayload) {
+func (h handler) updateMessage(ctx context.Context, payload *BlockActionsPayload) {
 	resp := Response{
 		Text:            payload.Message.Text,
 		ResponseType:    "in_channel",
@@ -218,9 +221,9 @@ func (h handler) updateMessage(l *zap.Logger, payload *BlockActionsPayload) {
 
 	// Send the update to Slack's webhook.
 	meta := &chat.UpdateResponse{}
-	ctx := extrazap.AttachLoggerToContext(l, context.Background())
 	err := api.PostJSON(ctx, h.vars, resp, meta, payload.ResponseURL)
 	if err != nil {
+		l := extrazap.ExtractLoggerFromContext(ctx)
 		l.Warn("Error in reply to user via interaction webhook",
 			zap.Error(err),
 			zap.String("url", payload.ResponseURL),


### PR DESCRIPTION
Calling `post()` with the Slack-provided URL to update the original message failed, because it failed to get the connection ID, and subsequently the OAuth token for it.

But responding to a Slack-provided temporary URL shouldn't require an OAuth token at all.

The code before eliminating connection tokens simply generated an empty OAuth token and couldn't fail, so I replicated this behavior in the second commit.