### PR TITLE
[ENG-1068] Make current directoy user code and add it to PYTHONPATH

### DIFF
--- a/runtimes/pythonrt/ak_runner/__main__.py
+++ b/runtimes/pythonrt/ak_runner/__main__.py
@@ -5,7 +5,7 @@ import tarfile
 from base64 import b64decode
 from importlib.util import module_from_spec, spec_from_file_location
 from inspect import getsourcelines
-from os import mkdir
+from os import chdir, mkdir
 from pathlib import Path
 from socket import AF_UNIX, SOCK_STREAM, socket
 
@@ -71,11 +71,14 @@ def run(args):
     log.info('sock: %r, tar: %r, module: %r', args.sock, args.tar, module_name)
     code_dir = extract_code(args.tar)
     log.info('code dir: %r', code_dir)
+    
+    # Allow users to import their own files and load data files
+    sys.path.append(code_dir)
+    chdir(code_dir)
 
     log.info('connected to %r', args.sock)
 
     log.info('loading %r', module_name)
-
     ak_call = AKCall(comm)
     mod = load_code(code_dir, ak_call, module_name)
     ak_call.set_module(mod)
@@ -121,6 +124,10 @@ def run(args):
 
 
 def inspect_file(root_dir, path):
+    # Allow users to import their own files and load data files
+    sys.path.append(root_dir)
+    chdir(root_dir)
+
     mod_name = path.stem
     spec = spec_from_file_location(mod_name, path)
     if spec is None:

--- a/runtimes/pythonrt/py.go
+++ b/runtimes/pythonrt/py.go
@@ -242,18 +242,17 @@ func writeTar(rootDir string, data []byte) (string, error) {
 	return tarName, err
 }
 
-func adjustPythonPath(env []string, runnerPath, userCodePath string) []string {
-	path := fmt.Sprintf("%s:%s", runnerPath, userCodePath) // runnerPath should be first
+func adjustPythonPath(env []string, runnerPath string) []string {
 	// Iterate in reverse since last value overrides
 	for i := len(env) - 1; i >= 0; i-- {
 		v := env[i]
 		if strings.HasPrefix(v, "PYTHONPATH=") {
-			env[i] = fmt.Sprintf("%s:%s", v, path)
+			env[i] = fmt.Sprintf("%s:%s", v, runnerPath)
 			return env
 		}
 	}
 
-	return append(env, fmt.Sprintf("PYTHONPATH=%s", path))
+	return append(env, fmt.Sprintf("PYTHONPATH=%s", runnerPath))
 }
 
 func overrideEnv(envMap map[string]string, runnerPath, userCodePath string) []string {
@@ -263,7 +262,7 @@ func overrideEnv(envMap map[string]string, runnerPath, userCodePath string) []st
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	return adjustPythonPath(env, runnerPath, userCodePath)
+	return adjustPythonPath(env, runnerPath)
 }
 
 func createVEnv(pyExe string, venvPath string) error {
@@ -327,7 +326,7 @@ func pyExports(ctx context.Context, pyExe string, fsys fs.FS) ([]Export, error) 
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf
-	cmd.Env = adjustPythonPath(os.Environ(), runnerDir, tmpDir)
+	cmd.Env = adjustPythonPath(os.Environ(), runnerDir)
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("inspect: %w.\nPython output: %s", err, buf.String())
 	}

--- a/runtimes/pythonrt/py_test.go
+++ b/runtimes/pythonrt/py_test.go
@@ -206,35 +206,30 @@ func Test_pyExports(t *testing.T) {
 
 }
 
-const (
-	testRunnerPath   = "/tmp/zzz/ak_runner"
-	testUserCodePath = "/tmp/zzz/user_code"
-)
-
-var addedPath = fmt.Sprintf("%s:%s", testRunnerPath, testUserCodePath)
+const testRunnerPath = "/tmp/zzz/ak_runner"
 
 var adjustCases = []struct {
 	name     string
 	env      []string
 	expected []string
 }{
-	{"empty env", nil, []string{"PYTHONPATH=" + addedPath}},
+	{"empty env", nil, []string{"PYTHONPATH=" + testRunnerPath}},
 	{
 		name:     "regular",
 		env:      []string{"HOME=/home/ak", "PYTHONPATH=x"},
-		expected: []string{"HOME=/home/ak", "PYTHONPATH=x:" + addedPath},
+		expected: []string{"HOME=/home/ak", "PYTHONPATH=x:" + testRunnerPath},
 	},
 	{
 		name:     "last",
 		env:      []string{"PYTHONPATH=x", "HOME=/home/ak", "PYTHONPATH=y"},
-		expected: []string{"PYTHONPATH=x", "HOME=/home/ak", "PYTHONPATH=y:" + addedPath},
+		expected: []string{"PYTHONPATH=x", "HOME=/home/ak", "PYTHONPATH=y:" + testRunnerPath},
 	},
 }
 
 func Test_adjustPYTHONPATH(t *testing.T) {
 	for _, tc := range adjustCases {
 		t.Run(tc.name, func(t *testing.T) {
-			out := adjustPythonPath(tc.env, testRunnerPath, testUserCodePath)
+			out := adjustPythonPath(tc.env, testRunnerPath)
 			require.Equal(t, tc.expected, out)
 		})
 	}


### PR DESCRIPTION
I know the code 
```python
    sys.path.append(code_dir)
    chdir(code_dir)
```

Is duplicated, but I couldn't find a meaningful name for a utility function, so left it "as is".