### PR TITLE
Tiny fixes in connection init funcs

### DIFF
--- a/runtimes/pythonrt/py-sdk/autokitteh/atlassian.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/atlassian.py
@@ -60,13 +60,13 @@ def __atlassian_jira_client_cloud_oauth2(connection: str, **kwargs):
     if not expiry:
         raise ConnectionInitError(connection)
 
-    # Convert Go's time string (e.g. "2024-06-20 19:18:17 +0700 PDT") to
+    # Convert Go's time string (e.g. "2024-06-20 19:18:17 -0700 PDT") to
     # an ISO-8601 string that Python can parse with timezone awareness.
-    timestamp = re.sub(r"[ A-Z]+.*", "", expiry)
+    timestamp = re.sub(r" [A-Z]+.*", "", expiry)
     if datetime.fromisoformat(timestamp) < datetime.now(UTC):
         raise RuntimeError("OAuth 2.0 access token expired on: " + expiry)
 
-    cloud_id = os.getenv(connection + "__access_id")
+    cloud_id = os.getenv(connection + "__access_ID")
     if not cloud_id:
         raise ConnectionInitError(connection)
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/google.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/google.py
@@ -163,9 +163,9 @@ def __google_creds_oauth2(connection: str, refresh_token: str, scopes: list[str]
     if not expiry:
         raise ConnectionInitError(connection)
 
-    # Convert Go's time string (e.g. "2024-06-20 19:18:17 +0700 PDT") to
+    # Convert Go's time string (e.g. "2024-06-20 19:18:17 -0700 PDT") to
     # an ISO-8601 string that Python can parse with timezone awareness.
-    timestamp = re.sub(r"[ A-Z]+.*", "", expiry)
+    timestamp = re.sub(r" [A-Z]+.*", "", expiry)
     dt = datetime.fromisoformat(timestamp).astimezone(UTC)
 
     client_id = os.getenv("GOOGLE_CLIENT_ID")

--- a/runtimes/pythonrt/py-sdk/autokitteh/slack.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/slack.py
@@ -8,7 +8,7 @@ from .connections import check_connection_name
 from .errors import ConnectionInitError
 
 
-def client(connection: str, **kwargs) -> WebClient:
+def slack_client(connection: str, **kwargs) -> WebClient:
     """Initialize a Slack client, based on an AutoKitteh connection.
 
     API reference:


### PR DESCRIPTION
1. Rename Slack client function for consistency (`client` --> `slack_client`)
2. Tiny fix in OAuth expiry timestamp regex (Jira + Google)