### PR TITLE
Fix error handling in Confluence connection init

### DIFF
--- a/integrations/atlassian/confluence/webhooks.go
+++ b/integrations/atlassian/confluence/webhooks.go
@@ -3,6 +3,7 @@ package confluence
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -138,6 +139,7 @@ func registerWebhook(l *zap.Logger, base, user, key string) (int, string, error)
 			zap.Any("request", r),
 			zap.Error(err),
 		)
+		return 0, "", err
 	}
 
 	jsonReader := bytes.NewReader(body)
@@ -169,7 +171,7 @@ func registerWebhook(l *zap.Logger, base, user, key string) (int, string, error)
 			zap.Int("status", resp.StatusCode),
 			zap.ByteString("body", body),
 		)
-		return 0, "", err
+		return 0, "", errors.New(string(body))
 	}
 
 	var reg webhook
@@ -184,6 +186,7 @@ func registerWebhook(l *zap.Logger, base, user, key string) (int, string, error)
 	// Error mode 2: based on the content of the parsed JSON response.
 	if reg.Self == "" {
 		l.Warn("Confluence webhook ID not found", zap.ByteString("body", body))
+		return 0, "", errors.New(string(body))
 	}
 
 	// Success.

--- a/integrations/atlassian/confluence/webhooks.go
+++ b/integrations/atlassian/confluence/webhooks.go
@@ -171,7 +171,12 @@ func registerWebhook(l *zap.Logger, base, user, key string) (int, string, error)
 			zap.Int("status", resp.StatusCode),
 			zap.ByteString("body", body),
 		)
-		return 0, "", errors.New(string(body))
+		s := strings.TrimSpace(string(body))
+		s = s[:min(len(s), 256)]
+		if s == "" {
+			s = "no error message"
+		}
+		return 0, "", errors.New(s)
 	}
 
 	var reg webhook
@@ -186,7 +191,7 @@ func registerWebhook(l *zap.Logger, base, user, key string) (int, string, error)
 	// Error mode 2: based on the content of the parsed JSON response.
 	if reg.Self == "" {
 		l.Warn("Confluence webhook ID not found", zap.ByteString("body", body))
-		return 0, "", errors.New(string(body))
+		return 0, "", errors.New("no webhook ID in response")
 	}
 
 	// Success.


### PR DESCRIPTION
Now, if we fail to create/update the connection's webhook (if the connection details are wrong), we abort the connection with an informative error message.