### PR TITLE
ENG-389: Add Google Calendar integration

### DIFF
--- a/integrations/google/calendar/client.go
+++ b/integrations/google/calendar/client.go
@@ -1,0 +1,76 @@
+package calendar
+
+import (
+	"context"
+
+	"go.autokitteh.dev/autokitteh/integrations/google/internal/vars"
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
+	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
+	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+const (
+	googleScope = "google"
+)
+
+type api struct {
+	Vars  sdkservices.Vars
+	Scope string
+}
+
+var integrationID = sdktypes.NewIntegrationIDFromName("googlecalendar")
+
+var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
+	IntegrationId: integrationID.String(),
+	UniqueName:    "googlecalendar",
+	DisplayName:   "Google Calendar",
+	Description:   "Google Calendar is a time-management and scheduling calendar service developed by Google.",
+	LogoUrl:       "/static/images/google_calendar.svg",
+	UserLinks: map[string]string{
+		"1 REST API reference": "https://developers.google.com/calendar/api/v3/reference",
+		"2 Go client API":      "https://pkg.go.dev/google.golang.org/api/calendar/v3",
+		"3 Python client API":  "https://developers.google.com/resources/api-libraries/documentation/calendar/v3/python/latest/",
+		"4 Python samples":     "https://github.com/googleworkspace/python-samples/tree/main/calendar",
+	},
+	ConnectionUrl: "/googlecalendar/connect",
+	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
+		RequiresConnectionInit: true,
+	},
+}))
+
+func New(cvars sdkservices.Vars) sdkservices.Integration {
+	return sdkintegrations.NewIntegration(
+		desc,
+		sdkmodule.New( /* No exported functions for Starlark */ ),
+		connStatus(cvars),
+		sdkintegrations.WithConnectionConfigFromVars(cvars),
+	)
+}
+
+// connStatus is an optional connection status check provided by the
+// integration to AutoKitteh. The possible results are "init required"
+// (the connection is not usable yet) and "using X" (where "X" is the
+// authentication method: OAuth 2.0 (user), or JSON key (service account).
+func connStatus(cvars sdkservices.Vars) sdkintegrations.OptFn {
+	return sdkintegrations.WithConnectionStatus(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
+		if !cid.IsValid() {
+			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "init required"), nil
+		}
+
+		vs, err := cvars.Get(ctx, sdktypes.NewVarScopeID(cid))
+		if err != nil {
+			return sdktypes.InvalidStatus, err
+		}
+
+		if vs.Has(vars.OAuthData) {
+			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using OAuth 2.0"), nil
+		}
+		if vs.Has(vars.JSON) {
+			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using JSON key"), nil
+		}
+
+		return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "unrecognized auth"), nil
+	})
+}

--- a/integrations/google/calendar/client.go
+++ b/integrations/google/calendar/client.go
@@ -11,15 +11,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-const (
-	googleScope = "google"
-)
-
-type api struct {
-	Vars  sdkservices.Vars
-	Scope string
-}
-
 var integrationID = sdktypes.NewIntegrationIDFromName("googlecalendar")
 
 var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{

--- a/integrations/google/client.go
+++ b/integrations/google/client.go
@@ -33,7 +33,6 @@ var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.Integrati
 func New(cvars sdkservices.Vars) sdkservices.Integration {
 	scope := desc.UniqueName().String()
 
-	// TODO: Calendar.
 	// TODO: Chat.
 	// TODO: Drive.
 	// TODO: Forms.

--- a/integrations/google/internal/vars/vars.go
+++ b/integrations/google/internal/vars/vars.go
@@ -1,6 +1,15 @@
 package vars
 
+import (
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
 type Vars struct {
 	OAuthData string `var:"secret"`
 	JSON      string `var:"secret"`
 }
+
+var (
+	OAuthData = sdktypes.NewSymbol("OAuthData")
+	JSON      = sdktypes.NewSymbol("JSON")
+)

--- a/internal/backend/integrations/integrations.go
+++ b/internal/backend/integrations/integrations.go
@@ -10,6 +10,7 @@ import (
 	"go.autokitteh.dev/autokitteh/integrations/chatgpt"
 	"go.autokitteh.dev/autokitteh/integrations/github"
 	"go.autokitteh.dev/autokitteh/integrations/google"
+	"go.autokitteh.dev/autokitteh/integrations/google/calendar"
 	"go.autokitteh.dev/autokitteh/integrations/google/gmail"
 	"go.autokitteh.dev/autokitteh/integrations/google/sheets"
 	"go.autokitteh.dev/autokitteh/integrations/grpc"
@@ -35,6 +36,7 @@ var Configs = configset.Set[Config]{
 func New(cfg *Config, vars sdkservices.Vars) sdkservices.Integrations {
 	ints := []sdkservices.Integration{
 		aws.New(vars),
+		calendar.New(vars),
 		chatgpt.New(vars),
 		github.New(vars),
 		gmail.New(vars),

--- a/web/static/embed.go
+++ b/web/static/embed.go
@@ -22,7 +22,7 @@ var GmailWebContent embed.FS
 //go:embed google/connect
 var GoogleWebContent embed.FS
 
-//go:embed google/connect
+//go:embed googlecalendar/connect
 var GoogleCalendarWebContent embed.FS
 
 //go:embed google/connect

--- a/web/static/googlecalendar/connect/error.html
+++ b/web/static/googlecalendar/connect/error.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>autokitteh Google Calendar Integration - Error!</title>
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/static/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/static/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/static/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/static/site.webmanifest" />
+    <link rel="stylesheet" type="text/css" href="styles.css" />
+    <meta name="robots" content="noindex, nofollow" />
+    <script src="error.js" defer></script>
+  </head>
+
+  <body>
+    <a href="/" target="_self">
+      <img class="banner" src="/static/banner.svg" alt="autokitteh" />
+    </a>
+
+    <table class="title">
+      <td>
+        <img class="logo" src="/static/images/google_calendar.svg" alt="Logo" />
+      </td>
+      <td><h1>Google Calendar - Connection Error</h1></td>
+    </table>
+
+    <p class="error" id="error"></p>
+
+    <p class="info">
+      <a href="../connect" class="info">Try to create another connection</a>
+    </p>
+  </body>
+</html>

--- a/web/static/googlecalendar/connect/error.js
+++ b/web/static/googlecalendar/connect/error.js
@@ -1,0 +1,8 @@
+// Display the error message in the page too, not just as a URL parameter.
+
+const param = new URLSearchParams(window.location.search).get("error");
+const elem = document.getElementById("error");
+
+if (param) {
+  elem.textContent = param;
+}

--- a/web/static/googlecalendar/connect/form.js
+++ b/web/static/googlecalendar/connect/form.js
@@ -1,0 +1,22 @@
+// Switch between 2 available modes: user impersonation (using
+// OAuth 2.0), and a GCP service account (using a JSON key).
+
+function toggleTab(id) {
+  // Update the toggle buttons.
+  const buttons = document.getElementsByClassName("toggle");
+  for (let i = 0; i < buttons.length; i++) {
+    buttons[i].classList.remove("active");
+  }
+  document.getElementById("toggle" + id).classList.add("active");
+
+  // Update the tab contents.
+  const tabs = document.getElementsByClassName("tab");
+  for (let i = 0; i < tabs.length; i++) {
+    tabs[i].classList.remove("active");
+  }
+  document.getElementById(id).classList.add("active");
+}
+
+window.onload = function () {
+  toggleTab("tab1");
+};

--- a/web/static/googlecalendar/connect/index.html
+++ b/web/static/googlecalendar/connect/index.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>AutoKitteh Google Calendar Integration</title>
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/static/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/static/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/static/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/static/site.webmanifest" />
+    <link rel="stylesheet" type="text/css" href="styles.css" />
+    <meta name="robots" content="noindex, nofollow" />
+    <script src="form.js" defer></script>
+  </head>
+
+  <body>
+    <a href="/" target="_self">
+      <img class="banner" src="/static/banner.svg" alt="AutoKitteh" />
+    </a>
+
+    <table class="title">
+      <td>
+        <img class="logo" src="/static/images/google_calendar.svg" alt="Logo" />
+      </td>
+      <td>
+        <h1>Google Calendar - Create a New Connection</h1>
+      </td>
+    </table>
+
+    <div class="toggle-container">
+      <button class="toggle" id="toggletab1" onclick="toggleTab('tab1')">
+        User (OAuth 2.0)
+      </button>
+      <span class="toggle-sep"></span>
+      <button class="toggle" id="toggletab2" onclick="toggleTab('tab2')">
+        Service Account (JSON Key)
+      </button>
+    </div>
+
+    <div class="tab" id="tab1">
+      <p class="info">Information:</p>
+      <ul class="links">
+        <li>
+          Guide:
+          <a
+            href="https://docs.autokitteh.com/config/integrations/google"
+            target="_blank"
+            class="info"
+          >
+            configuring the Google integration
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://developers.google.com/workspace/guides/auth-overview"
+            target="_blank"
+            class="info"
+          >
+            Learn about authentication and authorization
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://developers.google.com/identity/protocols/oauth2/web-server"
+            target="_blank"
+            class="info"
+          >
+            Using OAuth 2.0 for web server applications
+          </a>
+        </li>
+      </ul>
+
+      <p class="info">
+        Click the button below to sign-in and authorize the
+        <strong>AutoKitteh</strong> service
+      </p>
+      <!-- TODO(ENG-799): remove ID once its unused -->
+      <a id="oauth-link" href="/oauth/start/googlecalendar" class="clickable"
+        >Start OAuth Flow</a
+      >
+    </div>
+
+    <div class="tab" id="tab2">
+      <p class="info">Information:</p>
+      <ul class="links">
+        <li>
+          <a
+            href="https://cloud.google.com/iam/docs/service-account-overview"
+            target="_blank"
+            class="info"
+          >
+            GCP service accounts overview
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://cloud.google.com/iam/docs/service-account-creds"
+            target="_blank"
+            class="info"
+          >
+            Service account credentials
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://cloud.google.com/iam/docs/keys-create-delete"
+            target="_blank"
+            class="info"
+          >
+            Create and delete service account keys
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys"
+            target="_blank"
+            class="info"
+          >
+            Best practices for managing service account keys
+          </a>
+        </li>
+      </ul>
+
+      <!-- TODO(ENG-799): remove ID once its unused -->
+      <form id="save-json-form" method="post" action="/google/save">
+        <div class="form-group">
+          <label for="json">JSON Key</label>
+          <textarea
+            name="json"
+            rows="14"
+            cols="65"
+            wrap="soft"
+            autocomplete="off"
+            spellcheck="false"
+            required
+          ></textarea>
+        </div>
+
+        <button type="submit" class="submit-btn">Save Connection</button>
+      </form>
+    </div>
+
+    <!-- TODO(ENG-799) -->
+    <script>
+      const queryString = window.location.search;
+      document
+        .getElementById("oauth-link")
+        .setAttribute("href", "/oauth/start/google" + queryString);
+      document
+        .getElementById("save-json-form")
+        .setAttribute("action", "/google/save" + queryString);
+    </script>
+  </body>
+</html>

--- a/web/static/googlecalendar/connect/styles.css
+++ b/web/static/googlecalendar/connect/styles.css
@@ -1,0 +1,155 @@
+body {
+  background-color: white;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  margin-left: 50px;
+}
+
+img.banner {
+  margin: 50px 0px 32px;
+  width: 250px;
+  height: auto;
+}
+
+img.logo {
+  height: 32px;
+  width: auto;
+}
+
+table.title {
+  border: none;
+  border-collapse: collapse;
+  margin-bottom: 32px;
+}
+
+td {
+  vertical-align: middle;
+  padding-right: 16px;
+}
+
+h1 {
+  margin: 0px;
+}
+
+div.toggle-container {
+  max-width: 550px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 32px;
+}
+
+button.toggle {
+  flex: 1;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: medium;
+}
+
+button.toggle.active {
+  background-color: #3498db;
+  color: white;
+}
+
+span.toggle-sep {
+  width: 10px;
+}
+
+div.tab {
+  display: none;
+}
+
+div.active {
+  display: block;
+}
+
+p.info {
+  margin: 0px;
+}
+
+ul.links {
+  margin: 4px 0px 32px;
+}
+
+a.info {
+  color: #2980b9;
+  text-decoration: none;
+}
+
+a.info:hover {
+  text-decoration: underline;
+}
+
+.clickable {
+  margin-top: 32px;
+  padding: 10px 20px;
+  display: inline-block;
+  background-color: #3498db;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background-color 0.3s;
+}
+
+.clickable:hover {
+  background-color: #2980b9;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.form-group textarea {
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+}
+
+.submit-btn {
+  display: inline-block;
+  margin-top: 32px;
+  padding: 10px 20px;
+  background-color: #3498db;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background-color 0.3s;
+  font-size: medium;
+}
+
+.submit-btn:hover {
+  background-color: #2980b9;
+}
+
+.copyable {
+  display: inline-block;
+  padding: 10px 20px;
+  font-family: "Courier New", Courier, monospace;
+  background-color: #3498db;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background-color 0.3s;
+}
+
+.copyable:hover {
+  background-color: #2980b9;
+}
+
+.notif {
+  color: green;
+  display: none;
+}
+
+p.error {
+  color: red;
+  font-family: "Courier New", Courier, monospace;
+  margin-bottom: 32px;
+}


### PR DESCRIPTION
Focusing on Python scripts, so not adding exported functions for Starlark.

Also added a connection status function (ENG-1065).

HTML files copied (with naming tweaks) from Google Sheets. JS and CSS files are identical, but we can't use symlinks because Go file embedding doesn't support them.