### PR TITLE
ENG-1038: Secure tar file extraction

### DIFF
--- a/runtimes/pythonrt/ak_runner/__main__.py
+++ b/runtimes/pythonrt/ak_runner/__main__.py
@@ -34,7 +34,7 @@ def extract_code(tar_path):
     code_dir = f'{root_dir}/code'
     mkdir(code_dir)
     with tarfile.open(tar_path) as tf:
-        tf.extractall(code_dir)
+        tf.extractall(code_dir, filter='data')
 
     return code_dir
 


### PR DESCRIPTION
Add an explicit data filter when extracting Python code from an AK build's tar file. This is important for security, and removes a future deprecation warning about Python 3.14.

Details:
- https://docs.python.org/3/library/tarfile.html#extraction-filters
- https://docs.python.org/3/library/tarfile.html#tarfile.data_filter

This limits AK to Python version 3.11.4+ instead of 3.11+, but it seems reasonable given that 3.11.4 was released a year ago (2023-06-06).