### PR TITLE
ENG-1048: Support connection status in Slack

### DIFF
--- a/integrations/github/client.go
+++ b/integrations/github/client.go
@@ -38,7 +38,7 @@ func New(cvars sdkservices.Vars) sdkservices.Integration {
 	i := &integration{vars: cvars}
 	return sdkintegrations.NewIntegration(
 		desc,
-		sdkmodule.New(funcs(i)...),
+		sdkmodule.New(exportFuncs(i)...),
 		connStatus(i),
 		connTest(i),
 		sdkintegrations.WithConnectionConfigFromVars(cvars),
@@ -74,7 +74,7 @@ func connStatus(i *integration) sdkintegrations.OptFn {
 	})
 }
 
-func funcs(i *integration) []sdkmodule.Optfn {
+func exportFuncs(i *integration) []sdkmodule.Optfn {
 	return []sdkmodule.Optfn{
 		// Issues.
 		sdkmodule.ExportFunction(

--- a/integrations/github/client.go
+++ b/integrations/github/client.go
@@ -55,7 +55,7 @@ func connTest(*integration) sdkintegrations.OptFn {
 // connStatus is an optional connection status check provided by the
 // integration to AutoKitteh. The possible results are "init required"
 // (the connection is not usable yet) and "using X" (where "X" is the
-// authentication method: OAuth 2.0, Cloud API token, or on-prem PAT).
+// authentication method: a GitHub app, or a user's PAT + webhook).
 func connStatus(i *integration) sdkintegrations.OptFn {
 	return sdkintegrations.WithConnectionStatus(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
 		if !cid.IsValid() {
@@ -68,10 +68,9 @@ func connStatus(i *integration) sdkintegrations.OptFn {
 		}
 
 		if vs.Has(vars.PAT) {
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using PAT"), nil
-		} else {
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using OAuth 2.0"), nil
+			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using PAT + webhook"), nil
 		}
+		return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using GitHub app"), nil
 	})
 }
 

--- a/integrations/slack/api/bookmarks/methods.go
+++ b/integrations/slack/api/bookmarks/methods.go
@@ -22,11 +22,11 @@ type API struct {
 //   - https://api.slack.com/scopes/bookmarks:write
 func (a API) Add(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
 	// Parse the input arguments.
-	req := AddRequest{Type: "link"}
+	req := AddRequest{}
 	err := sdkmodule.UnpackArgs(args, kwargs,
 		"channel_id", &req.ChannelID,
 		"title", &req.Title,
-		// "type", &req.Type,
+		"type?", &req.Type,
 		"link?", &req.Link,
 		"emoji?", &req.Emoji,
 		"entity_id?", &req.EntityID,
@@ -34,6 +34,10 @@ func (a API) Add(ctx context.Context, args []sdktypes.Value, kwargs map[string]s
 	)
 	if err != nil {
 		return sdktypes.InvalidValue, err
+	}
+
+	if req.Type == "" {
+		req.Type = "link" // Required by Slack.
 	}
 
 	// Invoke the API method.

--- a/integrations/slack/client.go
+++ b/integrations/slack/client.go
@@ -40,7 +40,7 @@ var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.Integrati
 func New(vs sdkservices.Vars) sdkservices.Integration {
 	return sdkintegrations.NewIntegration(
 		desc,
-		sdkmodule.New(funcs(vs)...),
+		sdkmodule.New(exportFuncs(vs)...),
 		connStatus(vs),
 		sdkintegrations.WithConnectionConfigFromVars(vs),
 	)
@@ -68,7 +68,7 @@ func connStatus(vs sdkservices.Vars) sdkintegrations.OptFn {
 	})
 }
 
-func funcs(vs sdkservices.Vars) []sdkmodule.Optfn {
+func exportFuncs(vs sdkservices.Vars) []sdkmodule.Optfn {
 	authAPI := auth.API{Vars: vs}
 	bookmarksAPI := bookmarks.API{Vars: vs}
 	botsAPI := bots.API{Vars: vs}
@@ -90,7 +90,7 @@ func funcs(vs sdkservices.Vars) []sdkmodule.Optfn {
 			"bookmarks_add",
 			bookmarksAPI.Add,
 			sdkmodule.WithFuncDoc("https://api.slack.com/methods/bookmarks.add"),
-			sdkmodule.WithArgs("channel_id", "title" /* , "type" */, "link?", "emoji?", "entity_id?", "parent_id?"),
+			sdkmodule.WithArgs("channel_id", "title", "type?", "link?", "emoji?", "entity_id?", "parent_id?"),
 		),
 		sdkmodule.ExportFunction(
 			"bookmarks_edit",
@@ -260,7 +260,7 @@ func funcs(vs sdkservices.Vars) []sdkmodule.Optfn {
 		),
 
 		// Users.
-		// TODO: sdkmodule.ExportFunction(
+		// TODO(ENG-1057): sdkmodule.ExportFunction(
 		// "users_conversations",
 		// 	sdkmodule.WithFuncDoc("https://api.slack.com/methods/users.conversations"),
 		// 	sdkmodule.WithArgs(...TODO...),

--- a/integrations/slack/client.go
+++ b/integrations/slack/client.go
@@ -1,6 +1,8 @@
 package slack
 
 import (
+	"context"
+
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/auth"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/bookmarks"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/bots"
@@ -8,6 +10,7 @@ import (
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/conversations"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/reactions"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/users"
+	"go.autokitteh.dev/autokitteh/integrations/slack/internal/vars"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
@@ -34,230 +37,257 @@ var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.Integrati
 	},
 }))
 
-func New(vars sdkservices.Vars) sdkservices.Integration {
-	authAPI := auth.API{Vars: vars}
-	bookmarksAPI := bookmarks.API{Vars: vars}
-	botsAPI := bots.API{Vars: vars}
-	chatAPI := chat.API{Vars: vars}
-	conversationsAPI := conversations.API{Vars: vars}
-	reactionsAPI := reactions.API{Vars: vars}
-	usersAPI := users.API{Vars: vars}
-
+func New(vs sdkservices.Vars) sdkservices.Integration {
 	return sdkintegrations.NewIntegration(
 		desc,
-		sdkmodule.New(
-			// Auth.
-			sdkmodule.ExportFunction(
-				"auth_test",
-				authAPI.Test,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/auth.test"),
-			),
-
-			// Bookmarks.
-			sdkmodule.ExportFunction(
-				"bookmarks_add",
-				bookmarksAPI.Add,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/bookmarks.add"),
-				sdkmodule.WithArgs("channel_id", "title" /* , "type" */, "link?", "emoji?", "entity_id?", "parent_id?"),
-			),
-			sdkmodule.ExportFunction(
-				"bookmarks_edit",
-				bookmarksAPI.Edit,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/bookmarks.edit"),
-				sdkmodule.WithArgs("bookmark_id", "channel_id", "emoji?", "link?", "title?"),
-			),
-			sdkmodule.ExportFunction(
-				"bookmarks_list",
-				bookmarksAPI.List,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/bookmarks.list"),
-				sdkmodule.WithArgs("channel_id"),
-			),
-			sdkmodule.ExportFunction(
-				"bookmarks_remove",
-				bookmarksAPI.Remove,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/bookmarks.remove"),
-				sdkmodule.WithArgs("bookmark_id", "channel_id", "quip_section_id?"),
-			),
-
-			// Bots.
-			sdkmodule.ExportFunction(
-				"bots_info",
-				botsAPI.Info,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/bots.info"),
-				sdkmodule.WithArgs("bot", "team_id?"),
-			),
-
-			// Chat.
-			sdkmodule.ExportFunction(
-				"chat_delete",
-				chatAPI.Delete,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/chat.delete"),
-				sdkmodule.WithArgs("channel", "ts"),
-			),
-			sdkmodule.ExportFunction(
-				"chat_get_permalink",
-				chatAPI.GetPermalink,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/chat.getPermalink"),
-				sdkmodule.WithArgs("channel", "message_ts"),
-			),
-			sdkmodule.ExportFunction(
-				"chat_post_ephemeral",
-				chatAPI.PostEphemeral,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/chat.postEphemeral"),
-				sdkmodule.WithArgs("channel", "user", "text", "blocks?", "thread_ts?"),
-			),
-			sdkmodule.ExportFunction(
-				"chat_post_message",
-				chatAPI.PostMessage,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/chat.postMessage"),
-				sdkmodule.WithArgs("channel", "text?", "blocks?", "thread_ts?", "reply_broadcast?", "username?", "icon_url?"),
-			),
-			sdkmodule.ExportFunction(
-				"chat_update",
-				chatAPI.Update,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/chat.update"),
-				sdkmodule.WithArgs("channel", "ts", "text?", "blocks?", "reply_broadcast?"),
-			),
-
-			// Convenience wrappers for "chat.postMessage".
-			sdkmodule.ExportFunction(
-				"send_text_message",
-				chatAPI.SendTextMessage,
-				sdkmodule.WithFuncDoc("convenience wrapper for chat.postMessage"),
-				sdkmodule.WithArgs("target", "text", "thread_ts?", "reply_broadcast?"),
-			),
-			sdkmodule.ExportFunction(
-				"send_approval_message",
-				chatAPI.SendApprovalMessage,
-				sdkmodule.WithFuncDoc("convenience wrapper for chat.postMessage"),
-				sdkmodule.WithArgs("target", "header", "message", "green_button?", "red_button?", "thread_ts?", "reply_broadcast?"),
-			),
-
-			// Conversations.
-			sdkmodule.ExportFunction(
-				"conversations_archive",
-				conversationsAPI.Archive,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.archive"),
-				sdkmodule.WithArgs("channel"),
-			),
-			sdkmodule.ExportFunction(
-				"conversations_close",
-				conversationsAPI.Close,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.close"),
-				sdkmodule.WithArgs("close"),
-			),
-			sdkmodule.ExportFunction(
-				"conversations_create",
-				conversationsAPI.Create,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.create"),
-				sdkmodule.WithArgs("name", "is_private?", "team_id?"),
-			),
-			sdkmodule.ExportFunction(
-				"conversations_history",
-				conversationsAPI.History,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.history"),
-				sdkmodule.WithArgs("channel", "cursor?", "limit?", "include_all_metadata?", "inclusive?", "oldest?", "latest?"),
-			),
-			sdkmodule.ExportFunction(
-				"conversations_info",
-				conversationsAPI.Info,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.info"),
-				sdkmodule.WithArgs("channel", "include_locale?", "include_num_members?"),
-			),
-			sdkmodule.ExportFunction(
-				"conversations_invite",
-				conversationsAPI.Invite,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.invite"),
-				sdkmodule.WithArgs("channel", "users", "force?"),
-			),
-			sdkmodule.ExportFunction(
-				"conversations_list",
-				conversationsAPI.List,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.list"),
-				sdkmodule.WithArgs("cursor?", "limit?", "exclude_archived?", "team_id?", "types?"),
-			),
-			sdkmodule.ExportFunction(
-				"conversations_members",
-				conversationsAPI.Members,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.members"),
-				sdkmodule.WithArgs("channel", "cursor?", "limit?"),
-			),
-			sdkmodule.ExportFunction(
-				"conversations_open",
-				conversationsAPI.Open,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.open"),
-				sdkmodule.WithArgs("channel?", "users?", "prevent_creation?"),
-			),
-			sdkmodule.ExportFunction(
-				"conversations_rename",
-				conversationsAPI.Rename,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.rename"),
-				sdkmodule.WithArgs("channel", "name"),
-			),
-			sdkmodule.ExportFunction(
-				"conversations_replies",
-				conversationsAPI.Replies,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.replies"),
-				sdkmodule.WithArgs("channel", "ts", "cursor?", "limit?", "include_all_metadata?", "inclusive?", "oldest?", "latest?"),
-			),
-			sdkmodule.ExportFunction(
-				"conversations_set_purpose",
-				conversationsAPI.SetPurpose,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.setPurpose"),
-				sdkmodule.WithArgs("channel", "purpose"),
-			),
-			sdkmodule.ExportFunction(
-				"conversations_set_topic",
-				conversationsAPI.SetTopic,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.setTopic"),
-				sdkmodule.WithArgs("channel", "topic"),
-			),
-			sdkmodule.ExportFunction(
-				"conversations_unarchive",
-				conversationsAPI.Unarchive,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.unarchive"),
-				sdkmodule.WithArgs("channel"),
-			),
-
-			// Reactions.
-			sdkmodule.ExportFunction(
-				"reactions_add",
-				reactionsAPI.Add,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/reactions.add"),
-				sdkmodule.WithArgs("channel", "name", "timestamp"),
-			),
-
-			// Users.
-			// TODO: sdkmodule.ExportFunction(
-			// "users_conversations",
-			// 	sdkmodule.WithFuncDoc("https://api.slack.com/methods/users.conversations"),
-			// 	sdkmodule.WithArgs(...TODO...),
-			// 	usersAPI.GetPresence),
-			sdkmodule.ExportFunction(
-				"users_get_presence",
-				usersAPI.GetPresence,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/users.getPresence"),
-				sdkmodule.WithArgs("user?"),
-			),
-			sdkmodule.ExportFunction(
-				"users_info",
-				usersAPI.Info,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/users.info"),
-				sdkmodule.WithArgs("user", "include_locale?"),
-			),
-			sdkmodule.ExportFunction(
-				"users_list",
-				usersAPI.List,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/users.list"),
-				sdkmodule.WithArgs("cursor?", "limit?", "include_locale?", "team_id?"),
-			),
-			sdkmodule.ExportFunction(
-				"users_lookup_by_email",
-				usersAPI.LookupByEmail,
-				sdkmodule.WithFuncDoc("https://api.slack.com/methods/users.lookupByEmail"),
-				sdkmodule.WithArgs("email"),
-			),
-		),
-		sdkintegrations.WithConnectionConfigFromVars(vars),
+		sdkmodule.New(funcs(vs)...),
+		connStatus(vs),
+		sdkintegrations.WithConnectionConfigFromVars(vs),
 	)
+}
+
+// connStatus is an optional connection status check provided by the
+// integration to AutoKitteh. The possible results are "init required"
+// (the connection is not usable yet) and "using X" (where "X" is the
+// authentication method: an OAuth v2 app, or a Socket Mode app).
+func connStatus(vs sdkservices.Vars) sdkintegrations.OptFn {
+	return sdkintegrations.WithConnectionStatus(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
+		if !cid.IsValid() {
+			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "init required"), nil
+		}
+
+		vs, err := vs.Get(ctx, sdktypes.NewVarScopeID(cid))
+		if err != nil {
+			return sdktypes.InvalidStatus, err
+		}
+
+		if vs.Has(vars.AppTokenName) {
+			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using Socket Mode app"), nil
+		}
+		return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using OAuth v2 app"), nil
+	})
+}
+
+func funcs(vs sdkservices.Vars) []sdkmodule.Optfn {
+	authAPI := auth.API{Vars: vs}
+	bookmarksAPI := bookmarks.API{Vars: vs}
+	botsAPI := bots.API{Vars: vs}
+	chatAPI := chat.API{Vars: vs}
+	conversationsAPI := conversations.API{Vars: vs}
+	reactionsAPI := reactions.API{Vars: vs}
+	usersAPI := users.API{Vars: vs}
+
+	return []sdkmodule.Optfn{
+		// Auth.
+		sdkmodule.ExportFunction(
+			"auth_test",
+			authAPI.Test,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/auth.test"),
+		),
+
+		// Bookmarks.
+		sdkmodule.ExportFunction(
+			"bookmarks_add",
+			bookmarksAPI.Add,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/bookmarks.add"),
+			sdkmodule.WithArgs("channel_id", "title" /* , "type" */, "link?", "emoji?", "entity_id?", "parent_id?"),
+		),
+		sdkmodule.ExportFunction(
+			"bookmarks_edit",
+			bookmarksAPI.Edit,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/bookmarks.edit"),
+			sdkmodule.WithArgs("bookmark_id", "channel_id", "emoji?", "link?", "title?"),
+		),
+		sdkmodule.ExportFunction(
+			"bookmarks_list",
+			bookmarksAPI.List,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/bookmarks.list"),
+			sdkmodule.WithArgs("channel_id"),
+		),
+		sdkmodule.ExportFunction(
+			"bookmarks_remove",
+			bookmarksAPI.Remove,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/bookmarks.remove"),
+			sdkmodule.WithArgs("bookmark_id", "channel_id", "quip_section_id?"),
+		),
+
+		// Bots.
+		sdkmodule.ExportFunction(
+			"bots_info",
+			botsAPI.Info,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/bots.info"),
+			sdkmodule.WithArgs("bot", "team_id?"),
+		),
+
+		// Chat.
+		sdkmodule.ExportFunction(
+			"chat_delete",
+			chatAPI.Delete,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/chat.delete"),
+			sdkmodule.WithArgs("channel", "ts"),
+		),
+		sdkmodule.ExportFunction(
+			"chat_get_permalink",
+			chatAPI.GetPermalink,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/chat.getPermalink"),
+			sdkmodule.WithArgs("channel", "message_ts"),
+		),
+		sdkmodule.ExportFunction(
+			"chat_post_ephemeral",
+			chatAPI.PostEphemeral,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/chat.postEphemeral"),
+			sdkmodule.WithArgs("channel", "user", "text", "blocks?", "thread_ts?"),
+		),
+		sdkmodule.ExportFunction(
+			"chat_post_message",
+			chatAPI.PostMessage,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/chat.postMessage"),
+			sdkmodule.WithArgs("channel", "text?", "blocks?", "thread_ts?", "reply_broadcast?", "username?", "icon_url?"),
+		),
+		sdkmodule.ExportFunction(
+			"chat_update",
+			chatAPI.Update,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/chat.update"),
+			sdkmodule.WithArgs("channel", "ts", "text?", "blocks?", "reply_broadcast?"),
+		),
+
+		// Convenience wrappers for "chat.postMessage".
+		sdkmodule.ExportFunction(
+			"send_text_message",
+			chatAPI.SendTextMessage,
+			sdkmodule.WithFuncDoc("convenience wrapper for chat.postMessage"),
+			sdkmodule.WithArgs("target", "text", "thread_ts?", "reply_broadcast?"),
+		),
+		sdkmodule.ExportFunction(
+			"send_approval_message",
+			chatAPI.SendApprovalMessage,
+			sdkmodule.WithFuncDoc("convenience wrapper for chat.postMessage"),
+			sdkmodule.WithArgs("target", "header", "message", "green_button?", "red_button?", "thread_ts?", "reply_broadcast?"),
+		),
+
+		// Conversations.
+		sdkmodule.ExportFunction(
+			"conversations_archive",
+			conversationsAPI.Archive,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.archive"),
+			sdkmodule.WithArgs("channel"),
+		),
+		sdkmodule.ExportFunction(
+			"conversations_close",
+			conversationsAPI.Close,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.close"),
+			sdkmodule.WithArgs("close"),
+		),
+		sdkmodule.ExportFunction(
+			"conversations_create",
+			conversationsAPI.Create,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.create"),
+			sdkmodule.WithArgs("name", "is_private?", "team_id?"),
+		),
+		sdkmodule.ExportFunction(
+			"conversations_history",
+			conversationsAPI.History,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.history"),
+			sdkmodule.WithArgs("channel", "cursor?", "limit?", "include_all_metadata?", "inclusive?", "oldest?", "latest?"),
+		),
+		sdkmodule.ExportFunction(
+			"conversations_info",
+			conversationsAPI.Info,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.info"),
+			sdkmodule.WithArgs("channel", "include_locale?", "include_num_members?"),
+		),
+		sdkmodule.ExportFunction(
+			"conversations_invite",
+			conversationsAPI.Invite,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.invite"),
+			sdkmodule.WithArgs("channel", "users", "force?"),
+		),
+		sdkmodule.ExportFunction(
+			"conversations_list",
+			conversationsAPI.List,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.list"),
+			sdkmodule.WithArgs("cursor?", "limit?", "exclude_archived?", "team_id?", "types?"),
+		),
+		sdkmodule.ExportFunction(
+			"conversations_members",
+			conversationsAPI.Members,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.members"),
+			sdkmodule.WithArgs("channel", "cursor?", "limit?"),
+		),
+		sdkmodule.ExportFunction(
+			"conversations_open",
+			conversationsAPI.Open,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.open"),
+			sdkmodule.WithArgs("channel?", "users?", "prevent_creation?"),
+		),
+		sdkmodule.ExportFunction(
+			"conversations_rename",
+			conversationsAPI.Rename,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.rename"),
+			sdkmodule.WithArgs("channel", "name"),
+		),
+		sdkmodule.ExportFunction(
+			"conversations_replies",
+			conversationsAPI.Replies,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.replies"),
+			sdkmodule.WithArgs("channel", "ts", "cursor?", "limit?", "include_all_metadata?", "inclusive?", "oldest?", "latest?"),
+		),
+		sdkmodule.ExportFunction(
+			"conversations_set_purpose",
+			conversationsAPI.SetPurpose,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.setPurpose"),
+			sdkmodule.WithArgs("channel", "purpose"),
+		),
+		sdkmodule.ExportFunction(
+			"conversations_set_topic",
+			conversationsAPI.SetTopic,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.setTopic"),
+			sdkmodule.WithArgs("channel", "topic"),
+		),
+		sdkmodule.ExportFunction(
+			"conversations_unarchive",
+			conversationsAPI.Unarchive,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/conversations.unarchive"),
+			sdkmodule.WithArgs("channel"),
+		),
+
+		// Reactions.
+		sdkmodule.ExportFunction(
+			"reactions_add",
+			reactionsAPI.Add,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/reactions.add"),
+			sdkmodule.WithArgs("channel", "name", "timestamp"),
+		),
+
+		// Users.
+		// TODO: sdkmodule.ExportFunction(
+		// "users_conversations",
+		// 	sdkmodule.WithFuncDoc("https://api.slack.com/methods/users.conversations"),
+		// 	sdkmodule.WithArgs(...TODO...),
+		// 	usersAPI.GetPresence),
+		sdkmodule.ExportFunction(
+			"users_get_presence",
+			usersAPI.GetPresence,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/users.getPresence"),
+			sdkmodule.WithArgs("user?"),
+		),
+		sdkmodule.ExportFunction(
+			"users_info",
+			usersAPI.Info,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/users.info"),
+			sdkmodule.WithArgs("user", "include_locale?"),
+		),
+		sdkmodule.ExportFunction(
+			"users_list",
+			usersAPI.List,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/users.list"),
+			sdkmodule.WithArgs("cursor?", "limit?", "include_locale?", "team_id?"),
+		),
+		sdkmodule.ExportFunction(
+			"users_lookup_by_email",
+			usersAPI.LookupByEmail,
+			sdkmodule.WithFuncDoc("https://api.slack.com/methods/users.lookupByEmail"),
+			sdkmodule.WithArgs("email"),
+		),
+	}
 }


### PR DESCRIPTION
Add a `connStatus()` function to the Slack integration.

On the way, simplify Slack's `New()` function by moving all the functions to a separate function, and clean-up cosmetic details in GitHub's `connStatus()` function.