### PR TITLE
ENG-1106 (part 2/2): 

### DIFF
--- a/integrations/atlassian/confluence/server.go
+++ b/integrations/atlassian/confluence/server.go
@@ -1,9 +1,7 @@
 package confluence
 
 import (
-	"fmt"
 	"net/http"
-	"net/url"
 
 	"go.uber.org/zap"
 
@@ -34,9 +32,4 @@ func Start(l *zap.Logger, mux *http.ServeMux, vars sdkservices.Vars, o sdkservic
 
 	// Event webhook.
 	mux.HandleFunc("POST "+webhookPath, h.handleEvent)
-}
-
-func redirectToErrorPage(w http.ResponseWriter, r *http.Request, err string) {
-	u := fmt.Sprintf("%s/error.html?error=%s", desc.ConnectionURL().Path, url.QueryEscape(err))
-	http.Redirect(w, r, u, http.StatusFound)
 }

--- a/integrations/atlassian/jira/server.go
+++ b/integrations/atlassian/jira/server.go
@@ -1,9 +1,7 @@
 package jira
 
 import (
-	"fmt"
 	"net/http"
-	"net/url"
 
 	"go.uber.org/zap"
 
@@ -34,9 +32,4 @@ func Start(l *zap.Logger, mux *http.ServeMux, vars sdkservices.Vars, o sdkservic
 
 	// Event webhook.
 	mux.HandleFunc("POST "+webhookPath, h.handleEvent)
-}
-
-func redirectToErrorPage(w http.ResponseWriter, r *http.Request, err string) {
-	u := fmt.Sprintf("%s/error.html?error=%s", desc.ConnectionURL().Path, url.QueryEscape(err))
-	http.Redirect(w, r, u, http.StatusFound)
 }

--- a/integrations/aws/client.go
+++ b/integrations/aws/client.go
@@ -73,20 +73,22 @@ func initOpts(vars sdkservices.Vars) (opts []sdkmodule.Optfn) {
 
 var integrationID = sdktypes.NewIntegrationIDFromName("aws")
 
+var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
+	IntegrationId: integrationID.String(),
+	UniqueName:    "aws",
+	DisplayName:   "AWS (All APIs)",
+	Description:   "Aggregation of all available Amazon Web Services (AWS) APIs.",
+	LogoUrl:       "/static/images/aws.svg",
+	UserLinks: map[string]string{
+		"1 API documentation": "https://docs.aws.amazon.com/",
+		"2 Service console":   "https://console.aws.amazon.com/",
+	},
+	ConnectionUrl: "/aws/connect",
+}))
+
 func New(vars sdkservices.Vars) sdkservices.Integration {
 	return sdkintegrations.NewIntegration(
-		kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-			IntegrationId: integrationID.String(),
-			UniqueName:    "aws",
-			DisplayName:   "AWS (All APIs)",
-			Description:   "Aggregation of all available Amazon Web Services (AWS) APIs.",
-			LogoUrl:       "/static/images/aws.svg",
-			UserLinks: map[string]string{
-				"1 API documentation": "https://docs.aws.amazon.com/",
-				"2 Service console":   "https://console.aws.amazon.com/",
-			},
-			ConnectionUrl: "/aws/connect",
-		})),
+		desc,
 		sdkmodule.New(initOpts(vars)...),
 		sdkintegrations.WithConnectionConfigFromVars(vars),
 	)

--- a/integrations/aws/save.go
+++ b/integrations/aws/save.go
@@ -1,47 +1,52 @@
 package aws
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
+
+	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 const (
-	HeaderContentType = "Content-Type"
-	ContentTypeForm   = "application/x-www-form-urlencoded"
+	headerContentType = "Content-Type"
+	contentTypeForm   = "application/x-www-form-urlencoded"
 )
 
 // handler is an autokitteh webhook which implements [http.Handler]
 // to save data from web form submissions as connections.
-type handler struct{}
+type handler struct {
+	logger *zap.Logger
+}
 
-func NewHTTPHandler() http.Handler { return handler{} }
+func NewHTTPHandler(l *zap.Logger) http.Handler {
+	return handler{logger: l}
+}
 
 // ServeHTTP saves a new autokitteh connection with user-submitted data.
 func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	c, l := sdkintegrations.NewConnectionInit(h.logger, w, r, desc)
+
 	// Check "Content-Type" header.
-	ct := r.Header.Get(HeaderContentType)
-	if ct != ContentTypeForm {
-		http.Error(w, fmt.Sprintf("Unexpected Content-Type header: %q", ct), http.StatusBadRequest)
+	contentType := r.Header.Get(headerContentType)
+	if !strings.HasPrefix(contentType, contentTypeForm) {
+		c.Abort("unexpected content type")
 		return
 	}
 
 	// Read and parse POST request body.
-	err := r.ParseForm()
-	if err != nil {
-		http.Error(w, "Form parsing error: "+err.Error(), http.StatusBadRequest)
+	if err := r.ParseForm(); err != nil {
+		l.Warn("Failed to parse incoming HTTP request", zap.Error(err))
+		c.Abort("form parsing error")
 		return
 	}
 
-	initData := sdktypes.EncodeVars(authData{
+	c.Finalize(sdktypes.EncodeVars(authData{
 		Region:      strings.TrimSpace(r.FormValue("region")),
 		AccessKeyID: strings.TrimSpace(r.FormValue("access_key")),
 		SecretKey:   strings.TrimSpace(r.FormValue("secret_key")),
 		Token:       strings.TrimSpace(r.FormValue("token")),
-	})
-
-	sdkintegrations.FinalizeConnectionInit(w, r, integrationID, initData)
+	}))
 }

--- a/integrations/aws/server.go
+++ b/integrations/aws/server.go
@@ -3,6 +3,8 @@ package aws
 import (
 	"net/http"
 
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/web/static"
 )
 
@@ -15,8 +17,8 @@ const (
 	savePath = "/aws/save"
 )
 
-func Start(mux *http.ServeMux) {
+func Start(l *zap.Logger, mux *http.ServeMux) {
 	// New connection UI + form submission handler.
 	mux.Handle(uiPath, http.FileServer(http.FS(static.AWSWebContent)))
-	mux.Handle(savePath, NewHTTPHandler())
+	mux.Handle(savePath, NewHTTPHandler(l))
 }

--- a/integrations/google/oauth.go
+++ b/integrations/google/oauth.go
@@ -3,9 +3,7 @@ package google
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
-	"net/url"
 
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
@@ -35,21 +33,21 @@ func NewHTTPHandler(l *zap.Logger, o sdkservices.OAuth) handler {
 // (either way). If all is well, it saves a new autokitteh connection.
 // Either way, it redirects the user to success or failure webpages.
 func (h handler) HandleOAuth(w http.ResponseWriter, r *http.Request) {
-	l := h.logger.With(zap.String("urlPath", r.URL.Path))
+	c, l := sdkintegrations.NewConnectionInit(h.logger, w, r, desc)
 
 	// Handle errors (e.g. the user didn't authorize us) based on:
 	// https://developers.google.com/identity/protocols/oauth2/web-server#handlingresponse
 	e := r.FormValue("error")
 	if e != "" {
 		l.Warn("OAuth redirect request reported an error", zap.Error(errors.New(e)))
-		redirectToErrorPage(w, r, e)
+		c.Abort(e)
 		return
 	}
 
 	raw, data, err := sdkintegrations.GetOAuthDataFromURL(r.URL)
 	if err != nil {
 		l.Warn("Invalid data in OAuth redirect request", zap.Error(err))
-		redirectToErrorPage(w, r, "invalid data parameter")
+		c.Abort("invalid data parameter")
 		return
 
 	}
@@ -57,7 +55,7 @@ func (h handler) HandleOAuth(w http.ResponseWriter, r *http.Request) {
 	oauthToken := data.Token
 	if oauthToken == nil {
 		l.Warn("Missing token in OAuth redirect request", zap.Any("data", data))
-		redirectToErrorPage(w, r, "missing OAuth token")
+		c.Abort("missing OAuth token")
 		return
 	}
 
@@ -67,27 +65,20 @@ func (h handler) HandleOAuth(w http.ResponseWriter, r *http.Request) {
 	svc, err := googleoauth2.NewService(ctx, option.WithTokenSource(src))
 	if err != nil {
 		l.Warn("OAuth user token error", zap.Error(err))
-		redirectToErrorPage(w, r, "token source")
+		c.Abort("token source")
 		return
 	}
 
 	user, err := h.getUserDetails(l, svc)
 	if err != nil {
 		l.Warn("OAuth user details error", zap.Error(err))
-		redirectToErrorPage(w, r, "Google user details error")
+		c.Abort("Google user details error")
 		return
 	}
 
-	initData := sdktypes.EncodeVars(&vars.Vars{OAuthData: raw}).
+	c.Finalize(sdktypes.EncodeVars(&vars.Vars{OAuthData: raw}).
 		Append(data.ToVars()...).
-		Append(user...)
-
-	sdkintegrations.FinalizeConnectionInit(w, r, integrationID, initData)
-}
-
-func redirectToErrorPage(w http.ResponseWriter, r *http.Request, err string) {
-	u := fmt.Sprintf("%s/error.html?error=%s", desc.ConnectionURL().Path, url.QueryEscape(err))
-	http.Redirect(w, r, u, http.StatusFound)
+		Append(user...))
 }
 
 func (h handler) tokenSource(ctx context.Context, t *oauth2.Token) oauth2.TokenSource {

--- a/integrations/slack/server.go
+++ b/integrations/slack/server.go
@@ -31,7 +31,7 @@ func Start(l *zap.Logger, mux *http.ServeMux, vs sdkservices.Vars, d sdkservices
 
 	mux.Handle("GET "+oauthPath, NewHandler(l))
 
-	wsh := websockets.NewHandler(l, vs, d, integrationID)
+	wsh := websockets.NewHandler(l, vs, d, desc)
 	mux.HandleFunc("POST "+formPath, wsh.HandleForm)
 
 	// Event webhooks.

--- a/integrations/slack/websockets/form.go
+++ b/integrations/slack/websockets/form.go
@@ -16,10 +16,6 @@ import (
 )
 
 const (
-	// uiPath is the URL root path of a simple web UI to interact
-	// with users to install a Slack Socket Mode app.
-	uiPath = "/slack/connect"
-
 	headerContentType = "Content-Type"
 	contentTypeForm   = "application/x-www-form-urlencoded"
 )

--- a/integrations/slack/websockets/form.go
+++ b/integrations/slack/websockets/form.go
@@ -1,9 +1,7 @@
 package websockets
 
 import (
-	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"go.uber.org/zap"
@@ -28,20 +26,19 @@ const (
 
 // HandleForm saves a new autokitteh connection, based on a user-submitted form.
 func (h handler) HandleForm(w http.ResponseWriter, r *http.Request) {
-	l := h.logger.With(zap.String("urlPath", r.URL.Path))
+	c, l := sdkintegrations.NewConnectionInit(h.logger, w, r, h.integration)
 
-	// Check the "Content-Type" header.
+	// Check "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
 	if !strings.HasPrefix(contentType, contentTypeForm) {
-		// Probably an attack, so no need for user-friendliness.
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		c.Abort("unexpected content type")
 		return
 	}
 
 	// Read and parse POST request body.
 	if err := r.ParseForm(); err != nil {
-		l.Warn("Failed to parse inbound HTTP request", zap.Error(err))
-		redirectToErrorPage(w, r, "form parsing error: "+err.Error())
+		l.Warn("Failed to parse incoming HTTP request", zap.Error(err))
+		c.Abort("form parsing error")
 		return
 	}
 
@@ -53,39 +50,32 @@ func (h handler) HandleForm(w http.ResponseWriter, r *http.Request) {
 	authTest, err := auth.TestWithToken(ctx, botToken)
 	if err != nil {
 		l.Warn("Slack OAuth token test failed", zap.Error(err))
-		redirectToErrorPage(w, r, "token auth test failed: "+err.Error())
+		c.Abort("token auth test failed: " + err.Error())
 		return
 	}
 
 	botInfo, err := bots.InfoWithToken(ctx, botToken, authTest)
 	if err != nil {
 		l.Warn("Slack bot info request failed", zap.Error(err))
-		redirectToErrorPage(w, r, "bot info request failed: "+err.Error())
+		c.Abort("bot info request failed: " + err.Error())
 		return
 	}
 
 	_, err = apps.ConnectionsOpenWithToken(ctx, h.vars, appToken)
 	if err != nil {
 		l.Warn("Slack websocket connection error", zap.Error(err))
-		redirectToErrorPage(w, r, "websocket connection error: "+err.Error())
+		c.Abort("websocket connection error: " + err.Error())
 		return
 	}
 
-	initData := sdktypes.EncodeVars(vars.Vars{
+	// Open a new Socket Mode connection.
+	h.OpenSocketModeConnection(botInfo.Bot.AppID, botToken, appToken)
+
+	c.Finalize(sdktypes.EncodeVars(vars.Vars{
 		AppID:        botInfo.Bot.AppID,
 		EnterpriseID: authTest.EnterpriseID,
 		TeamID:       authTest.TeamID,
 	}).
 		Set(vars.AppTokenName, appToken, true).
-		Set(vars.BotTokenName, botToken, true)
-
-	// Open a new Socket Mode connection.
-	h.OpenSocketModeConnection(botInfo.Bot.AppID, botToken, appToken)
-
-	sdkintegrations.FinalizeConnectionInit(w, r, h.integrationID, initData)
-}
-
-func redirectToErrorPage(w http.ResponseWriter, r *http.Request, err string) {
-	u := fmt.Sprintf("%s/error.html?error=%s", uiPath, url.QueryEscape(err))
-	http.Redirect(w, r, u, http.StatusFound)
+		Set(vars.BotTokenName, botToken, true))
 }

--- a/integrations/slack/websockets/socketmode.go
+++ b/integrations/slack/websockets/socketmode.go
@@ -21,15 +21,17 @@ type handler struct {
 	logger        *zap.Logger
 	vars          sdkservices.Vars
 	dispatcher    sdkservices.Dispatcher
+	integration   sdktypes.Integration
 	integrationID sdktypes.IntegrationID
 }
 
-func NewHandler(l *zap.Logger, v sdkservices.Vars, d sdkservices.Dispatcher, id sdktypes.IntegrationID) handler {
+func NewHandler(l *zap.Logger, v sdkservices.Vars, d sdkservices.Dispatcher, i sdktypes.Integration) handler {
 	return handler{
 		logger:        l,
 		vars:          v,
 		dispatcher:    d,
-		integrationID: id,
+		integration:   i,
+		integrationID: i.ID(),
 	}
 }
 

--- a/integrations/twilio/server.go
+++ b/integrations/twilio/server.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Start(l *zap.Logger, mux *http.ServeMux, vars sdkservices.Vars, d sdkservices.Dispatcher) {
-	h := webhooks.NewHandler(l, vars, d, "twilio", integrationID)
+	h := webhooks.NewHandler(l, vars, d, "twilio", desc)
 
 	// Save new autokitteh connections with user-submitted Twilio secrets.
 	uiPath := "GET " + desc.ConnectionURL().Path + "/"

--- a/integrations/twilio/webhooks/webhook.go
+++ b/integrations/twilio/webhooks/webhook.go
@@ -17,16 +17,18 @@ type handler struct {
 	vars          sdkservices.Vars
 	dispatcher    sdkservices.Dispatcher
 	scope         string
+	integration   sdktypes.Integration
 	integrationID sdktypes.IntegrationID
 }
 
-func NewHandler(l *zap.Logger, vars sdkservices.Vars, d sdkservices.Dispatcher, scope string, id sdktypes.IntegrationID) handler {
+func NewHandler(l *zap.Logger, vars sdkservices.Vars, d sdkservices.Dispatcher, scope string, i sdktypes.Integration) handler {
 	return handler{
 		logger:        l,
 		vars:          vars,
 		dispatcher:    d,
 		scope:         scope,
-		integrationID: id,
+		integration:   i,
+		integrationID: i.ID(),
 	}
 }
 

--- a/internal/backend/dashboardsvc/connections.go
+++ b/internal/backend/dashboardsvc/connections.go
@@ -244,7 +244,9 @@ func initResult(w http.ResponseWriter, r *http.Request) {
 		output = []byte(`{"status":500,"error":"failed to encode error message"}`)
 	}
 
-	w.Write(output)
+	if _, err := w.Write(output); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func (s Svc) rmAllConnectionVars(w http.ResponseWriter, r *http.Request) {

--- a/internal/backend/dashboardsvc/connections.go
+++ b/internal/backend/dashboardsvc/connections.go
@@ -17,12 +17,14 @@ func (s Svc) initConnections() {
 
 	s.Muxes.Auth.HandleFunc("GET /connections", s.connections)
 	s.Muxes.Auth.HandleFunc("GET /connections/{cid}", s.connection)
-	s.Muxes.Auth.HandleFunc("GET /connections/{id}/init/{origin}", s.initConnection)
-	s.Muxes.Auth.HandleFunc("GET /connections/{id}/postinit", s.postInitConnection)
-	s.Muxes.Auth.HandleFunc("DELETE /connections/{id}/vars", s.rmAllConnectionVars)
 
-	s.Muxes.Auth.HandleFunc("/connections/{id}/test", s.testConnection)
-	s.Muxes.Auth.HandleFunc("/connections/{id}/refresh", s.refreshConnection)
+	s.Muxes.Auth.HandleFunc("GET /connections/{id}/init/{origin}", s.init)
+	s.Muxes.Auth.HandleFunc("GET /connections/{id}/postinit", s.postInit)
+	// s.Muxes.Auth.HandleFunc("GET /connections/{id}/result", s.initResult)
+
+	s.Muxes.Auth.HandleFunc("DELETE /connections/{id}/vars", s.rmAllConnectionVars)
+	s.Muxes.Auth.HandleFunc("GET /connections/{id}/test", s.test)
+	s.Muxes.Auth.HandleFunc("GET /connections/{id}/refresh", s.refresh)
 }
 
 type connection struct{ sdktypes.Connection }
@@ -147,7 +149,7 @@ func (s Svc) connection(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s Svc) initConnection(w http.ResponseWriter, r *http.Request) {
+func (s Svc) init(w http.ResponseWriter, r *http.Request) {
 	id, origin := r.PathValue("id"), r.PathValue("origin")
 
 	cid, err := sdktypes.StrictParseConnectionID(id)
@@ -213,11 +215,11 @@ func (s Svc) initUnknownConnection(w http.ResponseWriter, r *http.Request, id, v
 	renderList(w, r, "connections", l)
 }
 
-// postInitConnection is the last step in the connection initialization
-// flow. It saves the connection's data in the connection's scope, and
+// postInit is the last step in the connection initialization flow.
+// It saves the connection's data in the connection's scope, and
 // redirects the user to the last HTTP response, based on its origin
 // (local AK server / local VS Code extension / SaaS web UI).
-func (s Svc) postInitConnection(w http.ResponseWriter, r *http.Request) {
+func (s Svc) postInit(w http.ResponseWriter, r *http.Request) {
 	vars, origin := r.URL.Query().Get("vars"), r.URL.Query().Get("origin")
 
 	id := r.PathValue("id")
@@ -276,7 +278,7 @@ func (s Svc) rmAllConnectionVars(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s Svc) testConnection(w http.ResponseWriter, r *http.Request) {
+func (s Svc) test(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 
 	cid, err := sdktypes.StrictParseConnectionID(id)
@@ -297,7 +299,7 @@ func (s Svc) testConnection(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s Svc) refreshConnection(w http.ResponseWriter, r *http.Request) {
+func (s Svc) refresh(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 
 	cid, err := sdktypes.StrictParseConnectionID(id)

--- a/internal/backend/dashboardsvc/connections_test.go
+++ b/internal/backend/dashboardsvc/connections_test.go
@@ -1,0 +1,66 @@
+package dashboardsvc
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_initResult(t *testing.T) {
+	basePath := "/connections/cid_12345/result"
+
+	tests := []struct {
+		name   string
+		path   string
+		status int
+		err    string
+	}{
+		{
+			name:   "no status",
+			path:   basePath,
+			status: 500,
+			err:    "non-integer status",
+		},
+		{
+			name:   "invalid status",
+			path:   basePath + "?status=abc",
+			status: 500,
+			err:    "non-integer status",
+		},
+		{
+			name:   "happy path for init success",
+			path:   basePath + "?status=200",
+			status: 200,
+			err:    "",
+		},
+		{
+			name:   "happy path for init failure",
+			path:   basePath + "?status=500&error=oh%20no",
+			status: 500,
+			err:    "oh no",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", basePath+tt.path, nil)
+			w := httptest.NewRecorder()
+			initResult(w, req)
+
+			resp := w.Result()
+			body, _ := io.ReadAll(resp.Body)
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+			assert.Contains(t, string(body), fmt.Sprintf(`"status":%d`, tt.status))
+			if tt.err == "" {
+				assert.NotContains(t, string(body), fmt.Sprintf(`"error":`))
+			} else {
+				assert.Contains(t, string(body), fmt.Sprintf(`"error":"%s"`, tt.err))
+			}
+		})
+	}
+}

--- a/internal/backend/dashboardsvc/connections_test.go
+++ b/internal/backend/dashboardsvc/connections_test.go
@@ -1,9 +1,7 @@
 package dashboardsvc
 
 import (
-	"fmt"
 	"io"
-	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -22,13 +20,13 @@ func Test_initResult(t *testing.T) {
 		{
 			name:   "no status",
 			path:   basePath,
-			status: 500,
+			status: 400,
 			err:    "non-integer status",
 		},
 		{
 			name:   "invalid status",
 			path:   basePath + "?status=abc",
-			status: 500,
+			status: 400,
 			err:    "non-integer status",
 		},
 		{
@@ -53,13 +51,11 @@ func Test_initResult(t *testing.T) {
 			resp := w.Result()
 			body, _ := io.ReadAll(resp.Body)
 
-			assert.Equal(t, http.StatusOK, resp.StatusCode)
-			assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-			assert.Contains(t, string(body), fmt.Sprintf(`"status":%d`, tt.status))
+			assert.Equal(t, tt.status, resp.StatusCode)
 			if tt.err == "" {
-				assert.NotContains(t, string(body), `"error":`)
+				assert.Empty(t, string(body))
 			} else {
-				assert.Contains(t, string(body), fmt.Sprintf(`"error":"%s"`, tt.err))
+				assert.Equal(t, tt.err+"\n", string(body))
 			}
 		})
 	}

--- a/internal/backend/dashboardsvc/connections_test.go
+++ b/internal/backend/dashboardsvc/connections_test.go
@@ -57,7 +57,7 @@ func Test_initResult(t *testing.T) {
 			assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 			assert.Contains(t, string(body), fmt.Sprintf(`"status":%d`, tt.status))
 			if tt.err == "" {
-				assert.NotContains(t, string(body), fmt.Sprintf(`"error":`))
+				assert.NotContains(t, string(body), `"error":`)
 			} else {
 				assert.Contains(t, string(body), fmt.Sprintf(`"error":"%s"`, tt.err))
 			}

--- a/internal/backend/integrations/integrations.go
+++ b/internal/backend/integrations/integrations.go
@@ -64,7 +64,7 @@ func New(cfg *Config, vars sdkservices.Vars) sdkservices.Integrations {
 }
 
 func Start(_ context.Context, l *zap.Logger, mux *http.ServeMux, vars sdkservices.Vars, o sdkservices.OAuth, d sdkservices.Dispatcher, c sdkservices.Connections, p sdkservices.Projects) error {
-	aws.Start(mux)
+	aws.Start(l, mux)
 	chatgpt.Start(l, mux)
 	confluence.Start(l, mux, vars, o, d)
 	github.Start(l, mux, vars, o, d)

--- a/internal/backend/oauth/svc.go
+++ b/internal/backend/oauth/svc.go
@@ -90,7 +90,7 @@ func (s *server) StartFlow(ctx context.Context, req *connect.Request[oauthv1.Sta
 		return nil, sdkerrors.AsConnectError(err)
 	}
 
-	cid, err := sdktypes.ParseConnectionID(req.Msg.ConnectionId)
+	cid, err := sdktypes.StrictParseConnectionID(req.Msg.ConnectionId)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}

--- a/internal/backend/oauth/webhook.go
+++ b/internal/backend/oauth/webhook.go
@@ -48,7 +48,7 @@ func (s *svc) start(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cid, err := sdktypes.ParseConnectionID(r.URL.Query().Get("cid"))
+	cid, err := sdktypes.StrictParseConnectionID(r.URL.Query().Get("cid"))
 	if err != nil {
 		l.Warn("Failed to parse connection ID", zap.Error(err))
 		http.Error(w, "Bad request: invalid connection ID", http.StatusBadRequest)

--- a/internal/backend/oauth/webhook.go
+++ b/internal/backend/oauth/webhook.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"time"
 
@@ -30,7 +31,7 @@ func InitWebhook(l *zap.Logger, muxes *muxes.Muxes, c sdkservices.Services) {
 
 func (s *svc) start(w http.ResponseWriter, r *http.Request) {
 	intg := r.PathValue("intg")
-	origin := r.URL.Query().Get("origin")
+	origin := r.FormValue("origin")
 
 	l := s.logger.With(
 		zap.String("urlPath", r.URL.Path),
@@ -60,6 +61,7 @@ func (s *svc) start(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Bad request: start flow error", http.StatusBadRequest)
 		return
 	}
+
 	http.Redirect(w, r, startURL, http.StatusFound)
 }
 
@@ -76,45 +78,62 @@ func (s *svc) exchange(w http.ResponseWriter, r *http.Request) {
 
 	// Ensure the specified integration is registered.
 	o := s.svcs.OAuth()
-	if _, _, err := o.Get(ctx, r.PathValue("intg")); err != nil {
-		abort(l, w, "unrecognized integration name", err, http.StatusBadRequest)
+	if _, _, err := o.Get(ctx, intg); err != nil {
+		l.Error("Unrecognized integration name")
+		http.Error(w, "Unrecognized integration name", http.StatusBadRequest)
 		return
 	}
 
-	// Read the temporary authorization code from the redirected request.
+	// Ensure the state parameter is well-formed.
+	sub := regexp.MustCompile(`^(.+)_([a-z]+)$`).FindStringSubmatch(state)
+	if len(sub) != 3 {
+		l.Error("Invalid state parameter")
+		http.Error(w, "Invalid state parameter", http.StatusBadRequest)
+		return
+	}
+
+	// Report back OAuth errors.
+	if err := r.FormValue("error_description"); err != "" {
+		abort(w, r, intg, sub[1], sub[2], err)
+		return
+	}
+
+	if err := r.FormValue("error"); err != "" {
+		abort(w, r, intg, sub[1], sub[2], err)
+		return
+	}
+
+	// Convert the OAuth code into a refresh token / user access token.
 	code := r.FormValue("code")
 	if code == "" {
-		abort(l, w, "missing code parameter", nil, http.StatusBadRequest)
+		abort(w, r, intg, sub[1], sub[2], "missing code parameter")
 		return
 	}
 
-	// Convert it into an OAuth refresh token / user access token.
 	token, err := o.Exchange(ctx, intg, code)
 	if err != nil {
-		abort(l, w, "OAuth exchange error", err, http.StatusBadRequest)
+		l.Warn("OAuth exchange error", zap.Error(err))
+		abort(w, r, intg, sub[1], sub[2], "OAuth exchange error")
 		return
 	}
 
 	l.Info("OAuth token exchange successful")
 
+	// Pass the OAuth data back to the originating integration.
 	oauthData, err := sdkintegrations.OAuthData{Token: token, Params: r.URL.Query()}.Encode()
 	if err != nil {
-		abort(l, w, "failed to encode OAuth token", err, http.StatusInternalServerError)
+		abort(w, r, intg, sub[1], sub[2], "OAuth token encoding error")
 		return
 	}
 
-	sub := regexp.MustCompile(`^(.+)_([a-z]+)$`).FindStringSubmatch(state)
-	if len(sub) != 3 {
-		err := fmt.Errorf("invalid state parameter: %q", state)
-		abort(l, w, "invalid state parameter", err, http.StatusBadRequest)
-		return
-	}
-
-	u := fmt.Sprintf("/%s/oauth?oauth=%s&cid=con_%s&origin=%s", intg, oauthData, sub[1], sub[2])
-	http.Redirect(w, r, u, http.StatusFound)
+	redirect(w, r, intg, sub[1], sub[2], "oauth", oauthData)
 }
 
-func abort(l *zap.Logger, w http.ResponseWriter, msg string, err error, code int) {
-	l.Warn(msg, zap.Error(err))
-	http.Error(w, msg, code)
+func abort(w http.ResponseWriter, r *http.Request, intg, cid, origin, err string) {
+	redirect(w, r, intg, cid, origin, "error", url.QueryEscape(err))
+}
+
+func redirect(w http.ResponseWriter, r *http.Request, intg, cid, origin, param, value string) {
+	u := fmt.Sprintf("/%s/oauth?cid=con_%s&origin=%s&%s=%s", intg, cid, origin, param, value)
+	http.Redirect(w, r, u, http.StatusFound)
 }

--- a/sdk/sdkintegrations/initconn.go
+++ b/sdk/sdkintegrations/initconn.go
@@ -50,7 +50,8 @@ func (c ConnectionInit) Abort(err string) {
 // and redirects the user to the last HTTP response, based on its
 // origin (local AK server / local VS Code extension / SaaS web UI).
 func (c ConnectionInit) AbortWithStatus(status int, err string) {
-	switch c.Request.FormValue("origin") {
+	origin := c.Request.FormValue("origin")
+	switch origin {
 	case "vscode":
 		u := "vscode://autokitteh.autokitteh?cid=%s&status=%d&error=%s"
 		u = fmt.Sprintf(u, c.ConnectionID, status, url.QueryEscape(err))
@@ -58,8 +59,8 @@ func (c ConnectionInit) AbortWithStatus(status int, err string) {
 	case "web":
 		http.Error(c.Writer, err, status)
 	default: // Local server ("cli", "dash", etc.)
-		path := c.Integration.ConnectionURL().Path + "/error.html"
-		u := fmt.Sprintf("%s?error=%s", path, url.QueryEscape(err))
+		u := c.Integration.ConnectionURL().Path + "/error.html?cid=%s&origin=%s&error=%s"
+		u = fmt.Sprintf(u, c.ConnectionID, origin, url.QueryEscape(err))
 		http.Redirect(c.Writer, c.Request, u, http.StatusFound)
 	}
 }

--- a/sdk/sdkintegrations/initconn.go
+++ b/sdk/sdkintegrations/initconn.go
@@ -5,37 +5,92 @@ import (
 	"net/http"
 	"net/url"
 
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-// FinalizeConnectionInit finalizes all integration-specific connection flows.
-// It encodes their resulting details and redirects the user to the final HTTP
-// handler ("post-init") that saves the data in the connection's scope, and
-// redirects the user to the last HTTP response, based on its origin
-// (local AK server / local VS Code extension / SaaS web UI).
-func FinalizeConnectionInit(w http.ResponseWriter, r *http.Request, iid sdktypes.IntegrationID, data []sdktypes.Var) {
+type ConnectionInit struct {
+	Writer       http.ResponseWriter
+	Request      *http.Request
+	Integration  sdktypes.Integration
+	ConnectionID string
+	Origin       string
+	logger       *zap.Logger
+}
+
+func NewConnectionInit(l *zap.Logger, w http.ResponseWriter, r *http.Request, i sdktypes.Integration) (ConnectionInit, *zap.Logger) {
+	cid := r.FormValue("cid")
+	origin := r.FormValue("origin")
+
+	l = l.With(
+		zap.String("urlPath", r.URL.Path),
+		zap.String("connectionID", cid),
+		zap.String("origin", origin),
+	)
+
+	return ConnectionInit{
+		Writer:       w,
+		Request:      r,
+		Integration:  i,
+		ConnectionID: cid,
+		Origin:       origin,
+		logger:       l,
+	}, l
+}
+
+// Abort is the same as [AbortWithStatus] with HTTP 400 (Bad Request).
+func (c ConnectionInit) Abort(err string) {
+	c.AbortWithStatus(http.StatusBadRequest, err)
+}
+
+// Abort aborts the connection initialization flow due to
+// a runtime error. It encodes the error status and message,
+// and redirects the user to the last HTTP response, based on its
+// origin (local AK server / local VS Code extension / SaaS web UI).
+func (c ConnectionInit) AbortWithStatus(status int, err string) {
+	switch c.Request.FormValue("origin") {
+	case "vscode":
+		u := "vscode://autokitteh.autokitteh?cid=%s&status=%d&error=%s"
+		u = fmt.Sprintf(u, c.ConnectionID, status, url.QueryEscape(err))
+		http.Redirect(c.Writer, c.Request, u, http.StatusFound)
+	case "web":
+		u := "/connections/%s/result?status=%d&error=%s"
+		u = fmt.Sprintf(u, c.ConnectionID, status, url.QueryEscape(err))
+		http.Redirect(c.Writer, c.Request, u, http.StatusFound)
+	default: // Local server ("cli", "dash", etc.)
+		path := c.Integration.ConnectionURL().Path + "/error.html"
+		u := fmt.Sprintf("%s?error=%s", path, url.QueryEscape(err))
+		http.Redirect(c.Writer, c.Request, u, http.StatusFound)
+	}
+}
+
+// Finalize finalizes all integration-specific connection flows.
+// It encodes their resulting details and redirects the user to the
+// final HTTP handler ("post-init") that saves the data in the connection's
+// scope, and redirects the user to the last HTTP response, based on its
+// origin (local AK server / local VS Code extension / SaaS web UI).
+func (c ConnectionInit) Finalize(data []sdktypes.Var) {
 	vars, err := kittehs.EncodeURLData(data)
 	if err != nil {
-		http.Error(w, "Failed to encode URL vars", http.StatusInternalServerError)
+		c.logger.Warn("Connection data encoding error", zap.Error(err))
+		c.AbortWithStatus(http.StatusInternalServerError, "connection data encoding error")
 		return
 	}
 
-	cid, err := sdktypes.ParseConnectionID(r.URL.Query().Get("cid"))
-	if err != nil {
-		http.Error(w, "Failed to parse connection ID", http.StatusBadRequest)
+	if _, err = sdktypes.ParseConnectionID(c.ConnectionID); err != nil {
+		c.logger.Warn("Invalid connection ID")
+		c.Abort("invalid connection ID")
 		return
 	}
 
-	id := cid.String()
-	if id == "" {
+	if c.ConnectionID == "" {
 		// The user needs to select a specific connection at the end,
 		// based on the integration, if it wasn't selected at the beginning.
-		id = iid.String()
+		c.ConnectionID = c.Integration.ID().String()
 	}
 
-	origin := url.QueryEscape(r.URL.Query().Get("origin"))
-
-	u := fmt.Sprintf("/connections/%s/postinit?vars=%s&origin=%s", id, vars, origin)
-	http.Redirect(w, r, u, http.StatusFound)
+	u := fmt.Sprintf("/connections/%s/postinit?vars=%s&origin=%s", c.ConnectionID, vars, c.Origin)
+	http.Redirect(c.Writer, c.Request, u, http.StatusFound)
 }

--- a/sdk/sdkintegrations/initconn.go
+++ b/sdk/sdkintegrations/initconn.go
@@ -56,9 +56,7 @@ func (c ConnectionInit) AbortWithStatus(status int, err string) {
 		u = fmt.Sprintf(u, c.ConnectionID, status, url.QueryEscape(err))
 		http.Redirect(c.Writer, c.Request, u, http.StatusFound)
 	case "web":
-		u := "/connections/%s/result?status=%d&error=%s"
-		u = fmt.Sprintf(u, c.ConnectionID, status, url.QueryEscape(err))
-		http.Redirect(c.Writer, c.Request, u, http.StatusFound)
+		http.Error(c.Writer, err, status)
 	default: // Local server ("cli", "dash", etc.)
 		path := c.Integration.ConnectionURL().Path + "/error.html"
 		u := fmt.Sprintf("%s?error=%s", path, url.QueryEscape(err))

--- a/sdk/sdkintegrations/initconn.go
+++ b/sdk/sdkintegrations/initconn.go
@@ -79,16 +79,10 @@ func (c ConnectionInit) Finalize(data []sdktypes.Var) {
 		return
 	}
 
-	if _, err = sdktypes.ParseConnectionID(c.ConnectionID); err != nil {
+	if _, err = sdktypes.StrictParseConnectionID(c.ConnectionID); err != nil {
 		c.logger.Warn("Invalid connection ID")
 		c.Abort("invalid connection ID")
 		return
-	}
-
-	if c.ConnectionID == "" {
-		// The user needs to select a specific connection at the end,
-		// based on the integration, if it wasn't selected at the beginning.
-		c.ConnectionID = c.Integration.ID().String()
 	}
 
 	u := fmt.Sprintf("/connections/%s/postinit?vars=%s&origin=%s", c.ConnectionID, vars, c.Origin)


### PR DESCRIPTION
Continuation of https://github.com/autokitteh/autokitteh/pull/447

All integrations now report connection init successes and failures in a standard way, and the display of this status depends on the init request's origin.

- `/connections/CID/init/vscode` --> VS Code URL
- `/connections/CID/init/web` --> JSON message with "status" (200, 400, 500, etc.) and optional "error" string
- Everything else (CLI, web dashboard) - as usual

The core of this PR is in these files:

- internal/backend/dashboardsvc/connections.go
- internal/backend/oauth/webhook.go
- proto/autokitteh/oauth/v1/svc.proto
- sdk/sdkintegrations/initconn.go