### PR TITLE
ENG-1045: un/marshal Slack blocks without structs

### DIFF
--- a/integrations/slack/api/chat/data.go
+++ b/integrations/slack/api/chat/data.go
@@ -48,7 +48,7 @@ type PostEphemeralRequest struct {
 	// https://api.slack.com/messaging/composing/layouts
 	// https://api.slack.com/messaging/interactivity
 	// https://app.slack.com/block-kit-builder/
-	Blocks []Block `json:"blocks,omitempty"`
+	Blocks []map[string]interface{} `json:"blocks,omitempty"`
 
 	// ThreadTS provides another message's [TS] value to make this message
 	// a reply. Avoid using a reply's [TS] value; use its parent instead.
@@ -80,7 +80,7 @@ type PostMessageRequest struct {
 	// https://api.slack.com/messaging/composing/layouts
 	// https://api.slack.com/messaging/interactivity
 	// https://app.slack.com/block-kit-builder/
-	Blocks []Block `json:"blocks,omitempty"`
+	Blocks []map[string]interface{} `json:"blocks,omitempty"`
 
 	// ThreadTS provides another message's [TS] value to make this message
 	// a reply. Avoid using a reply's [TS] value; use its parent instead.
@@ -124,7 +124,7 @@ type UpdateRequest struct {
 	// https://api.slack.com/messaging/composing/layouts
 	// https://api.slack.com/messaging/interactivity
 	// https://app.slack.com/block-kit-builder/
-	Blocks []Block `json:"blocks,omitempty"`
+	Blocks []map[string]interface{} `json:"blocks,omitempty"`
 
 	// ReplyBroadcast is used in conjunction with [TS] and indicates whether
 	// the reply should be made visible to everyone in the channel or
@@ -175,29 +175,6 @@ type SendApprovalMessageRequest struct {
 
 // -------------------- Auxiliary data structures --------------------
 
-// https://api.slack.com/reference/block-kit/blocks
-type Block struct {
-	// Valid values: "actions", "context", "divider", "header", or "section".
-	// TODO: add the rest too - "file", "image", "input", and "video".
-	Type string `json:"type,omitempty"`
-	// https://api.slack.com/reference/block-kit/composition-objects#text.
-	// Header: maximum length for the text in this field is 150 characters.
-	// Section: maximum length for the text in this field is 3000 characters.
-	// Optional when "fields" is not empty.
-	Text *Text `json:"text,omitempty"`
-	// https://api.slack.com/reference/block-kit/block-elements.
-	// Actions: maximum of 25 elements. Context: maximum of 10 elements.
-	// TODO: Support other element types.
-	Elements  []Button `json:"elements,omitempty"`
-	Accessory *Button  `json:"accessory,omitempty"`
-	// Required if "text" is empty. Maximum of 10 elements,
-	// each with a maximum length of 2000 characters.
-	Fields []Text `json:"fields,omitempty"`
-	// Maximum length is 255 characters. It should be unique for each message and
-	// each iteration of a message. If a message is updated, use a new value.
-	BlockID string `json:"block_id,omitempty"`
-}
-
 type BotProfile struct {
 	ID     string `json:"id,omitempty"`
 	AppID  string `json:"app_id,omitempty"`
@@ -209,43 +186,9 @@ type BotProfile struct {
 	Updated int  `json:"updated,omitempty"`
 }
 
-// https://api.slack.com/reference/block-kit/block-elements#button
-type Button struct {
-	// Type must be "button".
-	Type string `json:"type,omitempty"`
-	// Text's type must be "plain_text", may truncate with ~30 characters,
-	// maximum length is 75 characters.
-	Text *Text `json:"text,omitempty"`
-	// ActionID can be used when receiving an interaction payload to identify the
-	// action's source (https://api.slack.com/interactivity/handling#payloads).
-	// Should be unique among all other [ActionId]s in the containing block.
-	ActionID string `json:"action_id,omitempty"`
-	// URL to load in the user's browser when the button is clicked. Maximum
-	// length is 3000 characters. If you're using this, you'll
-	// still receive an interaction payload and need to send an acknowledgement
-	// response (https://api.slack.com/interactivity/handling#acknowledgment_response).
-	URL string `json:"url,omitempty"`
-	// Value to send along with the interaction payload.
-	// Maximum length is 2000 characters.
-	Value string `json:"value,omitempty"`
-	// Style is optional. Decorates buttons with alternative visual color
-	// schemes. Use this option with restraint. If specified, must be either
-	// "primary" (green) or "danger" (red).
-	Style string `json:"style,omitempty"`
-	// AccessibilityLabel for longer descriptive text about the button. This
-	// label will be read out by screen readers instead of the Text object.
-	// Maximum length is 75 characters.
-	AccessibilityLabel string `json:"accessibility_label,omitempty"`
-}
-
 type Edited struct {
 	User string `json:"user,omitempty"`
 	TS   string `json:"ts,omitempty"`
-}
-
-// https://api.slack.com/reference/block-kit/block-elements
-type Element struct {
-	// TODO: Implement.
 }
 
 // https://api.slack.com/types/conversation
@@ -259,9 +202,9 @@ type Message struct {
 	// https://api.slack.com/events/message#hidden_subtypes
 	Hidden bool `json:"hidden,omitempty"`
 
-	Text   string  `json:"text,omitempty"`
-	Blocks []Block `json:"blocks,omitempty"`
-	Edited *Edited `json:"edited,omitempty"`
+	Text   string                   `json:"text,omitempty"`
+	Blocks []map[string]interface{} `json:"blocks,omitempty"`
+	Edited *Edited                  `json:"edited,omitempty"`
 
 	User         string      `json:"user,omitempty"`
 	AppID        string      `json:"app_id,omitempty"`

--- a/integrations/slack/api/chat/data.go
+++ b/integrations/slack/api/chat/data.go
@@ -48,7 +48,7 @@ type PostEphemeralRequest struct {
 	// https://api.slack.com/messaging/composing/layouts
 	// https://api.slack.com/messaging/interactivity
 	// https://app.slack.com/block-kit-builder/
-	Blocks []map[string]interface{} `json:"blocks,omitempty"`
+	Blocks []map[string]any `json:"blocks,omitempty"`
 
 	// ThreadTS provides another message's [TS] value to make this message
 	// a reply. Avoid using a reply's [TS] value; use its parent instead.
@@ -80,7 +80,7 @@ type PostMessageRequest struct {
 	// https://api.slack.com/messaging/composing/layouts
 	// https://api.slack.com/messaging/interactivity
 	// https://app.slack.com/block-kit-builder/
-	Blocks []map[string]interface{} `json:"blocks,omitempty"`
+	Blocks []map[string]any `json:"blocks,omitempty"`
 
 	// ThreadTS provides another message's [TS] value to make this message
 	// a reply. Avoid using a reply's [TS] value; use its parent instead.
@@ -124,7 +124,7 @@ type UpdateRequest struct {
 	// https://api.slack.com/messaging/composing/layouts
 	// https://api.slack.com/messaging/interactivity
 	// https://app.slack.com/block-kit-builder/
-	Blocks []map[string]interface{} `json:"blocks,omitempty"`
+	Blocks []map[string]any `json:"blocks,omitempty"`
 
 	// ReplyBroadcast is used in conjunction with [TS] and indicates whether
 	// the reply should be made visible to everyone in the channel or
@@ -202,9 +202,9 @@ type Message struct {
 	// https://api.slack.com/events/message#hidden_subtypes
 	Hidden bool `json:"hidden,omitempty"`
 
-	Text   string                   `json:"text,omitempty"`
-	Blocks []map[string]interface{} `json:"blocks,omitempty"`
-	Edited *Edited                  `json:"edited,omitempty"`
+	Text   string           `json:"text,omitempty"`
+	Blocks []map[string]any `json:"blocks,omitempty"`
+	Edited *Edited          `json:"edited,omitempty"`
 
 	User         string      `json:"user,omitempty"`
 	AppID        string      `json:"app_id,omitempty"`

--- a/integrations/slack/api/chat/methods.go
+++ b/integrations/slack/api/chat/methods.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"net/url"
 
+	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-
-	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 )
 
 const (
@@ -270,52 +269,52 @@ func (a API) SendApprovalMessage(ctx context.Context, args []sdktypes.Value, kwa
 	if redButton == "" {
 		redButton = DefaultApprovalRedButton
 	}
-	req.Blocks = []Block{
+	req.Blocks = []map[string]interface{}{
 		{
-			Type: "header",
-			Text: &Text{
-				Type:  "plain_text",
-				Emoji: true,
-				Text:  req.Text,
+			"type": "header",
+			"text": map[string]interface{}{
+				"type":  "plain_text",
+				"emoji": true,
+				"text":  req.Text,
 			},
 		},
 		{
-			Type: "divider",
+			"type": "divider",
 		},
 		{
-			Type: "section",
-			Text: &Text{
-				Type: "mrkdwn",
-				Text: message,
+			"type": "section",
+			"text": map[string]string{
+				"type": "mrkdwn",
+				"text": message,
 			},
 		},
 		{
-			Type: "divider",
+			"type": "divider",
 		},
 		{
-			Type: "actions",
-			Elements: []Button{
+			"type": "actions",
+			"elements": []map[string]interface{}{
 				{
-					Type:  "button",
-					Style: "primary",
-					Text: &Text{
-						Type:  "plain_text",
-						Emoji: true,
-						Text:  greenButton,
+					"type":  "button",
+					"style": "primary",
+					"text": map[string]interface{}{
+						"type":  "plain_text",
+						"emoji": true,
+						"text":  greenButton,
 					},
-					Value:    DefaultApprovalGreenButton,
-					ActionID: DefaultApprovalGreenButton,
+					"value":     DefaultApprovalGreenButton,
+					"action_id": DefaultApprovalGreenButton,
 				},
 				{
-					Type:  "button",
-					Style: "danger",
-					Text: &Text{
-						Type:  "plain_text",
-						Emoji: true,
-						Text:  redButton,
+					"type":  "button",
+					"style": "danger",
+					"text": map[string]interface{}{
+						"type":  "plain_text",
+						"emoji": true,
+						"text":  redButton,
 					},
-					Value:    DefaultApprovalRedButton,
-					ActionID: DefaultApprovalRedButton,
+					"value":     DefaultApprovalRedButton,
+					"action_id": DefaultApprovalRedButton,
 				},
 			},
 		},

--- a/integrations/slack/api/chat/methods.go
+++ b/integrations/slack/api/chat/methods.go
@@ -269,10 +269,10 @@ func (a API) SendApprovalMessage(ctx context.Context, args []sdktypes.Value, kwa
 	if redButton == "" {
 		redButton = DefaultApprovalRedButton
 	}
-	req.Blocks = []map[string]interface{}{
+	req.Blocks = []map[string]any{
 		{
 			"type": "header",
-			"text": map[string]interface{}{
+			"text": map[string]any{
 				"type":  "plain_text",
 				"emoji": true,
 				"text":  req.Text,
@@ -293,11 +293,11 @@ func (a API) SendApprovalMessage(ctx context.Context, args []sdktypes.Value, kwa
 		},
 		{
 			"type": "actions",
-			"elements": []map[string]interface{}{
+			"elements": []map[string]any{
 				{
 					"type":  "button",
 					"style": "primary",
-					"text": map[string]interface{}{
+					"text": map[string]any{
 						"type":  "plain_text",
 						"emoji": true,
 						"text":  greenButton,
@@ -308,7 +308,7 @@ func (a API) SendApprovalMessage(ctx context.Context, args []sdktypes.Value, kwa
 				{
 					"type":  "button",
 					"style": "danger",
-					"text": map[string]interface{}{
+					"text": map[string]any{
 						"type":  "plain_text",
 						"emoji": true,
 						"text":  redButton,

--- a/integrations/slack/events/app_mention.go
+++ b/integrations/slack/events/app_mention.go
@@ -17,8 +17,8 @@ type AppMentionEvent struct {
 	TS      string `json:"ts,omitempty"`
 	EventTS string `json:"event_ts,omitempty"`
 
-	Text   string                   `json:"text,omitempty"`
-	Blocks []map[string]interface{} `json:"blocks,omitempty"`
+	Text   string           `json:"text,omitempty"`
+	Blocks []map[string]any `json:"blocks,omitempty"`
 
 	ClientMsgID string `json:"client_msg_id,omitempty"`
 }

--- a/integrations/slack/events/app_mention.go
+++ b/integrations/slack/events/app_mention.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 
 	"go.uber.org/zap"
-
-	"go.autokitteh.dev/autokitteh/integrations/slack/api/chat"
 )
 
 // https://api.slack.com/events/app_mention
@@ -19,8 +17,8 @@ type AppMentionEvent struct {
 	TS      string `json:"ts,omitempty"`
 	EventTS string `json:"event_ts,omitempty"`
 
-	Text   string       `json:"text,omitempty"`
-	Blocks []chat.Block `json:"blocks,omitempty"`
+	Text   string                   `json:"text,omitempty"`
+	Blocks []map[string]interface{} `json:"blocks,omitempty"`
 
 	ClientMsgID string `json:"client_msg_id,omitempty"`
 }

--- a/integrations/slack/webhooks/interaction.go
+++ b/integrations/slack/webhooks/interaction.go
@@ -101,12 +101,12 @@ type Team struct {
 }
 
 type Response struct {
-	Text            string                   `json:"text,omitempty"`
-	Blocks          []map[string]interface{} `json:"blocks,omitempty"`
-	ResponseType    string                   `json:"response_type,omitempty"`
-	ThreadTS        string                   `json:"thread_ts,omitempty"`
-	ReplaceOriginal bool                     `json:"replace_original,omitempty"`
-	DeleteOriginal  bool                     `json:"delete_original,omitempty"`
+	Text            string           `json:"text,omitempty"`
+	Blocks          []map[string]any `json:"blocks,omitempty"`
+	ResponseType    string           `json:"response_type,omitempty"`
+	ThreadTS        string           `json:"thread_ts,omitempty"`
+	ReplaceOriginal bool             `json:"replace_original,omitempty"`
+	DeleteOriginal  bool             `json:"delete_original,omitempty"`
 }
 
 // HandleInteraction dispatches and acknowledges a user interaction callback
@@ -191,7 +191,7 @@ func (h handler) updateMessage(ctx context.Context, payload *BlockActionsPayload
 	for _, b := range payload.Message.Blocks {
 		// Header text is HTML-encoded, so unescape it.
 		if b["type"] == "header" {
-			h := b["text"].(map[string]interface{})
+			h := b["text"].(map[string]any)
 			h["text"] = html.UnescapeString(h["text"].(string))
 		}
 		if b["type"] != "actions" {
@@ -210,7 +210,7 @@ func (h handler) updateMessage(ctx context.Context, payload *BlockActionsPayload
 			case "danger":
 				action = ":large_red_square: " + action
 			}
-			resp.Blocks = append(resp.Blocks, map[string]interface{}{
+			resp.Blocks = append(resp.Blocks, map[string]any{
 				"type": "section",
 				"text": map[string]string{
 					"type": "mrkdwn",

--- a/integrations/slack/webhooks/interaction.go
+++ b/integrations/slack/webhooks/interaction.go
@@ -101,12 +101,12 @@ type Team struct {
 }
 
 type Response struct {
-	Text            string       `json:"text,omitempty"`
-	Blocks          []chat.Block `json:"blocks,omitempty"`
-	ResponseType    string       `json:"response_type,omitempty"`
-	ThreadTS        string       `json:"thread_ts,omitempty"`
-	ReplaceOriginal bool         `json:"replace_original,omitempty"`
-	DeleteOriginal  bool         `json:"delete_original,omitempty"`
+	Text            string                   `json:"text,omitempty"`
+	Blocks          []map[string]interface{} `json:"blocks,omitempty"`
+	ResponseType    string                   `json:"response_type,omitempty"`
+	ThreadTS        string                   `json:"thread_ts,omitempty"`
+	ReplaceOriginal bool                     `json:"replace_original,omitempty"`
+	DeleteOriginal  bool                     `json:"delete_original,omitempty"`
 }
 
 // HandleInteraction dispatches and acknowledges a user interaction callback
@@ -186,11 +186,15 @@ func (h handler) updateMessage(ctx context.Context, payload *BlockActionsPayload
 	}
 
 	// Copy all the message's blocks, except actions.
+	// The event is verifiably from Slack, so we can trust the data.
+	// TODO(ENG-1052): Support updating actions in non-last blocks.
 	for _, b := range payload.Message.Blocks {
-		if b.Type == "header" {
-			b.Text.Text = html.UnescapeString(b.Text.Text)
+		// Header text is HTML-encoded, so unescape it.
+		if b["type"] == "header" {
+			h := b["text"].(map[string]interface{})
+			h["text"] = html.UnescapeString(h["text"].(string))
 		}
-		if b.Type != "actions" {
+		if b["type"] != "actions" {
 			resp.Blocks = append(resp.Blocks, b)
 		}
 	}
@@ -206,11 +210,11 @@ func (h handler) updateMessage(ctx context.Context, payload *BlockActionsPayload
 			case "danger":
 				action = ":large_red_square: " + action
 			}
-			resp.Blocks = append(resp.Blocks, chat.Block{
-				Type: "section",
-				Text: &chat.Text{
-					Type: "mrkdwn",
-					Text: action,
+			resp.Blocks = append(resp.Blocks, map[string]interface{}{
+				"type": "section",
+				"text": map[string]string{
+					"type": "mrkdwn",
+					"text": action,
 				},
 			})
 		}

--- a/integrations/slack/websockets/interactive.go
+++ b/integrations/slack/websockets/interactive.go
@@ -80,11 +80,15 @@ func (h handler) updateMessage(payload *webhooks.BlockActionsPayload, cids []sdk
 	}
 
 	// Copy all the message's blocks, except actions.
+	// The event is verifiably from Slack, so we can trust the data.
+	// TODO(ENG-1052): Support updating actions in non-last blocks.
 	for _, b := range payload.Message.Blocks {
-		if b.Type == "header" {
-			b.Text.Text = html.UnescapeString(b.Text.Text)
+		// Header text is HTML-encoded, so unescape it.
+		if b["type"] == "header" {
+			h := b["text"].(map[string]interface{})
+			h["text"] = html.UnescapeString(h["text"].(string))
 		}
-		if b.Type != "actions" {
+		if b["type"] != "actions" {
 			resp.Blocks = append(resp.Blocks, b)
 		}
 	}
@@ -100,11 +104,11 @@ func (h handler) updateMessage(payload *webhooks.BlockActionsPayload, cids []sdk
 			case "danger":
 				action = ":large_red_square: " + action
 			}
-			resp.Blocks = append(resp.Blocks, chat.Block{
-				Type: "section",
-				Text: &chat.Text{
-					Type: "mrkdwn",
-					Text: action,
+			resp.Blocks = append(resp.Blocks, map[string]interface{}{
+				"type": "section",
+				"text": map[string]string{
+					"type": "mrkdwn",
+					"text": action,
 				},
 			})
 		}

--- a/integrations/slack/websockets/interactive.go
+++ b/integrations/slack/websockets/interactive.go
@@ -85,7 +85,7 @@ func (h handler) updateMessage(payload *webhooks.BlockActionsPayload, cids []sdk
 	for _, b := range payload.Message.Blocks {
 		// Header text is HTML-encoded, so unescape it.
 		if b["type"] == "header" {
-			h := b["text"].(map[string]interface{})
+			h := b["text"].(map[string]any)
 			h["text"] = html.UnescapeString(h["text"].(string))
 		}
 		if b["type"] != "actions" {
@@ -104,7 +104,7 @@ func (h handler) updateMessage(payload *webhooks.BlockActionsPayload, cids []sdk
 			case "danger":
 				action = ":large_red_square: " + action
 			}
-			resp.Blocks = append(resp.Blocks, map[string]interface{}{
+			resp.Blocks = append(resp.Blocks, map[string]any{
 				"type": "section",
 				"text": map[string]string{
 					"type": "mrkdwn",

--- a/integrations/slack/websockets/slash_command.go
+++ b/integrations/slack/websockets/slash_command.go
@@ -63,7 +63,7 @@ func (h handler) handleSlashCommand(e *socketmode.Event, c *socketmode.Client) {
 	}
 
 	// https://api.slack.com/apis/connections/socket#command
-	c.Ack(*e.Request, map[string][]map[string]interface{}{
+	c.Ack(*e.Request, map[string][]map[string]any{
 		"blocks": {
 			{
 				"type": "section",

--- a/integrations/slack/websockets/slash_command.go
+++ b/integrations/slack/websockets/slash_command.go
@@ -8,7 +8,6 @@ import (
 	"github.com/slack-go/slack/socketmode"
 	"go.uber.org/zap"
 
-	"go.autokitteh.dev/autokitteh/integrations/slack/api/chat"
 	"go.autokitteh.dev/autokitteh/integrations/slack/internal/vars"
 	"go.autokitteh.dev/autokitteh/integrations/slack/webhooks"
 )
@@ -64,13 +63,13 @@ func (h handler) handleSlashCommand(e *socketmode.Event, c *socketmode.Client) {
 	}
 
 	// https://api.slack.com/apis/connections/socket#command
-	c.Ack(*e.Request, map[string][]*chat.Block{
+	c.Ack(*e.Request, map[string][]map[string]interface{}{
 		"blocks": {
 			{
-				Type: "section",
-				Text: &chat.Text{
-					Type: "mrkdwn",
-					Text: fmt.Sprintf("Your command: `%s`", cmd.Text),
+				"type": "section",
+				"text": map[string]string{
+					"type": "mrkdwn",
+					"text": fmt.Sprintf("Your command: `%s`", cmd.Text),
 				},
 			},
 		},


### PR DESCRIPTION
This avoids the need for 100% accurate modeling of Slack UI blocks, to support users with advanced Slack needs.