### PR TITLE
Small but important changes in connection pages

### DIFF
--- a/integrations/jira/client.go
+++ b/integrations/jira/client.go
@@ -64,9 +64,9 @@ func connStatus(i *integration) sdkintegrations.OptFn {
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using OAuth 2.0"), nil
 		}
 		if vs.Has(email) {
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using API key"), nil
+			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using API token"), nil
 		}
-		if vs.Has(apiKeyOrPAT) {
+		if vs.Has(token) {
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using PAT"), nil
 		}
 

--- a/integrations/jira/save.go
+++ b/integrations/jira/save.go
@@ -35,7 +35,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 
 	vars := sdktypes.NewVars().
 		Set(baseURL, r.Form.Get("base_url"), false).
-		Set(apiKeyOrPAT, r.Form.Get("key_or_pat"), true)
+		Set(token, r.Form.Get("token"), true)
 
 	addr := r.Form.Get("email")
 	if addr != "" {

--- a/integrations/jira/vars.go
+++ b/integrations/jira/vars.go
@@ -6,9 +6,8 @@ import (
 
 var (
 	baseURL = sdktypes.NewSymbol("BaseURL")
-
-	apiKeyOrPAT = sdktypes.NewSymbol("APIKeyOrPAT")
-	email       = sdktypes.NewSymbol("Email")
+	token   = sdktypes.NewSymbol("Token")
+	email   = sdktypes.NewSymbol("Email")
 
 	oauthAccessToken = sdktypes.NewSymbol("oauth_AccessToken")
 	accessID         = sdktypes.NewSymbol("access_ID")

--- a/web/static/gmail/connect/index.html
+++ b/web/static/gmail/connect/index.html
@@ -51,6 +51,16 @@
       <p class="info">Information:</p>
       <ul class="links">
         <li>
+          Guide:
+          <a
+            href="https://docs.autokitteh.com/config/integrations/google"
+            target="_blank"
+            class="info"
+          >
+            configuring the Google integration
+          </a>
+        </li>
+        <li>
           <a
             href="https://developers.google.com/workspace/guides/auth-overview"
             target="_blank"

--- a/web/static/google/connect/index.html
+++ b/web/static/google/connect/index.html
@@ -51,6 +51,16 @@
       <p class="info">Information:</p>
       <ul class="links">
         <li>
+          Guide:
+          <a
+            href="https://docs.autokitteh.com/config/integrations/google"
+            target="_blank"
+            class="info"
+          >
+            configuring the Google integration
+          </a>
+        </li>
+        <li>
           <a
             href="https://developers.google.com/workspace/guides/auth-overview"
             target="_blank"

--- a/web/static/googlesheets/connect/index.html
+++ b/web/static/googlesheets/connect/index.html
@@ -53,6 +53,16 @@
       <p class="info">Information:</p>
       <ul class="links">
         <li>
+          Guide:
+          <a
+            href="https://docs.autokitteh.com/config/integrations/google"
+            target="_blank"
+            class="info"
+          >
+            configuring the Google integration
+          </a>
+        </li>
+        <li>
           <a
             href="https://developers.google.com/workspace/guides/auth-overview"
             target="_blank"

--- a/web/static/jira/connect/index.html
+++ b/web/static/jira/connect/index.html
@@ -109,10 +109,10 @@
         </div>
 
         <div class="form-group">
-          <label for="key">API Token / Personal Access Token (PAT)</label>
+          <label for="token">API Token / Personal Access Token (PAT)</label>
           <input
             type="text"
-            name="key_or_pat"
+            name="token"
             autocomplete="off"
             spellcheck="false"
             required

--- a/web/static/jira/connect/index.html
+++ b/web/static/jira/connect/index.html
@@ -119,7 +119,7 @@
         </div>
 
         <div class="form-group">
-          <label for="key">API Key / Personal Access Token (PAT)</label>
+          <label for="key">API Token / Personal Access Token (PAT)</label>
           <input
             type="text"
             name="key_or_pat"
@@ -131,7 +131,7 @@
 
         <div class="form-group">
           <label for="email">
-            User email address (for API keys only, not for PATs)
+            User email address (API tokens only, not PATs!)
           </label>
           <input
             type="email"

--- a/web/static/jira/connect/index.html
+++ b/web/static/jira/connect/index.html
@@ -128,6 +128,7 @@
             name="email"
             autocomplete="off"
             spellcheck="false"
+            placeholder="name@example.com"
           />
         </div>
 

--- a/web/static/jira/connect/index.html
+++ b/web/static/jira/connect/index.html
@@ -59,11 +59,6 @@
             Jira Cloud platform: OAuth 2.0 (3LO) apps
           </a>
         </li>
-        <li>
-          <a href="" target="_blank" class="info">
-            TODO(ENG-965): Docusaurus guide, like GitHub
-          </a>
-        </li>
       </ul>
 
       <p class="info">
@@ -95,11 +90,6 @@
             class="info"
           >
             Jira Data Center: Personal Access Tokens
-          </a>
-        </li>
-        <li>
-          <a href="" target="_blank" class="info">
-            TODO(ENG-965): Docusaurus guide, like GitHub
           </a>
         </li>
       </ul>

--- a/web/static/jira/connect/index.html
+++ b/web/static/jira/connect/index.html
@@ -110,7 +110,7 @@
           <label for="base_url">Base URL</label>
           <input
             type="url"
-            name="url"
+            name="base_url"
             autocomplete="off"
             spellcheck="false"
             placeholder="https://your-domain.atlassian.net or on-prem URL"

--- a/web/static/jira/connect/index.html
+++ b/web/static/jira/connect/index.html
@@ -107,7 +107,7 @@
       <!-- TODO(ENG-799): remove ID once its unused -->
       <form id="save-form" method="post" action="/jira/save">
         <div class="form-group">
-          <label for="url">Base URL</label>
+          <label for="base_url">Base URL</label>
           <input
             type="url"
             name="url"


### PR DESCRIPTION
1. Bug fix: save Jira base URL - without this, AK saves an empty string in Jira connections that use an API key, which causes the Jira Python client to fail
2. Fix the Jira token param name across the index file and connection saving webhook
3. Add our OAuth guide to Google pages
4. Cosmetic tweaks in Jira page