### PR TITLE
fix: pass context in resolver

### DIFF
--- a/cmd/ak/cmd/builds/delete.go
+++ b/cmd/ak/cmd/builds/delete.go
@@ -17,7 +17,10 @@ var deleteCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		b, id, err := r.BuildID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		b, id, err := r.BuildID(ctx, args[0])
 		if err != nil {
 			return err
 		}
@@ -25,9 +28,6 @@ var deleteCmd = common.StandardCommand(&cobra.Command{
 			err = fmt.Errorf("build ID %q not found", args[0])
 			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		if err := builds().Delete(ctx, id); err != nil {
 			return fmt.Errorf("delete build: %w", err)

--- a/cmd/ak/cmd/builds/describe.go
+++ b/cmd/ak/cmd/builds/describe.go
@@ -16,13 +16,13 @@ var describeCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		_, bid, err := r.BuildID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		_, bid, err := r.BuildID(ctx, args[0])
 		if err != nil {
 			return err
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		bf, err := builds().Describe(ctx, bid)
 		if err != nil {

--- a/cmd/ak/cmd/builds/download.go
+++ b/cmd/ak/cmd/builds/download.go
@@ -22,7 +22,10 @@ var downloadCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		b, id, err := r.BuildID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		b, id, err := r.BuildID(ctx, args[0])
 		if err != nil {
 			return err
 		}
@@ -30,9 +33,6 @@ var downloadCmd = common.StandardCommand(&cobra.Command{
 			err = fmt.Errorf("build ID %q not found", args[0])
 			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		reader, err := builds().Download(ctx, id)
 		if err != nil {

--- a/cmd/ak/cmd/builds/get.go
+++ b/cmd/ak/cmd/builds/get.go
@@ -19,7 +19,7 @@ var getCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		b, _, err := r.BuildID(ctx, args[0])
-		err = common.AddNotFoundErrIfNeeded(err, b.IsValid())
+		err = common.AddNotFoundErrIfCond(err, b.IsValid())
 		if err = common.FailIfError2(cmd, err, "build"); err != nil {
 			return err
 		}

--- a/cmd/ak/cmd/builds/get.go
+++ b/cmd/ak/cmd/builds/get.go
@@ -19,11 +19,8 @@ var getCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		b, _, err := r.BuildID(ctx, args[0])
-		if err != nil {
-			return err
-		}
-
-		if err := common.FailIfNotFound(cmd, "build", b.IsValid()); err != nil {
+		err = common.AddNotFoundErrIfNeeded(err, b.IsValid())
+		if err = common.FailIfError2(cmd, err, "build"); err != nil {
 			return err
 		}
 

--- a/cmd/ak/cmd/builds/get.go
+++ b/cmd/ak/cmd/builds/get.go
@@ -15,7 +15,10 @@ var getCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		b, _, err := r.BuildID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		b, _, err := r.BuildID(ctx, args[0])
 		if err != nil {
 			return err
 		}

--- a/cmd/ak/cmd/connections/create.go
+++ b/cmd/ak/cmd/connections/create.go
@@ -24,7 +24,10 @@ var createCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		p, pid, err := r.ProjectNameOrID(project)
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		p, pid, err := r.ProjectNameOrID(ctx, project)
 		if err != nil {
 			return err
 		}
@@ -33,7 +36,7 @@ var createCmd = common.StandardCommand(&cobra.Command{
 			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
 
-		i, iid, err := r.IntegrationNameOrID(integration)
+		i, iid, err := r.IntegrationNameOrID(ctx, integration)
 		if err != nil {
 			return err
 		}
@@ -50,9 +53,6 @@ var createCmd = common.StandardCommand(&cobra.Command{
 		if err != nil {
 			return fmt.Errorf("invalid connection: %w", err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		cid, err := connections().Create(ctx, c)
 		if err != nil {

--- a/cmd/ak/cmd/connections/delete.go
+++ b/cmd/ak/cmd/connections/delete.go
@@ -16,16 +16,16 @@ var deleteCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		c, id, err := r.ConnectionNameOrID(args[0], "")
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		c, id, err := r.ConnectionNameOrID(ctx, args[0], "")
 		if err != nil {
 			return common.ToExitCodeError(err, "connection")
 		}
 		if !c.IsValid() {
 			return common.ToExitCodeError(sdkerrors.ErrNotFound, "connection")
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		err = connections().Delete(ctx, id)
 		return common.ToExitCodeError(err, "delete connection")

--- a/cmd/ak/cmd/connections/get.go
+++ b/cmd/ak/cmd/connections/get.go
@@ -1,8 +1,6 @@
 package connections
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
 
 	"go.autokitteh.dev/autokitteh/cmd/ak/common"
@@ -21,17 +19,8 @@ var getCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		c, _, err := r.ConnectionNameOrID(ctx, args[0], "")
-		if err != nil {
-			if errors.As(err, resolver.NotFoundErrorType) {
-				if err := common.FailIfNotFound(cmd, "connection", c.IsValid()); err != nil {
-					return err
-				}
-				return nil
-			}
-			return err
-		}
-
-		if err := common.FailIfNotFound(cmd, "connection", c.IsValid()); err != nil {
+		err = common.AddNotFoundErrIfCond(err, c.IsValid())
+		if err = common.FailIfError2(cmd, err, "connection"); err != nil {
 			return err
 		}
 

--- a/cmd/ak/cmd/connections/get.go
+++ b/cmd/ak/cmd/connections/get.go
@@ -17,7 +17,10 @@ var getCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		c, _, err := r.ConnectionNameOrID(args[0], "")
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		c, _, err := r.ConnectionNameOrID(ctx, args[0], "")
 		if err != nil {
 			if errors.As(err, resolver.NotFoundErrorType) {
 				if err := common.FailIfNotFound(cmd, "connection", c.IsValid()); err != nil {

--- a/cmd/ak/cmd/connections/init.go
+++ b/cmd/ak/cmd/connections/init.go
@@ -19,7 +19,10 @@ var initCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		c, _, err := r.ConnectionNameOrID(args[0], "")
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		c, _, err := r.ConnectionNameOrID(ctx, args[0], "")
 		if err != nil {
 			if errors.As(err, resolver.NotFoundErrorType) {
 				if err := common.FailIfNotFound(cmd, "connection", c.IsValid()); err != nil {

--- a/cmd/ak/cmd/connections/list.go
+++ b/cmd/ak/cmd/connections/list.go
@@ -20,9 +20,11 @@ var listCmd = common.StandardCommand(&cobra.Command{
 		var f sdkservices.ListConnectionsFilter
 
 		r := resolver.Resolver{Client: common.Client()}
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
 
 		if integration != "" {
-			_, iid, err := r.IntegrationNameOrID(integration)
+			_, iid, err := r.IntegrationNameOrID(ctx, integration)
 			if err != nil {
 				return err
 			}
@@ -34,7 +36,7 @@ var listCmd = common.StandardCommand(&cobra.Command{
 		}
 
 		if project != "" {
-			_, pid, err := r.ProjectNameOrID(project)
+			_, pid, err := r.ProjectNameOrID(ctx, project)
 			if err != nil {
 				return err
 			}
@@ -44,9 +46,6 @@ var listCmd = common.StandardCommand(&cobra.Command{
 			}
 			f.ProjectID = pid
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		cs, err := connections().List(ctx, f)
 		if err != nil {

--- a/cmd/ak/cmd/connections/test.go
+++ b/cmd/ak/cmd/connections/test.go
@@ -17,13 +17,13 @@ var testCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		_, cid, err := r.ConnectionNameOrID(args[0], "")
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		_, cid, err := r.ConnectionNameOrID(ctx, args[0], "")
 		if err != nil {
 			return err
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		s, err := connections().Test(ctx, cid)
 		if err != nil {

--- a/cmd/ak/cmd/deploy.go
+++ b/cmd/ak/cmd/deploy.go
@@ -67,12 +67,9 @@ var deployCmd = common.StandardCommand(&cobra.Command{
 
 		// Step 3: parse the optional environment argument.
 		e, eid, err := r.EnvNameOrID(ctx, env, project)
-		if err != nil {
+		err = common.AddNotFoundErrIfCond(err, e.IsValid())
+		if err = common.FailIfError2(cmd, err, "environment"); err != nil {
 			return err
-		}
-		if !e.IsValid() {
-			err = fmt.Errorf("environment %q not found", env)
-			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
 
 		// Step 4: deploy the build

--- a/cmd/ak/cmd/deployments/activate.go
+++ b/cmd/ak/cmd/deployments/activate.go
@@ -17,7 +17,10 @@ var activateCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		d, id, err := r.DeploymentID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		d, id, err := r.DeploymentID(ctx, args[0])
 		if err != nil {
 			return err
 		}
@@ -25,10 +28,6 @@ var activateCmd = common.StandardCommand(&cobra.Command{
 			err = fmt.Errorf("deployment %q not found", args[0])
 			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
-
 		if err := deployments().Activate(ctx, id); err != nil {
 			return fmt.Errorf("activate deployment: %w", err)
 		}

--- a/cmd/ak/cmd/deployments/activate.go
+++ b/cmd/ak/cmd/deployments/activate.go
@@ -21,7 +21,7 @@ var activateCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		d, id, err := r.DeploymentID(ctx, args[0])
-		err = common.AddNotFoundErrIfNeeded(err, d.IsValid())
+		err = common.AddNotFoundErrIfCond(err, d.IsValid())
 		if err = common.FailIfError2(cmd, err, "deployment"); err != nil {
 			return err
 		}

--- a/cmd/ak/cmd/deployments/activate.go
+++ b/cmd/ak/cmd/deployments/activate.go
@@ -21,13 +21,11 @@ var activateCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		d, id, err := r.DeploymentID(ctx, args[0])
-		if err != nil {
+		err = common.AddNotFoundErrIfNeeded(err, d.IsValid())
+		if err = common.FailIfError2(cmd, err, "deployment"); err != nil {
 			return err
 		}
-		if !d.IsValid() {
-			err = fmt.Errorf("deployment %q not found", args[0])
-			return common.NewExitCodeError(common.NotFoundExitCode, err)
-		}
+
 		if err := deployments().Activate(ctx, id); err != nil {
 			return fmt.Errorf("activate deployment: %w", err)
 		}

--- a/cmd/ak/cmd/deployments/create.go
+++ b/cmd/ak/cmd/deployments/create.go
@@ -25,21 +25,15 @@ var createCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		b, _, err := r.BuildID(ctx, buildID)
-		if err != nil {
+		err = common.AddNotFoundErrIfNeeded(err, b.IsValid())
+		if err = common.FailIfError2(cmd, err, fmt.Sprintf("build ID %q", buildID)); err != nil {
 			return err
-		}
-		if !b.IsValid() {
-			err = fmt.Errorf("build ID %q not found", buildID)
-			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
 
 		e, eid, err := r.EnvNameOrID(ctx, env, "")
-		if err != nil {
+		err = common.AddNotFoundErrIfNeeded(err, e.IsValid())
+		if err = common.FailIfError2(cmd, err, fmt.Sprintf("environment %q", env)); err != nil {
 			return err
-		}
-		if !e.IsValid() {
-			err = fmt.Errorf("environment %q not found", env)
-			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
 
 		deployment, err := sdktypes.DeploymentFromProto(&sdktypes.DeploymentPB{

--- a/cmd/ak/cmd/deployments/create.go
+++ b/cmd/ak/cmd/deployments/create.go
@@ -21,7 +21,10 @@ var createCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		b, _, err := r.BuildID(buildID)
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		b, _, err := r.BuildID(ctx, buildID)
 		if err != nil {
 			return err
 		}
@@ -30,7 +33,7 @@ var createCmd = common.StandardCommand(&cobra.Command{
 			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
 
-		e, eid, err := r.EnvNameOrID(env, "")
+		e, eid, err := r.EnvNameOrID(ctx, env, "")
 		if err != nil {
 			return err
 		}
@@ -46,9 +49,6 @@ var createCmd = common.StandardCommand(&cobra.Command{
 		if err != nil {
 			return fmt.Errorf("invalid deployment: %w", err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		did, err := deployments().Create(ctx, deployment)
 		if err != nil {

--- a/cmd/ak/cmd/deployments/create.go
+++ b/cmd/ak/cmd/deployments/create.go
@@ -25,13 +25,13 @@ var createCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		b, _, err := r.BuildID(ctx, buildID)
-		err = common.AddNotFoundErrIfNeeded(err, b.IsValid())
+		err = common.AddNotFoundErrIfCond(err, b.IsValid())
 		if err = common.FailIfError2(cmd, err, fmt.Sprintf("build ID %q", buildID)); err != nil {
 			return err
 		}
 
 		e, eid, err := r.EnvNameOrID(ctx, env, "")
-		err = common.AddNotFoundErrIfNeeded(err, e.IsValid())
+		err = common.AddNotFoundErrIfCond(err, e.IsValid())
 		if err = common.FailIfError2(cmd, err, fmt.Sprintf("environment %q", env)); err != nil {
 			return err
 		}

--- a/cmd/ak/cmd/deployments/deactivate.go
+++ b/cmd/ak/cmd/deployments/deactivate.go
@@ -21,12 +21,9 @@ var deactivateCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		d, id, err := r.DeploymentID(ctx, args[0])
-		if err != nil {
+		err = common.AddNotFoundErrIfNeeded(err, d.IsValid())
+		if err = common.FailIfError2(cmd, err, "deployment"); err != nil {
 			return err
-		}
-		if !d.IsValid() {
-			err = fmt.Errorf("deployment %q not found", args[0])
-			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
 
 		if err := deployments().Deactivate(ctx, id); err != nil {

--- a/cmd/ak/cmd/deployments/deactivate.go
+++ b/cmd/ak/cmd/deployments/deactivate.go
@@ -17,7 +17,10 @@ var deactivateCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		d, id, err := r.DeploymentID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		d, id, err := r.DeploymentID(ctx, args[0])
 		if err != nil {
 			return err
 		}
@@ -25,9 +28,6 @@ var deactivateCmd = common.StandardCommand(&cobra.Command{
 			err = fmt.Errorf("deployment %q not found", args[0])
 			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		if err := deployments().Deactivate(ctx, id); err != nil {
 			return fmt.Errorf("deactivate deployment: %w", err)

--- a/cmd/ak/cmd/deployments/deactivate.go
+++ b/cmd/ak/cmd/deployments/deactivate.go
@@ -21,7 +21,7 @@ var deactivateCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		d, id, err := r.DeploymentID(ctx, args[0])
-		err = common.AddNotFoundErrIfNeeded(err, d.IsValid())
+		err = common.AddNotFoundErrIfCond(err, d.IsValid())
 		if err = common.FailIfError2(cmd, err, "deployment"); err != nil {
 			return err
 		}

--- a/cmd/ak/cmd/deployments/delete.go
+++ b/cmd/ak/cmd/deployments/delete.go
@@ -15,7 +15,10 @@ var deleteCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		d, id, err := r.DeploymentID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		d, id, err := r.DeploymentID(ctx, args[0])
 		if err != nil {
 			return common.FailIfError(cmd, err, "deployment")
 		}
@@ -23,9 +26,6 @@ var deleteCmd = common.StandardCommand(&cobra.Command{
 		if err := common.FailIfNotFound(cmd, "deployment", d.IsValid()); err != nil {
 			return err
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		err = deployments().Delete(ctx, id)
 		return common.ToExitCodeError(err, "delete deployment")

--- a/cmd/ak/cmd/deployments/drain.go
+++ b/cmd/ak/cmd/deployments/drain.go
@@ -17,7 +17,10 @@ var drainCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		d, id, err := r.DeploymentID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		d, id, err := r.DeploymentID(ctx, args[0])
 		if err != nil {
 			return err
 		}
@@ -25,9 +28,6 @@ var drainCmd = common.StandardCommand(&cobra.Command{
 			err = fmt.Errorf("deployment %q not found", args[0])
 			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		if err := deployments().Drain(ctx, id); err != nil {
 			return fmt.Errorf("drain deployment: %w", err)

--- a/cmd/ak/cmd/deployments/drain.go
+++ b/cmd/ak/cmd/deployments/drain.go
@@ -21,7 +21,7 @@ var drainCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		d, id, err := r.DeploymentID(ctx, args[0])
-		err = common.AddNotFoundErrIfNeeded(err, d.IsValid())
+		err = common.AddNotFoundErrIfCond(err, d.IsValid())
 		if err = common.FailIfError2(cmd, err, "deployment"); err != nil {
 			return err
 		}

--- a/cmd/ak/cmd/deployments/drain.go
+++ b/cmd/ak/cmd/deployments/drain.go
@@ -21,12 +21,9 @@ var drainCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		d, id, err := r.DeploymentID(ctx, args[0])
-		if err != nil {
+		err = common.AddNotFoundErrIfNeeded(err, d.IsValid())
+		if err = common.FailIfError2(cmd, err, "deployment"); err != nil {
 			return err
-		}
-		if !d.IsValid() {
-			err = fmt.Errorf("deployment %q not found", args[0])
-			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
 
 		if err := deployments().Drain(ctx, id); err != nil {

--- a/cmd/ak/cmd/deployments/get.go
+++ b/cmd/ak/cmd/deployments/get.go
@@ -15,7 +15,10 @@ var getCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		d, _, err := r.DeploymentID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		d, _, err := r.DeploymentID(ctx, args[0])
 		if err != nil {
 			return err
 		}

--- a/cmd/ak/cmd/deployments/get.go
+++ b/cmd/ak/cmd/deployments/get.go
@@ -19,7 +19,7 @@ var getCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		d, _, err := r.DeploymentID(ctx, args[0])
-		err = common.AddNotFoundErrIfNeeded(err, d.IsValid())
+		err = common.AddNotFoundErrIfCond(err, d.IsValid())
 		if err = common.FailIfError2(cmd, err, "deployment"); err != nil {
 			return err
 		}

--- a/cmd/ak/cmd/deployments/get.go
+++ b/cmd/ak/cmd/deployments/get.go
@@ -19,11 +19,8 @@ var getCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		d, _, err := r.DeploymentID(ctx, args[0])
-		if err != nil {
-			return err
-		}
-
-		if err := common.FailIfNotFound(cmd, "deployment", d.IsValid()); err != nil {
+		err = common.AddNotFoundErrIfNeeded(err, d.IsValid())
+		if err = common.FailIfError2(cmd, err, "deployment"); err != nil {
 			return err
 		}
 

--- a/cmd/ak/cmd/deployments/list.go
+++ b/cmd/ak/cmd/deployments/list.go
@@ -33,9 +33,12 @@ var listCmd = common.StandardCommand(&cobra.Command{
 		}
 		f.BuildID = bid
 
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
 		if env != "" {
 			r := resolver.Resolver{Client: common.Client()}
-			e, _, err := r.EnvNameOrID(env, "")
+			e, _, err := r.EnvNameOrID(ctx, env, "")
 			if err != nil {
 				return err
 			}
@@ -47,9 +50,6 @@ var listCmd = common.StandardCommand(&cobra.Command{
 		}
 
 		f.IncludeSessionStats = includeSessionStats
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		ds, err := deployments().List(ctx, f)
 		if err != nil {

--- a/cmd/ak/cmd/envs/create.go
+++ b/cmd/ak/cmd/envs/create.go
@@ -18,7 +18,10 @@ var createCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		p, pid, err := r.ProjectNameOrID(project)
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		p, pid, err := r.ProjectNameOrID(ctx, project)
 		if err != nil {
 			return err
 		}
@@ -31,9 +34,6 @@ var createCmd = common.StandardCommand(&cobra.Command{
 		if err != nil {
 			return fmt.Errorf("invalid environment: %w", err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		eid, err := envs().Create(ctx, e)
 		if err != nil {

--- a/cmd/ak/cmd/envs/get.go
+++ b/cmd/ak/cmd/envs/get.go
@@ -15,7 +15,10 @@ var getCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		e, _, err := r.EnvNameOrID(args[0], project)
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		e, _, err := r.EnvNameOrID(ctx, args[0], project)
 		if err != nil {
 			return err
 		}

--- a/cmd/ak/cmd/envs/list.go
+++ b/cmd/ak/cmd/envs/list.go
@@ -22,9 +22,13 @@ var listCmd = common.StandardCommand(&cobra.Command{
 			pid sdktypes.ProjectID
 			err error
 		)
+
+		r := resolver.Resolver{Client: common.Client()}
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
 		if project != "" {
-			r := resolver.Resolver{Client: common.Client()}
-			p, pid, err = r.ProjectNameOrID(project)
+			p, pid, err = r.ProjectNameOrID(ctx, project)
 			if err != nil {
 				return err
 			}
@@ -33,9 +37,6 @@ var listCmd = common.StandardCommand(&cobra.Command{
 				return common.NewExitCodeError(common.NotFoundExitCode, err)
 			}
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		es, err := envs().List(ctx, pid)
 		if err != nil {

--- a/cmd/ak/cmd/events/dispatch.go
+++ b/cmd/ak/cmd/events/dispatch.go
@@ -23,6 +23,10 @@ var dispatchCmd = common.StandardCommand(&cobra.Command{
 		var event sdktypes.Event
 		pb := &sdktypes.EventPB{}
 
+		r := resolver.Resolver{Client: common.Client()}
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
 		if filename != "" {
 			text, err := os.ReadFile(filename)
 			if err != nil {
@@ -35,8 +39,7 @@ var dispatchCmd = common.StandardCommand(&cobra.Command{
 		}
 
 		if connection != "" {
-			r := resolver.Resolver{Client: common.Client()}
-			_, cid, err := r.ConnectionNameOrID(args[0], "")
+			_, cid, err := r.ConnectionNameOrID(ctx, args[0], "")
 			if err != nil {
 				return err
 			}
@@ -65,9 +68,6 @@ var dispatchCmd = common.StandardCommand(&cobra.Command{
 		if err != nil {
 			return fmt.Errorf("invalid event: %w", err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		eid, err := common.Client().Dispatcher().Dispatch(ctx, e, nil)
 		if err != nil {

--- a/cmd/ak/cmd/events/get.go
+++ b/cmd/ak/cmd/events/get.go
@@ -18,7 +18,10 @@ var getCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		e, _, err := r.EventID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		e, _, err := r.EventID(ctx, args[0])
 		if err != nil {
 			if errors.Is(err, sdkerrors.ErrNotFound) {
 				return common.FailNotFound(cmd, "event")

--- a/cmd/ak/cmd/events/get.go
+++ b/cmd/ak/cmd/events/get.go
@@ -1,13 +1,10 @@
 package events
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
 
 	"go.autokitteh.dev/autokitteh/cmd/ak/common"
 	"go.autokitteh.dev/autokitteh/internal/resolver"
-	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 )
 
 var getCmd = common.StandardCommand(&cobra.Command{
@@ -22,14 +19,8 @@ var getCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		e, _, err := r.EventID(ctx, args[0])
-		if err != nil {
-			if errors.Is(err, sdkerrors.ErrNotFound) {
-				return common.FailNotFound(cmd, "event")
-			}
-			return err
-		}
-
-		if err := common.FailIfNotFound(cmd, "event", e.IsValid()); err != nil {
+		err = common.AddNotFoundErrIfNeeded(err, e.IsValid())
+		if err = common.FailIfError2(cmd, err, "event"); err != nil {
 			return err
 		}
 

--- a/cmd/ak/cmd/events/get.go
+++ b/cmd/ak/cmd/events/get.go
@@ -19,7 +19,7 @@ var getCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		e, _, err := r.EventID(ctx, args[0])
-		err = common.AddNotFoundErrIfNeeded(err, e.IsValid())
+		err = common.AddNotFoundErrIfCond(err, e.IsValid())
 		if err = common.FailIfError2(cmd, err, "event"); err != nil {
 			return err
 		}

--- a/cmd/ak/cmd/events/list.go
+++ b/cmd/ak/cmd/events/list.go
@@ -21,9 +21,12 @@ var listCmd = common.StandardCommand(&cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var f sdkservices.ListEventsFilter
 
+		r := resolver.Resolver{Client: common.Client()}
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
 		if connection != "" {
-			r := resolver.Resolver{Client: common.Client()}
-			_, cid, err := r.ConnectionNameOrID(args[0], "")
+			_, cid, err := r.ConnectionNameOrID(ctx, args[0], "")
 			if err != nil {
 				return err
 			}
@@ -34,8 +37,7 @@ var listCmd = common.StandardCommand(&cobra.Command{
 		}
 
 		if integration != "" {
-			r := resolver.Resolver{Client: common.Client()}
-			i, iid, err := r.IntegrationNameOrID(integration)
+			i, iid, err := r.IntegrationNameOrID(ctx, integration)
 			if err != nil {
 				return err
 			}
@@ -46,9 +48,6 @@ var listCmd = common.StandardCommand(&cobra.Command{
 		}
 
 		f.Order = sdkservices.ListOrder(listOrder)
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		es, err := events().List(ctx, f)
 		if err != nil {

--- a/cmd/ak/cmd/events/list.go
+++ b/cmd/ak/cmd/events/list.go
@@ -27,22 +27,18 @@ var listCmd = common.StandardCommand(&cobra.Command{
 
 		if connection != "" {
 			_, cid, err := r.ConnectionNameOrID(ctx, args[0], "")
-			if err != nil {
+			err = common.AddNotFoundErrIfCond(err, cid.IsValid())
+			if err = common.FailIfError2(cmd, err, "connection"); err != nil {
 				return err
-			}
-			if !cid.IsValid() {
-				return fmt.Errorf("connection %q not found", connection)
 			}
 			f.ConnectionID = cid
 		}
 
 		if integration != "" {
 			i, iid, err := r.IntegrationNameOrID(ctx, integration)
-			if err != nil {
+			err = common.AddNotFoundErrIfCond(err, i.IsValid())
+			if err = common.FailIfError2(cmd, err, "integration"); err != nil {
 				return err
-			}
-			if !i.IsValid() {
-				return fmt.Errorf("integration %q not found", integration)
 			}
 			f.IntegrationID = iid
 		}

--- a/cmd/ak/cmd/events/records/add.go
+++ b/cmd/ak/cmd/events/records/add.go
@@ -22,7 +22,10 @@ var addCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		e, eid, err := r.EventID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		e, eid, err := r.EventID(ctx, args[0])
 		if err != nil {
 			return err
 		}
@@ -32,9 +35,6 @@ var addCmd = common.StandardCommand(&cobra.Command{
 		}
 
 		record := sdktypes.NewEventRecord(eid, kittehs.Must1(sdktypes.ParseEventState(state.String())))
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		err = events().AddEventRecord(ctx, record)
 		if err != nil {

--- a/cmd/ak/cmd/events/records/list.go
+++ b/cmd/ak/cmd/events/records/list.go
@@ -18,7 +18,10 @@ var listCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		e, id, err := r.EventID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		e, id, err := r.EventID(ctx, args[0])
 		if err != nil {
 			return err
 		}
@@ -28,9 +31,6 @@ var listCmd = common.StandardCommand(&cobra.Command{
 		}
 
 		f := sdkservices.ListEventRecordsFilter{EventID: id}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		ers, err := events().ListEventRecords(ctx, f)
 		if err != nil {

--- a/cmd/ak/cmd/events/redispatch.go
+++ b/cmd/ak/cmd/events/redispatch.go
@@ -17,7 +17,10 @@ var redispatchCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		e, _, err := r.EventID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		e, _, err := r.EventID(ctx, args[0])
 		if err != nil {
 			return err
 		}
@@ -25,9 +28,6 @@ var redispatchCmd = common.StandardCommand(&cobra.Command{
 			err = fmt.Errorf("event ID %q not found", args[0])
 			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		eid, err := common.Client().Dispatcher().Dispatch(ctx, e, nil)
 		if err != nil {

--- a/cmd/ak/cmd/events/save.go
+++ b/cmd/ak/cmd/events/save.go
@@ -23,6 +23,10 @@ var saveCmd = common.StandardCommand(&cobra.Command{
 		var event sdktypes.Event
 		pb := &sdktypes.EventPB{}
 
+		r := resolver.Resolver{Client: common.Client()}
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
 		if filename != "" {
 			text, err := os.ReadFile(filename)
 			if err != nil {
@@ -35,8 +39,7 @@ var saveCmd = common.StandardCommand(&cobra.Command{
 		}
 
 		if connection != "" {
-			r := resolver.Resolver{Client: common.Client()}
-			_, cid, err := r.ConnectionNameOrID(args[0], "")
+			_, cid, err := r.ConnectionNameOrID(ctx, args[0], "")
 			if err != nil {
 				return err
 			}
@@ -65,9 +68,6 @@ var saveCmd = common.StandardCommand(&cobra.Command{
 		if err != nil {
 			return fmt.Errorf("invalid event: %w", err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		eid, err := events().Save(ctx, e)
 		if err != nil {

--- a/cmd/ak/cmd/integrations/get.go
+++ b/cmd/ak/cmd/integrations/get.go
@@ -17,7 +17,10 @@ var getCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		i, _, err := r.IntegrationNameOrID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		i, _, err := r.IntegrationNameOrID(ctx, args[0])
 		if err != nil {
 			if errors.As(err, resolver.NotFoundErrorType) {
 				err = common.NewExitCodeError(common.NotFoundExitCode, err)

--- a/cmd/ak/cmd/manifest/deploy.go
+++ b/cmd/ak/cmd/manifest/deploy.go
@@ -50,8 +50,11 @@ var deployCmd = common.StandardCommand(&cobra.Command{
 		}
 		logFunc(cmd, "exec")(fmt.Sprintf("create_build: created %q", bid))
 
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
 		// Step 3: parse the optional environment argument.
-		e, eid, err := r.EnvNameOrID(env, project)
+		e, eid, err := r.EnvNameOrID(ctx, env, project)
 		if err != nil {
 			return err
 		}
@@ -69,9 +72,6 @@ var deployCmd = common.StandardCommand(&cobra.Command{
 		if err != nil {
 			return fmt.Errorf("invalid deployment: %w", err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		dep := common.Client().Deployments()
 		did, err := dep.Create(ctx, deployment)

--- a/cmd/ak/cmd/projects/delete.go
+++ b/cmd/ak/cmd/projects/delete.go
@@ -15,7 +15,10 @@ var deleteCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		p, id, err := r.ProjectNameOrID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		p, id, err := r.ProjectNameOrID(ctx, args[0])
 		if err != nil {
 			return common.FailIfError(cmd, err, "project")
 		}
@@ -23,9 +26,6 @@ var deleteCmd = common.StandardCommand(&cobra.Command{
 		if err := common.FailIfNotFound(cmd, "project", p.IsValid()); err != nil {
 			return err
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		err = projects().Delete(ctx, id)
 		return common.ToExitCodeError(err, "delete project")

--- a/cmd/ak/cmd/projects/deploy.go
+++ b/cmd/ak/cmd/projects/deploy.go
@@ -35,12 +35,9 @@ var deployCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		e, eid, err := r.EnvNameOrID(ctx, env, args[0])
-		if err != nil {
+		err = common.AddNotFoundErrIfCond(err, e.IsValid())
+		if err = common.FailIfError2(cmd, err, "environment"); err != nil {
 			return err
-		}
-		if !e.IsValid() {
-			err = fmt.Errorf("environment %q not found", env)
-			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
 
 		// Step 3: deploy the build (see the "deployment" parent command).

--- a/cmd/ak/cmd/projects/deploy.go
+++ b/cmd/ak/cmd/projects/deploy.go
@@ -30,7 +30,11 @@ var deployCmd = common.StandardCommand(&cobra.Command{
 
 		// Step 2: parse the optional environment argument.
 		r := resolver.Resolver{Client: common.Client()}
-		e, eid, err := r.EnvNameOrID(env, args[0])
+
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		e, eid, err := r.EnvNameOrID(ctx, env, args[0])
 		if err != nil {
 			return err
 		}
@@ -47,9 +51,6 @@ var deployCmd = common.StandardCommand(&cobra.Command{
 		if err != nil {
 			return fmt.Errorf("invalid deployment: %w", err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		did, err := deployments().Create(ctx, deployment)
 		if err != nil {

--- a/cmd/ak/cmd/projects/download.go
+++ b/cmd/ak/cmd/projects/download.go
@@ -1,7 +1,6 @@
 package projects
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -26,12 +25,8 @@ var downloadCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		p, pid, err := r.ProjectNameOrID(ctx, args[0])
-		if err != nil {
-			return common.FailIfError(cmd, err, "project")
-		}
-		if !p.IsValid() {
-			err = errors.New("project not found")
-			return common.NewExitCodeError(common.NotFoundExitCode, err)
+		if err = common.AddNotFoundErrIfCond(err, p.IsValid()); err != nil {
+			return common.ToExitCodeErrorNotNilErr(err, "project")
 		}
 
 		resources, err := projects().DownloadResources(ctx, pid)

--- a/cmd/ak/cmd/projects/download.go
+++ b/cmd/ak/cmd/projects/download.go
@@ -22,7 +22,10 @@ var downloadCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		p, pid, err := r.ProjectNameOrID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		p, pid, err := r.ProjectNameOrID(ctx, args[0])
 		if err != nil {
 			return common.FailIfError(cmd, err, "project")
 		}
@@ -30,9 +33,6 @@ var downloadCmd = common.StandardCommand(&cobra.Command{
 			err = errors.New("project not found")
 			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		resources, err := projects().DownloadResources(ctx, pid)
 		if err != nil {

--- a/cmd/ak/cmd/projects/get.go
+++ b/cmd/ak/cmd/projects/get.go
@@ -19,7 +19,7 @@ var getCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		p, _, err := r.ProjectNameOrID(ctx, args[0])
-		err = common.AddNotFoundErrIfNeeded(err, p.IsValid())
+		err = common.AddNotFoundErrIfCond(err, p.IsValid())
 		if err = common.FailIfError2(cmd, err, "project"); err != nil {
 			return err
 		}

--- a/cmd/ak/cmd/projects/get.go
+++ b/cmd/ak/cmd/projects/get.go
@@ -1,13 +1,10 @@
 package projects
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"go.autokitteh.dev/autokitteh/cmd/ak/common"
 	"go.autokitteh.dev/autokitteh/internal/resolver"
-	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 )
 
 var getCmd = common.StandardCommand(&cobra.Command{
@@ -22,12 +19,9 @@ var getCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		p, _, err := r.ProjectNameOrID(ctx, args[0])
-		if err != nil {
+		err = common.AddNotFoundErrIfNeeded(err, p.IsValid())
+		if err = common.FailIfError2(cmd, err, "project"); err != nil {
 			return err
-		}
-
-		if !p.IsValid() {
-			return common.FailIfError(cmd, sdkerrors.ErrNotFound, fmt.Sprintf("project <%q>", args[0]))
 		}
 
 		common.RenderKVIfV("project", p)

--- a/cmd/ak/cmd/projects/get.go
+++ b/cmd/ak/cmd/projects/get.go
@@ -18,7 +18,10 @@ var getCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		p, _, err := r.ProjectNameOrID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		p, _, err := r.ProjectNameOrID(ctx, args[0])
 		if err != nil {
 			return err
 		}

--- a/cmd/ak/cmd/sessions/delete.go
+++ b/cmd/ak/cmd/sessions/delete.go
@@ -15,7 +15,10 @@ var deleteCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		s, id, err := r.SessionID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		s, id, err := r.SessionID(ctx, args[0])
 		if err != nil {
 			return common.FailIfError(cmd, err, "session")
 		}
@@ -24,8 +27,6 @@ var deleteCmd = common.StandardCommand(&cobra.Command{
 			return err
 		}
 
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 		err = sessions().Delete(ctx, id)
 		if err != nil {
 			return common.FailIfError(cmd, err, "session")

--- a/cmd/ak/cmd/sessions/get.go
+++ b/cmd/ak/cmd/sessions/get.go
@@ -23,7 +23,10 @@ var getCmd = common.StandardCommand(&cobra.Command{
 		}
 
 		r := resolver.Resolver{Client: common.Client()}
-		s, _, err := r.SessionID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		s, _, err := r.SessionID(ctx, args[0])
 		if err != nil {
 			return err
 		}

--- a/cmd/ak/cmd/sessions/list.go
+++ b/cmd/ak/cmd/sessions/list.go
@@ -29,9 +29,11 @@ var listCmd = common.StandardCommand(&cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
 		f := sdkservices.ListSessionsFilter{}
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
 
 		if deploymentID != "" {
-			d, did, err := r.DeploymentID(deploymentID)
+			d, did, err := r.DeploymentID(ctx, deploymentID)
 			if err != nil {
 				return err
 			}
@@ -43,7 +45,7 @@ var listCmd = common.StandardCommand(&cobra.Command{
 		}
 
 		if env != "" {
-			e, _, err := r.EnvNameOrID(env, "")
+			e, _, err := r.EnvNameOrID(ctx, env, "")
 			if err != nil {
 				return err
 			}
@@ -51,7 +53,7 @@ var listCmd = common.StandardCommand(&cobra.Command{
 		}
 
 		if eventID != "" {
-			e, eid, err := r.EventID(eventID)
+			e, eid, err := r.EventID(ctx, eventID)
 			if err != nil {
 				return err
 			}
@@ -78,9 +80,6 @@ var listCmd = common.StandardCommand(&cobra.Command{
 		if f.StateType, err = sdktypes.ParseSessionStateType(stateType.String()); err != nil {
 			return fmt.Errorf("invalid state %q: %w", stateType, err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		result, err := sessions().List(ctx, f)
 		if err != nil {

--- a/cmd/ak/cmd/sessions/log.go
+++ b/cmd/ak/cmd/sessions/log.go
@@ -34,7 +34,10 @@ var logCmd = common.StandardCommand(&cobra.Command{
 		}
 
 		r := resolver.Resolver{Client: common.Client()}
-		s, id, err := r.SessionID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		s, id, err := r.SessionID(ctx, args[0])
 		if err != nil {
 			return err
 		}
@@ -42,9 +45,6 @@ var logCmd = common.StandardCommand(&cobra.Command{
 		if err := common.FailIfNotFound(cmd, "session", s.IsValid()); err != nil {
 			return err
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		f := sdkservices.ListSessionLogRecordsFilter{SessionID: id}
 		if nextPageToken != "" {
@@ -65,7 +65,6 @@ var logCmd = common.StandardCommand(&cobra.Command{
 		}
 
 		return sessionLog(ctx, f)
-
 	},
 })
 
@@ -80,7 +79,6 @@ func init() {
 	logCmd.Flags().IntVar(&skipRows, "skip-rows", 0, "skip rows")
 
 	common.AddFailIfNotFoundFlag(logCmd)
-
 }
 
 // skip >= 0: skip first records

--- a/cmd/ak/cmd/sessions/restart.go
+++ b/cmd/ak/cmd/sessions/restart.go
@@ -25,7 +25,10 @@ var restartCmd = common.StandardCommand(&cobra.Command{
 		}
 
 		r := resolver.Resolver{Client: common.Client()}
-		s, _, err := r.SessionID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		s, _, err := r.SessionID(ctx, args[0])
 		if err != nil {
 			return err
 		}
@@ -33,9 +36,6 @@ var restartCmd = common.StandardCommand(&cobra.Command{
 			err = fmt.Errorf("session ID %q not found", args[0])
 			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		sid, err := sessions().Start(ctx, s)
 		if err != nil {

--- a/cmd/ak/cmd/sessions/start.go
+++ b/cmd/ak/cmd/sessions/start.go
@@ -105,10 +105,12 @@ func parseinputs() (map[string]sdktypes.Value, error) {
 
 func sessionArgs() (did sdktypes.DeploymentID, eid sdktypes.EnvID, bid sdktypes.BuildID, ep sdktypes.CodeLocation, err error) {
 	r := resolver.Resolver{Client: common.Client()}
+	ctx, cancel := common.LimitedContext()
+	defer cancel()
 
 	if deploymentID != "" {
 		var d sdktypes.Deployment
-		if d, did, err = r.DeploymentID(deploymentID); err != nil {
+		if d, did, err = r.DeploymentID(ctx, deploymentID); err != nil {
 			return
 		}
 		if !d.IsValid() {
@@ -122,7 +124,7 @@ func sessionArgs() (did sdktypes.DeploymentID, eid sdktypes.EnvID, bid sdktypes.
 
 	if buildID != "" {
 		var b sdktypes.Build
-		if b, bid, err = r.BuildID(buildID); err != nil {
+		if b, bid, err = r.BuildID(ctx, buildID); err != nil {
 			return
 		}
 		if !b.IsValid() {
@@ -135,7 +137,7 @@ func sessionArgs() (did sdktypes.DeploymentID, eid sdktypes.EnvID, bid sdktypes.
 
 	if env != "" {
 		var e sdktypes.Env
-		if e, eid, err = r.EnvNameOrID(env, ""); err != nil {
+		if e, eid, err = r.EnvNameOrID(ctx, env, ""); err != nil {
 			return
 		}
 		if env != "" && !e.IsValid() {

--- a/cmd/ak/cmd/sessions/stop.go
+++ b/cmd/ak/cmd/sessions/stop.go
@@ -29,7 +29,10 @@ var stopCmd = common.StandardCommand(&cobra.Command{
 		}
 
 		r := resolver.Resolver{Client: common.Client()}
-		s, id, err := r.SessionID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		s, id, err := r.SessionID(ctx, args[0])
 		if err != nil {
 			return err
 		}
@@ -37,9 +40,6 @@ var stopCmd = common.StandardCommand(&cobra.Command{
 			err = fmt.Errorf("session ID %q not found", args[0])
 			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		if err = sessions().Stop(ctx, id, reason, force); err != nil {
 			return fmt.Errorf("stop session: %w", err)

--- a/cmd/ak/cmd/sessions/watch.go
+++ b/cmd/ak/cmd/sessions/watch.go
@@ -30,7 +30,10 @@ var watchCmd = common.StandardCommand(&cobra.Command{
 		}
 
 		r := resolver.Resolver{Client: common.Client()}
-		s, id, err := r.SessionID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		s, id, err := r.SessionID(ctx, args[0])
 		if err != nil {
 			return err
 		}

--- a/cmd/ak/cmd/triggers/delete.go
+++ b/cmd/ak/cmd/triggers/delete.go
@@ -17,7 +17,10 @@ var deleteCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		t, id, err := r.TriggerID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		t, id, err := r.TriggerID(ctx, args[0])
 		if err != nil {
 			return err
 		}
@@ -25,9 +28,6 @@ var deleteCmd = common.StandardCommand(&cobra.Command{
 			err = resolver.NotFoundError{Type: "trigger ID", Name: args[0]}
 			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		if err = triggers().Delete(ctx, id); err != nil {
 			return fmt.Errorf("delete trigger: %w", err)

--- a/cmd/ak/cmd/triggers/get.go
+++ b/cmd/ak/cmd/triggers/get.go
@@ -14,7 +14,10 @@ var getCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
-		t, _, err := r.TriggerID(args[0])
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
+
+		t, _, err := r.TriggerID(ctx, args[0])
 		if err != nil {
 			return err
 		}

--- a/cmd/ak/cmd/triggers/get.go
+++ b/cmd/ak/cmd/triggers/get.go
@@ -18,11 +18,8 @@ var getCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		t, _, err := r.TriggerID(ctx, args[0])
-		if err != nil {
-			return err
-		}
-
-		if err := common.FailIfNotFound(cmd, "trigger", t.IsValid()); err != nil {
+		err = common.AddNotFoundErrIfNeeded(err, t.IsValid())
+		if err = common.FailIfError2(cmd, err, "trigger"); err != nil {
 			return err
 		}
 

--- a/cmd/ak/cmd/triggers/get.go
+++ b/cmd/ak/cmd/triggers/get.go
@@ -18,7 +18,7 @@ var getCmd = common.StandardCommand(&cobra.Command{
 		defer cancel()
 
 		t, _, err := r.TriggerID(ctx, args[0])
-		err = common.AddNotFoundErrIfNeeded(err, t.IsValid())
+		err = common.AddNotFoundErrIfCond(err, t.IsValid())
 		if err = common.FailIfError2(cmd, err, "trigger"); err != nil {
 			return err
 		}

--- a/cmd/ak/cmd/triggers/list.go
+++ b/cmd/ak/cmd/triggers/list.go
@@ -18,9 +18,11 @@ var listCmd = common.StandardCommand(&cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
+		ctx, cancel := common.LimitedContext()
+		defer cancel()
 
 		// All flags are optional.
-		p, pid, err := r.ProjectNameOrID(project)
+		p, pid, err := r.ProjectNameOrID(ctx, project)
 		if err != nil {
 			return err
 		}
@@ -29,7 +31,7 @@ var listCmd = common.StandardCommand(&cobra.Command{
 			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
 
-		e, eid, err := r.EnvNameOrID(env, project)
+		e, eid, err := r.EnvNameOrID(ctx, env, project)
 		if err != nil {
 			return err
 		}
@@ -38,7 +40,7 @@ var listCmd = common.StandardCommand(&cobra.Command{
 			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
 
-		c, cid, err := r.ConnectionNameOrID(connection, project)
+		c, cid, err := r.ConnectionNameOrID(ctx, connection, project)
 		if err != nil {
 			if errors.As(err, resolver.NotFoundErrorType) {
 				err = common.NewExitCodeError(common.NotFoundExitCode, err)
@@ -49,9 +51,6 @@ var listCmd = common.StandardCommand(&cobra.Command{
 			err = resolver.NotFoundError{Type: "connection ID", Name: connection}
 			return common.NewExitCodeError(common.NotFoundExitCode, err)
 		}
-
-		ctx, cancel := common.LimitedContext()
-		defer cancel()
 
 		ts, err := triggers().List(ctx, sdkservices.ListTriggersFilter{
 			ProjectID:    pid,

--- a/cmd/ak/cmd/vars/vars.go
+++ b/cmd/ak/cmd/vars/vars.go
@@ -61,8 +61,11 @@ func vars() sdkservices.Vars {
 func resolveScopeID() (sdktypes.VarScopeID, error) {
 	r := resolver.Resolver{Client: common.Client()}
 
+	ctx, cancel := common.LimitedContext()
+	defer cancel()
+
 	if conn != "" {
-		c, id, err := r.ConnectionNameOrID(conn, project)
+		c, id, err := r.ConnectionNameOrID(ctx, conn, project)
 		if err != nil {
 			return sdktypes.InvalidVarScopeID, err
 		}
@@ -74,7 +77,7 @@ func resolveScopeID() (sdktypes.VarScopeID, error) {
 		return sdktypes.NewVarScopeID(id), nil
 	}
 
-	e, id, err := r.EnvNameOrID(env, project)
+	e, id, err := r.EnvNameOrID(ctx, env, project)
 	if err != nil {
 		return sdktypes.InvalidVarScopeID, err
 	}

--- a/cmd/ak/common/build.go
+++ b/cmd/ak/common/build.go
@@ -49,12 +49,8 @@ func BuildProject(project string, dirPaths, filePaths []string) (sdktypes.BuildI
 	defer cancel()
 
 	p, pid, err := r.ProjectNameOrID(ctx, project)
-	if err != nil {
-		return sdktypes.InvalidBuildID, err
-	}
-	if !p.IsValid() {
-		err := fmt.Errorf("project %q not found", project)
-		return sdktypes.InvalidBuildID, NewExitCodeError(NotFoundExitCode, err)
+	if err = AddNotFoundErrIfCond(err, p.IsValid()); err != nil {
+		return sdktypes.InvalidBuildID, ToExitCodeErrorNotNilErr(err, "project")
 	}
 
 	uploads := make(map[string][]byte)

--- a/cmd/ak/common/build.go
+++ b/cmd/ak/common/build.go
@@ -45,7 +45,10 @@ func Build(rts sdkservices.Runtimes, srcFS fs.FS, paths []string, syms []sdktype
 
 func BuildProject(project string, dirPaths, filePaths []string) (sdktypes.BuildID, error) {
 	r := resolver.Resolver{Client: Client()}
-	p, pid, err := r.ProjectNameOrID(project)
+	ctx, cancel := LimitedContext()
+	defer cancel()
+
+	p, pid, err := r.ProjectNameOrID(ctx, project)
 	if err != nil {
 		return sdktypes.InvalidBuildID, err
 	}
@@ -77,9 +80,6 @@ func BuildProject(project string, dirPaths, filePaths []string) (sdktypes.BuildI
 		}
 		uploads[fi.Name()] = contents
 	}
-
-	ctx, cancel := LimitedContext()
-	defer cancel()
 
 	// Communicate with the server in 2 steps.
 	if err := Client().Projects().SetResources(ctx, pid, uploads); err != nil {

--- a/cmd/ak/common/flags.go
+++ b/cmd/ak/common/flags.go
@@ -34,10 +34,7 @@ func FailNotFound(cmd *cobra.Command, what string) error {
 	return nil
 }
 
-func ToExitCodeError(err error, whats ...string) error {
-	if err == nil {
-		return nil
-	}
+func toExitCodeErrorNotNilErr(err error, whats ...string) ExitCodeError {
 	msg := strings.Join(whats, " ")
 	var code int = GenericFailure
 
@@ -53,7 +50,15 @@ func ToExitCodeError(err error, whats ...string) error {
 	if msg == "" {
 		return NewExitCodeError(code, err)
 	}
-	return NewExitCodeError(code, fmt.Errorf("%w: %s", err, msg))
+	// return NewExitCodeError(code, fmt.Errorf("%w: %s", err, msg))
+	return NewExitCodeError(code, err)
+}
+
+func ToExitCodeError(err error, whats ...string) error {
+	if err == nil {
+		return nil
+	}
+	return toExitCodeErrorNotNilErr(err, whats...)
 }
 
 func FailIfError(cmd *cobra.Command, err error, whats ...string) error {
@@ -61,4 +66,28 @@ func FailIfError(cmd *cobra.Command, err error, whats ...string) error {
 		return ToExitCodeError(err, whats...)
 	}
 	return nil
+}
+
+// keep given error, if passed or return notFound if !found condition
+func AddNotFoundErrIfNeeded(err error, found bool) error {
+	if err == nil && !found {
+		err = sdkerrors.ErrNotFound
+	}
+	return err
+}
+
+// FIXME: introduced to avoid more changes in existing code due non-skipping of NotFoundExitCode in services
+// Need to be combined and refactored with FailIfError and FailIfNotFound
+func FailIfError2(cmd *cobra.Command, err error, whats ...string) error {
+	if err == nil {
+		return err
+	}
+	exitErr := toExitCodeErrorNotNilErr(err, whats...)
+	if exitErr.Code == NotFoundExitCode {
+		flags := cmd.Flags()
+		if flags.Lookup("fail") != nil && !kittehs.Must1(flags.GetBool("fail")) {
+			return nil
+		}
+	}
+	return exitErr
 }

--- a/cmd/ak/common/flags.go
+++ b/cmd/ak/common/flags.go
@@ -34,7 +34,7 @@ func FailNotFound(cmd *cobra.Command, what string) error {
 	return nil
 }
 
-func toExitCodeErrorNotNilErr(err error, whats ...string) ExitCodeError {
+func ToExitCodeErrorNotNilErr(err error, whats ...string) ExitCodeError {
 	msg := strings.Join(whats, " ")
 	var code int = GenericFailure
 
@@ -58,7 +58,7 @@ func ToExitCodeError(err error, whats ...string) error {
 	if err == nil {
 		return nil
 	}
-	return toExitCodeErrorNotNilErr(err, whats...)
+	return ToExitCodeErrorNotNilErr(err, whats...)
 }
 
 func FailIfError(cmd *cobra.Command, err error, whats ...string) error {
@@ -69,7 +69,7 @@ func FailIfError(cmd *cobra.Command, err error, whats ...string) error {
 }
 
 // keep given error, if passed or return notFound if !found condition
-func AddNotFoundErrIfNeeded(err error, found bool) error {
+func AddNotFoundErrIfCond(err error, found bool) error {
 	if err == nil && !found {
 		err = sdkerrors.ErrNotFound
 	}
@@ -82,7 +82,7 @@ func FailIfError2(cmd *cobra.Command, err error, whats ...string) error {
 	if err == nil {
 		return err
 	}
-	exitErr := toExitCodeErrorNotNilErr(err, whats...)
+	exitErr := ToExitCodeErrorNotNilErr(err, whats...)
 	if exitErr.Code == NotFoundExitCode {
 		flags := cmd.Flags()
 		if flags.Lookup("fail") != nil && !kittehs.Must1(flags.GetBool("fail")) {

--- a/integrations/http/server.go
+++ b/integrations/http/server.go
@@ -132,7 +132,6 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, sdkerrors.ErrNotFound) {
 			l.Debug("project not found", zap.String("project", pname.String()))
-			http.Error(w, "Not Found", http.StatusNotFound)
 		} else {
 			l.Error("get project", zap.Error(err))
 		}

--- a/internal/backend/builds/builds.go
+++ b/internal/backend/builds/builds.go
@@ -12,7 +12,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/internal/backend/db"
 	"go.autokitteh.dev/autokitteh/sdk/sdkbuildfile"
-	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
@@ -27,7 +26,7 @@ type Builds struct {
 func New(b Builds) sdkservices.Builds { return &b }
 
 func (b *Builds) Get(ctx context.Context, id sdktypes.BuildID) (sdktypes.Build, error) {
-	return sdkerrors.IgnoreNotFoundErr(b.DB.GetBuild(ctx, id))
+	return b.DB.GetBuild(ctx, id)
 }
 
 func (b *Builds) List(ctx context.Context, filter sdkservices.ListBuildsFilter) ([]sdktypes.Build, error) {

--- a/internal/backend/buildsgrpcsvc/svc.go
+++ b/internal/backend/buildsgrpcsvc/svc.go
@@ -66,7 +66,7 @@ func (s *server) List(ctx context.Context, req *connect.Request[buildsv1.ListReq
 
 	builds, err := s.builds.List(ctx, filter)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("server error: %w", err))
+		return nil, sdkerrors.AsConnectError(err)
 	}
 
 	buildsPB := kittehs.Transform(builds, sdktypes.ToProto)
@@ -94,7 +94,7 @@ func (s *server) Download(ctx context.Context, req *connect.Request[buildsv1.Dow
 
 	buf := new(bytes.Buffer)
 	if _, err := buf.ReadFrom(data); err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("server error: %w", err))
+		return nil, sdkerrors.AsConnectError(fmt.Errorf("server error: %w", err))
 	}
 
 	return connect.NewResponse(&buildsv1.DownloadResponse{Data: buf.Bytes()}), nil
@@ -114,7 +114,7 @@ func (s *server) Save(ctx context.Context, req *connect.Request[buildsv1.SaveReq
 
 	bid, err := s.builds.Save(ctx, build, msg.Data)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("server error: %w", err))
+		return nil, sdkerrors.AsConnectError(err)
 	}
 
 	return connect.NewResponse(&buildsv1.SaveResponse{BuildId: bid.String()}), nil

--- a/internal/backend/connections/connections.go
+++ b/internal/backend/connections/connections.go
@@ -115,7 +115,6 @@ func (c *Connections) Get(ctx context.Context, id sdktypes.ConnectionID) (sdktyp
 	if err != nil || !conn.IsValid() {
 		return sdktypes.InvalidConnection, err
 	}
-	
 	return c.enrichConnection(ctx, conn)
 }
 

--- a/internal/backend/connections/connections.go
+++ b/internal/backend/connections/connections.go
@@ -2,7 +2,6 @@ package connections
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"go.uber.org/fx"
@@ -112,16 +111,12 @@ func (c *Connections) RefreshStatus(ctx context.Context, id sdktypes.ConnectionI
 }
 
 func (c *Connections) Get(ctx context.Context, id sdktypes.ConnectionID) (sdktypes.Connection, error) {
-	desc, err := c.DB.GetConnection(ctx, id)
-	if err != nil {
-		if errors.Is(err, sdkerrors.ErrNotFound) {
-			return sdktypes.InvalidConnection, nil
-		}
-
+	conn, err := c.DB.GetConnection(ctx, id)
+	if err != nil || !conn.IsValid() {
 		return sdktypes.InvalidConnection, err
 	}
-
-	return c.enrichConnection(ctx, desc)
+	
+	return c.enrichConnection(ctx, conn)
 }
 
 func (c *Connections) enrichConnection(ctx context.Context, conn sdktypes.Connection) (sdktypes.Connection, error) {

--- a/internal/backend/connectionsgrpcsvc/svc.go
+++ b/internal/backend/connectionsgrpcsvc/svc.go
@@ -86,11 +86,11 @@ func (s *server) Get(ctx context.Context, req *connect.Request[connectionsv1.Get
 		return nil, sdkerrors.AsConnectError(err)
 	}
 
-	c, err := s.connections.Get(ctx, id)
+	// report any err, except NotFound. On NotFound return report nil, and return empty response.
+	c, err := sdkerrors.IgnoreNotFoundErr(s.connections.Get(ctx, id))
 	if err != nil {
 		return nil, sdkerrors.AsConnectError(err)
 	}
-
 	if !c.IsValid() {
 		return connect.NewResponse(&connectionsv1.GetResponse{}), nil
 	}

--- a/internal/backend/dashboardsvc/builds.go
+++ b/internal/backend/dashboardsvc/builds.go
@@ -2,10 +2,12 @@ package dashboardsvc
 
 import (
 	"encoding/json"
+	"errors"
 	"html/template"
 	"net/http"
 
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 	"go.autokitteh.dev/autokitteh/web/webdashboard"
@@ -54,7 +56,11 @@ func (s Svc) build(w http.ResponseWriter, r *http.Request) {
 
 	sdkB, err := s.Svcs.Builds().Get(r.Context(), bid)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		status := http.StatusInternalServerError
+		if errors.Is(err, sdkerrors.ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), status)
 		return
 	}
 

--- a/internal/backend/dashboardsvc/connections.go
+++ b/internal/backend/dashboardsvc/connections.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 	"go.autokitteh.dev/autokitteh/web/webdashboard"
@@ -86,7 +87,11 @@ func (s Svc) getConnection(w http.ResponseWriter, r *http.Request) (sdktypes.Con
 
 	sdkC, err := s.Svcs.Connections().Get(r.Context(), cid)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		status := http.StatusInternalServerError
+		if err == sdkerrors.ErrNotFound {
+			status = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), status)
 		return sdktypes.InvalidConnection, false
 	}
 

--- a/internal/backend/dashboardsvc/deployments.go
+++ b/internal/backend/dashboardsvc/deployments.go
@@ -2,10 +2,12 @@ package dashboardsvc
 
 import (
 	"context"
+	"errors"
 	"html/template"
 	"net/http"
 
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 	"go.autokitteh.dev/autokitteh/web/webdashboard"
@@ -64,7 +66,11 @@ func (s Svc) deployment(w http.ResponseWriter, r *http.Request) {
 
 	sdkD, err := s.Svcs.Deployments().Get(r.Context(), did)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		status := http.StatusInternalServerError
+		if errors.Is(err, sdkerrors.ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), status)
 		return
 	}
 

--- a/internal/backend/dashboardsvc/projects.go
+++ b/internal/backend/dashboardsvc/projects.go
@@ -2,10 +2,12 @@ package dashboardsvc
 
 import (
 	_ "embed"
+	"errors"
 	"html/template"
 	"net/http"
 
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 	"go.autokitteh.dev/autokitteh/web/webdashboard"
@@ -53,7 +55,11 @@ func (s Svc) project(w http.ResponseWriter, r *http.Request) {
 
 	sdkP, err := s.Svcs.Projects().GetByID(r.Context(), pid)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		status := http.StatusInternalServerError
+		if errors.Is(err, sdkerrors.ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), status)
 		return
 	}
 

--- a/internal/backend/db/dbgorm/builds_test.go
+++ b/internal/backend/db/dbgorm/builds_test.go
@@ -18,7 +18,7 @@ func (f *dbFixture) saveBuildsAndAssert(t *testing.T, builds ...scheme.Build) {
 	}
 }
 
-func assertBuildDeleted(t *testing.T, f *dbFixture, buildID sdktypes.UUID) {
+func (f *dbFixture) assertBuildDeleted(t *testing.T, buildID sdktypes.UUID) {
 	assertSoftDeleted(t, f, scheme.Build{BuildID: buildID})
 }
 
@@ -44,7 +44,7 @@ func TestDeleteBuild(t *testing.T) {
 
 	// test deleteBuild
 	assert.NoError(t, f.gormdb.deleteBuild(f.ctx, b.BuildID))
-	assertBuildDeleted(t, f, b.BuildID)
+	f.assertBuildDeleted(t, b.BuildID)
 }
 
 func TestGetBuild(t *testing.T) {

--- a/internal/backend/db/dbgorm/connections_test.go
+++ b/internal/backend/db/dbgorm/connections_test.go
@@ -44,7 +44,7 @@ func TestCreateConnectionForeignKeys(t *testing.T) {
 	f := preConnectionTest(t)
 
 	p := f.newProject()
-	i := f.newIntegration()
+	i := f.newIntegration("test")
 	b := f.newBuild()
 	f.saveBuildsAndAssert(t, b)
 	f.createProjectsAndAssert(t, p)

--- a/internal/backend/db/dbgorm/deployments_test.go
+++ b/internal/backend/db/dbgorm/deployments_test.go
@@ -74,12 +74,7 @@ func TestCreateDeploymentsForeignKeys(t *testing.T) {
 	// check session creation if foreign keys are not nil
 	f := preDeploymentTest(t)
 
-	p := f.newProject()
-	e := f.newEnv(p)
-	b := f.newBuild()
-	f.createProjectsAndAssert(t, p)
-	f.createEnvsAndAssert(t, e)
-	f.saveBuildsAndAssert(t, b)
+	_, b, e := f.createProjectBuildEnv(t)
 
 	// negative test with non-existing assets
 	// zero buildID

--- a/internal/backend/db/dbgorm/events_test.go
+++ b/internal/backend/db/dbgorm/events_test.go
@@ -43,7 +43,7 @@ func TestCreateEventForeignKeys(t *testing.T) {
 	f := preEventTest(t)
 
 	e := f.newEvent()
-	i := f.newIntegration()
+	i := f.newIntegration("test")
 	c := f.newConnection()
 	b := f.newBuild()
 

--- a/internal/backend/db/dbgorm/gorm_test.go
+++ b/internal/backend/db/dbgorm/gorm_test.go
@@ -357,9 +357,11 @@ func (f *dbFixture) newProject() scheme.Project {
 
 func (f *dbFixture) newEnv(args ...any) scheme.Env {
 	id := newTestID()
+	name := idToName(id, "env")
 	env := scheme.Env{
 		EnvID:        id,
-		MembershipID: idToName(id, "env"),
+		Name:         name,
+		MembershipID: name,
 	}
 	for _, a := range args {
 		switch a := a.(type) {
@@ -435,9 +437,14 @@ func (f *dbFixture) newConnection(args ...any) scheme.Connection {
 	return c
 }
 
-func (f *dbFixture) newIntegration() scheme.Integration {
+func (f *dbFixture) newIntegration(name string) scheme.Integration {
+	id := sdktypes.NewIntegrationIDFromName(name).UUIDValue()
 	return scheme.Integration{
-		IntegrationID: newTestID(),
+		IntegrationID: id,
+		UniqueName:    name,
+		DisplayName:   name,
+		Description:   name + " integration",
+		UserLinks:     datatypes.JSON([]byte("{}")),
 	}
 }
 

--- a/internal/backend/db/dbgorm/integrations_test.go
+++ b/internal/backend/db/dbgorm/integrations_test.go
@@ -30,7 +30,7 @@ func preIntegrationTest(t *testing.T) *dbFixture {
 func TestCreateIntegration(t *testing.T) {
 	f := preIntegrationTest(t)
 
-	i := f.newIntegration()
+	i := f.newIntegration("test")
 	// test createIntegration
 	f.createIntegrationsAndAssert(t, i)
 }
@@ -38,7 +38,7 @@ func TestCreateIntegration(t *testing.T) {
 func TestDeleteIntegration(t *testing.T) {
 	f := preIntegrationTest(t)
 
-	i := f.newIntegration()
+	i := f.newIntegration("test")
 	f.createIntegrationsAndAssert(t, i)
 
 	// test deleteIntegration

--- a/internal/backend/db/dbgorm/ownership_resolver_test.go
+++ b/internal/backend/db/dbgorm/ownership_resolver_test.go
@@ -1,0 +1,312 @@
+package dbgorm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.autokitteh.dev/autokitteh/internal/backend/builds"
+	"go.autokitteh.dev/autokitteh/internal/backend/connections"
+	"go.autokitteh.dev/autokitteh/internal/backend/db"
+	"go.autokitteh.dev/autokitteh/internal/backend/deployments"
+	"go.autokitteh.dev/autokitteh/internal/backend/envs"
+	"go.autokitteh.dev/autokitteh/internal/backend/events"
+	"go.autokitteh.dev/autokitteh/internal/backend/projects"
+	"go.autokitteh.dev/autokitteh/internal/backend/sessions"
+	"go.autokitteh.dev/autokitteh/internal/backend/sessions/sessionsvcs"
+	"go.autokitteh.dev/autokitteh/internal/backend/triggers"
+	"go.autokitteh.dev/autokitteh/internal/backend/vars"
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/internal/resolver"
+	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
+	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
+	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
+	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+	"go.uber.org/zap/zaptest"
+)
+
+type dbs struct {
+	intSvc sdkservices.Integrations
+	prjSvc sdkservices.Projects
+	bldSvc sdkservices.Builds
+	depSvc sdkservices.Deployments
+	envSvc sdkservices.Envs
+	conSvc sdkservices.Connections
+	sesSvc sdkservices.Sessions
+	evtSvc sdkservices.Events
+	trgSvc sdkservices.Triggers
+	varSvc sdkservices.Vars
+}
+
+// type integrations struct {
+// 	db db.DB
+// 	z  *zap.Logger
+// }
+// func newIntegrationSvc(db db.DB, z *zap.Logger) sdkservices.Integrations {
+// 	return &integrations{db: db, z: z}
+// }
+
+// func (isvc *integrations) GetByID(ctx context.Context, id sdktypes.IntegrationID) (sdktypes.Integration, error) {
+// 	return isvc.db.GetIntegration(ctx, id)
+// }
+
+// func (isvc *integrations) GetByName(ctx context.Context, name sdktypes.Symbol) (sdktypes.Integration, error) {
+// 	ii, err := isvc.db.ListIntegrations(ctx)
+// 	if err == nil {
+// 		for _, i := range ii {
+// 			if i.DisplayName() == name.String() {
+// 				return i, nil
+// 			}
+// 		}
+// 	}
+// 	return sdktypes.InvalidIntegration, err
+// }
+
+// func (isvc *integrations) List(ctx context.Context, nameSubstring string) ([]sdktypes.Integration, error) {
+// 	ii, err := isvc.db.ListIntegrations(ctx)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	var iiFiltered []sdktypes.Integration
+
+//		for _, i := range ii {
+//			if strings.Contains(i.DisplayName(), nameSubstring) {
+//				iiFiltered = append(iiFiltered, i)
+//			}
+//		}
+//		return iiFiltered, nil
+//	}
+// type ConnectionsSvcWithoutEnrich struct {
+// 	connections.Connections
+// }
+
+// func newConnectionsSvc(db db.DB, z *zap.Logger) sdkservices.Connections {
+// 	return &ConnectionsSvcWithoutEnrich{connections.Connections{Z: z, DB: db, Name: "aaa"}}
+// }
+
+// func (c *ConnectionsSvcWithoutEnrich) enrichConnection(_ context.Context, conn sdktypes.Connection) (sdktypes.Connection, error) {
+// 	return conn, nil
+// }
+
+func newIntegrationsSvc() sdkservices.Integrations {
+	integrationID := sdktypes.NewIntegrationIDFromName("test")
+
+	desc := kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
+		IntegrationId: integrationID.String(),
+		UniqueName:    "test",
+		DisplayName:   "Test",
+		Description:   "Test integration",
+	}))
+
+	testIntegration := sdkintegrations.NewIntegration(desc, sdkmodule.New())
+	return sdkintegrations.New([]sdkservices.Integration{testIntegration})
+}
+
+func (dbs *dbs) Builds() sdkservices.Builds             { return dbs.bldSvc }
+func (dbs *dbs) Deployments() sdkservices.Deployments   { return dbs.depSvc }
+func (dbs *dbs) Projects() sdkservices.Projects         { return dbs.prjSvc }
+func (dbs *dbs) Envs() sdkservices.Envs                 { return dbs.envSvc }
+func (dbs *dbs) Connections() sdkservices.Connections   { return dbs.conSvc }
+func (dbs *dbs) Sessions() sdkservices.Sessions         { return dbs.sesSvc }
+func (dbs *dbs) Events() sdkservices.Events             { return dbs.evtSvc }
+func (dbs *dbs) Triggers() sdkservices.Triggers         { return dbs.trgSvc }
+func (dbs *dbs) Vars() sdkservices.Vars                 { return dbs.varSvc }
+func (dbs *dbs) Integrations() sdkservices.Integrations { return dbs.intSvc }
+
+func newDBServices(t *testing.T) (sdkservices.DBServices, *dbFixture) {
+	f := newDBFixture().WithDebug()
+	var gdb db.DB = f.gormdb
+
+	z := zaptest.NewLogger(t) // FIXME: or gormdb.z?
+
+	intSvc := newIntegrationsSvc()
+	bldSvc := builds.New(builds.Builds{Z: z, DB: gdb})
+	prjSvc := projects.New(projects.Projects{Z: z, DB: gdb})
+	depSvc := deployments.New(z, gdb)
+	conSvc := connections.New(connections.Connections{Z: z, DB: gdb, Integrations: intSvc})
+	envSvc := envs.New(z, gdb)
+	evtSvc := events.New(z, gdb)
+	trgSvc := triggers.New(z, gdb, nil)
+	varSvc := vars.New(z, gdb, nil)
+	sesSvc := sessions.New(z, nil, gdb,
+		sessionsvcs.Svcs{DB: gdb, Builds: bldSvc, Connections: conSvc, Deployments: depSvc, Envs: envSvc, Triggers: trgSvc, Vars: varSvc})
+
+	return &dbs{
+		intSvc: intSvc,
+		prjSvc: prjSvc,
+		bldSvc: bldSvc,
+		depSvc: depSvc,
+		envSvc: envSvc,
+		conSvc: conSvc,
+		sesSvc: sesSvc,
+		evtSvc: evtSvc,
+		trgSvc: trgSvc,
+		varSvc: varSvc,
+	}, f
+}
+
+func createResolverAndFixture(t *testing.T) (resolver.Resolver, *dbFixture) {
+	dbServices, f := newDBServices(t)
+	r := resolver.Resolver{Client: dbServices}
+	return r, f
+}
+
+func TestResolverBuildIDWithOwnership(t *testing.T) {
+	r, f := createResolverAndFixture(t)
+	b := f.newBuild()
+	f.saveBuildsAndAssert(t, b)
+
+	bid := sdktypes.NewIDFromUUID[sdktypes.BuildID](&b.BuildID)
+	bids := bid.String()
+
+	// resolve ok
+	b1, _, err := r.BuildID(f.ctx, bids)
+	assert.NoError(t, err)
+	assert.Equal(t, bid, b1.ID())
+
+	// fail due to auth
+	f.ctx = withUser(f.ctx, u)
+	_, _, err = r.BuildID(f.ctx, bids)
+	assert.ErrorIs(t, err, sdkerrors.ErrNotFound)
+}
+
+func TestResolverDeploymentIDWithOwnership(t *testing.T) {
+	r, f := createResolverAndFixture(t)
+
+	_, b, e := f.createProjectBuildEnv(t)
+	d := f.newDeployment(b, e)
+	f.createDeploymentsAndAssert(t, d)
+
+	did := sdktypes.NewIDFromUUID[sdktypes.DeploymentID](&d.DeploymentID)
+	dids := did.String()
+
+	// resolve ok
+	d1, _, err := r.DeploymentID(f.ctx, dids)
+	assert.NoError(t, err)
+	assert.Equal(t, did, d1.ID())
+
+	// fail due to auth
+	f.ctx = withUser(f.ctx, u)
+	_, _, err = r.DeploymentID(f.ctx, dids)
+	assert.ErrorIs(t, err, sdkerrors.ErrNotFound)
+}
+
+func TestResolverEventIDWithOwnership(t *testing.T) {
+	r, f := createResolverAndFixture(t)
+
+	c := f.newConnection()
+	e := f.newEvent(c)
+	f.createConnectionsAndAssert(t, c)
+	f.createEventsAndAssert(t, e)
+
+	eid := sdktypes.NewIDFromUUID[sdktypes.EventID](&e.EventID)
+	eids := eid.String()
+
+	// resolve ok
+	e1, _, err := r.EventID(f.ctx, eids)
+	assert.NoError(t, err)
+	assert.Equal(t, eid, e1.ID())
+
+	// fail due to auth
+	f.ctx = withUser(f.ctx, u)
+	_, _, err = r.EventID(f.ctx, eids)
+	assert.ErrorIs(t, err, sdkerrors.ErrNotFound)
+}
+
+func TestResolverTriggerIDWithOwnership(t *testing.T) {
+	r, f := createResolverAndFixture(t)
+
+	p, c, e := f.createProjectConnectionEnv(t)
+	trg := f.newTrigger(p, e, c)
+
+	f.createTriggersAndAssert(t, trg)
+
+	tid := sdktypes.NewIDFromUUID[sdktypes.TriggerID](&trg.TriggerID)
+	tids := tid.String()
+
+	// resolve ok
+	t1, _, err := r.TriggerID(f.ctx, tids)
+	assert.NoError(t, err)
+	assert.Equal(t, tid, t1.ID())
+
+	// fail due to auth
+	f.ctx = withUser(f.ctx, u)
+	_, _, err = r.TriggerID(f.ctx, tids)
+	assert.ErrorIs(t, err, sdkerrors.ErrNotFound)
+}
+
+func TestResolverSessionIDWithOwnership(t *testing.T) {
+	r, f := createResolverAndFixture(t)
+
+	b := f.newBuild()
+	s := f.newSession(b)
+	f.saveBuildsAndAssert(t, b)
+	f.createSessionsAndAssert(t, s)
+
+	sid := sdktypes.NewIDFromUUID[sdktypes.SessionID](&s.SessionID)
+	sids := sid.String()
+
+	// resolve ok
+	s1, _, err := r.SessionID(f.ctx, sids)
+	assert.NoError(t, err)
+	assert.Equal(t, sid, s1.ID())
+
+	// fail due to auth
+	f.ctx = withUser(f.ctx, u)
+	_, _, err = r.SessionID(f.ctx, sids)
+	assert.ErrorIs(t, err, sdkerrors.ErrNotFound)
+}
+
+func TestResolverConnectionNameOrIdWithOwnership(t *testing.T) {
+	r, f := createResolverAndFixture(t)
+
+	// since we are passing via service, connection should be defined properly otherwise will fail in parsing
+	// e.g. have project and integration defined
+
+	i := f.newIntegration()
+	i.IntegrationID = sdktypes.NewIntegrationIDFromName("test").UUIDValue()
+	p := f.newProject()
+	c := f.newConnection(p, i)
+	f.createIntegrationsAndAssert(t, i)
+	f.createProjectsAndAssert(t, p)
+	f.createConnectionsAndAssert(t, c)
+
+	cid := sdktypes.NewIDFromUUID[sdktypes.ConnectionID](&c.ConnectionID)
+	cids := cid.String()
+
+	testCases := []struct {
+		name     string
+		nameOrID string
+		project  string
+	}{
+		{"connectionID", cids, ""},
+		{"connectionName,projectName", c.Name, p.Name},
+		{"projectName/connectionName", fmt.Sprintf("%s/%s", p.Name, c.Name), ""},
+	}
+
+	// resolve ok
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _, err := r.ConnectionNameOrID(f.ctx, tc.nameOrID, tc.project)
+			assert.NoError(t, err)
+			assert.Equal(t, cid, c.ID())
+		})
+	}
+
+	// fail due to auth
+	f.ctx = withUser(f.ctx, u)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := r.ConnectionNameOrID(f.ctx, tc.nameOrID, tc.project)
+			assert.ErrorIs(t, err, sdkerrors.ErrNotFound)
+		})
+	}
+
+	// TODO: check that all users could access default cronConnection?
+}
+
+// FIXME:
+// EnvNameOrID
+// IntegraitonNameOrID
+// ProjectNameOrID

--- a/internal/backend/db/dbgorm/ownership_test.go
+++ b/internal/backend/db/dbgorm/ownership_test.go
@@ -24,6 +24,16 @@ func preOwnershipTest(t *testing.T) *dbFixture {
 	return f
 }
 
+func (f *dbFixture) createProjectBuildEnv(t *testing.T) (scheme.Project, scheme.Build, scheme.Env) {
+	p := f.newProject()
+	b := f.newBuild()
+	e := f.newEnv(p)
+	f.createProjectsAndAssert(t, p)
+	f.saveBuildsAndAssert(t, b)
+	f.createEnvsAndAssert(t, e)
+	return p, b, e
+}
+
 func TestCreateProjectWithOwnership(t *testing.T) {
 	f := preOwnershipTest(t)
 
@@ -57,12 +67,7 @@ func TestCreateBuildWithOwnership(t *testing.T) {
 func TestCreateDeploymentWithOwnership(t *testing.T) {
 	f := preOwnershipTest(t)
 
-	p := f.newProject()
-	e := f.newEnv(p)
-	b := f.newBuild()
-	f.createProjectsAndAssert(t, p)
-	f.createEnvsAndAssert(t, e)
-	f.saveBuildsAndAssert(t, b)
+	_, b, e := f.createProjectBuildEnv(t)
 
 	// with build owned by the same user
 	d1 := f.newDeployment(b)

--- a/internal/backend/db/dbgorm/projects_test.go
+++ b/internal/backend/db/dbgorm/projects_test.go
@@ -194,7 +194,7 @@ func TestDeleteProjectAndDependents(t *testing.T) {
 	//     - d1 (s3)
 	p1, p2 := f.newProject(), f.newProject()
 
-	i := f.newIntegration()
+	i := f.newIntegration("test")
 	c := f.newConnection()
 	c.IntegrationID = &i.IntegrationID
 	c.ProjectID = &p1.ProjectID

--- a/internal/backend/deployments/deployments.go
+++ b/internal/backend/deployments/deployments.go
@@ -162,5 +162,5 @@ func (d *deployments) List(ctx context.Context, filter sdkservices.ListDeploymen
 }
 
 func (d *deployments) Get(ctx context.Context, id sdktypes.DeploymentID) (sdktypes.Deployment, error) {
-	return sdkerrors.IgnoreNotFoundErr(d.db.GetDeployment(ctx, id))
+	return d.db.GetDeployment(ctx, id)
 }

--- a/internal/backend/deploymentsgrpcsvc/svc.go
+++ b/internal/backend/deploymentsgrpcsvc/svc.go
@@ -2,7 +2,6 @@ package deploymentsgrpcsvc
 
 import (
 	"context"
-	"fmt"
 
 	"connectrpc.com/connect"
 
@@ -45,7 +44,7 @@ func (s *server) Create(ctx context.Context, req *connect.Request[deploymentsv1.
 
 	did, err := s.deployments.Create(ctx, deployment)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("server error: %w", err))
+		return nil, sdkerrors.AsConnectError(err)
 	}
 
 	return connect.NewResponse(&deploymentsv1.CreateResponse{DeploymentId: did.String()}), nil
@@ -87,7 +86,7 @@ func (s *server) List(ctx context.Context, req *connect.Request[deploymentsv1.Li
 
 	deployments, err := s.deployments.List(ctx, filter)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("server error: %w", err))
+		return nil, sdkerrors.AsConnectError(err)
 	}
 
 	deploymentsPB := kittehs.Transform(deployments, sdktypes.ToProto)

--- a/internal/backend/dispatcher/resolve.go
+++ b/internal/backend/dispatcher/resolve.go
@@ -34,10 +34,7 @@ func resolveEnv(ctx context.Context, svcs *wf.Services, env string) (sdktypes.En
 
 		p, err := svcs.Projects.GetByName(context.Background(), name)
 		if err != nil {
-			return sdktypes.InvalidEnvID, err
-		}
-		if !p.IsValid() {
-			return sdktypes.InvalidEnvID, fmt.Errorf("project: %w", sdkerrors.ErrNotFound)
+			return sdktypes.InvalidEnvID, fmt.Errorf("project: %w", err)
 		}
 
 		envs, err := svcs.Envs.List(ctx, p.ID())

--- a/internal/backend/envsgrpcsvc/svc.go
+++ b/internal/backend/envsgrpcsvc/svc.go
@@ -56,11 +56,8 @@ func (s *server) Get(ctx context.Context, req *connect.Request[envsv1.GetRequest
 		if err != nil {
 			if errors.Is(err, sdkerrors.ErrNotFound) {
 				return connect.NewResponse(&envsv1.GetResponse{}), nil
-			} else if errors.Is(err, sdkerrors.ErrUnauthorized) {
-				return nil, connect.NewError(connect.CodePermissionDenied, err)
 			}
-
-			return nil, connect.NewError(connect.CodeUnknown, err)
+			return nil, sdkerrors.AsConnectError(err)
 		}
 
 		return connect.NewResponse(&envsv1.GetResponse{Env: env.ToProto()}), nil

--- a/internal/backend/eventsgrpcsvc/svc.go
+++ b/internal/backend/eventsgrpcsvc/svc.go
@@ -2,7 +2,6 @@ package eventsgrpcsvc
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -46,10 +45,7 @@ func (s *server) Get(ctx context.Context, req *connect.Request[eventsv1.GetReque
 
 	event, err := s.events.Get(ctx, eventId)
 	if err != nil {
-		if errors.Is(err, sdkerrors.ErrNotFound) {
-			return nil, connect.NewError(connect.CodeNotFound, err)
-		}
-		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("server error: %w", err))
+		return nil, sdkerrors.AsConnectError(err)
 	}
 
 	return connect.NewResponse(&eventsv1.GetResponse{Event: event.ToProto()}), nil

--- a/internal/backend/projects/projects.go
+++ b/internal/backend/projects/projects.go
@@ -63,7 +63,6 @@ func (ps *Projects) Create(ctx context.Context, project sdktypes.Project) (sdkty
 }
 
 func (ps *Projects) Delete(ctx context.Context, pid sdktypes.ProjectID) error {
-	// TODO: Make sure somone can't delete a project they don't own or member of its org.
 	return ps.DB.DeleteProject(ctx, pid)
 }
 
@@ -72,13 +71,11 @@ func (ps *Projects) Update(ctx context.Context, project sdktypes.Project) error 
 }
 
 func (ps *Projects) GetByID(ctx context.Context, pid sdktypes.ProjectID) (sdktypes.Project, error) {
-	// TODO: Make sure somone can't get a project they don't own or member of its org.
-	return sdkerrors.IgnoreNotFoundErr(ps.DB.GetProjectByID(ctx, pid))
+	return ps.DB.GetProjectByID(ctx, pid)
 }
 
 func (ps *Projects) GetByName(ctx context.Context, n sdktypes.Symbol) (sdktypes.Project, error) {
-	// TODO: Make sure somone can't get a project they don't own or member of its org.
-	return sdkerrors.IgnoreNotFoundErr(ps.DB.GetProjectByName(ctx, n))
+	return ps.DB.GetProjectByName(ctx, n)
 }
 
 func (ps *Projects) List(ctx context.Context) ([]sdktypes.Project, error) {

--- a/internal/backend/sessions/sessiondata/data.go
+++ b/internal/backend/sessions/sessiondata/data.go
@@ -11,6 +11,7 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/backend/sessions/sessionsvcs"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkbuildfile"
+	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
@@ -30,7 +31,7 @@ type Data struct {
 func retrieve[I sdktypes.ID, R sdktypes.Object](ctx context.Context, z *zap.Logger, id I, f func(context.Context, I) (R, error)) (R, error) {
 	var invalid R
 
-	r, err := f(ctx, id)
+	r, err := sdkerrors.IgnoreNotFoundErr(f(ctx, id))
 
 	if err != nil {
 		z.DPanic("get", zap.Error(err), zap.String("id", id.String()))

--- a/internal/backend/triggers/triggers.go
+++ b/internal/backend/triggers/triggers.go
@@ -8,7 +8,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/internal/backend/db"
 	"go.autokitteh.dev/autokitteh/internal/backend/fixtures"
-	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
@@ -103,7 +102,7 @@ func (m *triggers) Delete(ctx context.Context, triggerID sdktypes.TriggerID) err
 
 // Get implements sdkservices.Triggers.
 func (m *triggers) Get(ctx context.Context, triggerID sdktypes.TriggerID) (sdktypes.Trigger, error) {
-	return sdkerrors.IgnoreNotFoundErr(m.db.GetTrigger(ctx, triggerID))
+	return m.db.GetTrigger(ctx, triggerID)
 }
 
 // List implements sdkservices.Triggers.

--- a/internal/backend/triggersgrpcsvc/svc.go
+++ b/internal/backend/triggersgrpcsvc/svc.go
@@ -45,7 +45,7 @@ func (s *server) Create(ctx context.Context, req *connect.Request[triggersv1.Cre
 
 	mid, err := s.triggers.Create(ctx, trigger)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("server error: %w", err))
+		return nil, sdkerrors.AsConnectError(err)
 	}
 
 	return connect.NewResponse(&triggersv1.CreateResponse{TriggerId: mid.String()}), nil
@@ -64,7 +64,7 @@ func (s *server) Update(ctx context.Context, req *connect.Request[triggersv1.Upd
 	}
 
 	if err := s.triggers.Update(ctx, trigger); err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("server error: %w", err))
+		return nil, sdkerrors.AsConnectError(err)
 	}
 
 	return connect.NewResponse(&triggersv1.UpdateResponse{}), nil
@@ -83,7 +83,7 @@ func (s *server) Delete(ctx context.Context, req *connect.Request[triggersv1.Del
 	}
 
 	if err := s.triggers.Delete(ctx, mid); err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("server error: %w", err))
+		return nil, sdkerrors.AsConnectError(err)
 	}
 
 	return connect.NewResponse(&triggersv1.DeleteResponse{}), nil
@@ -103,7 +103,7 @@ func (s *server) Get(ctx context.Context, req *connect.Request[triggersv1.GetReq
 
 	trigger, err := s.triggers.Get(ctx, mid)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("server error: %w", err))
+		return nil, sdkerrors.AsConnectError(err)
 	}
 
 	return connect.NewResponse(&triggersv1.GetResponse{Trigger: trigger.ToProto()}), nil
@@ -139,7 +139,7 @@ func (s *server) List(ctx context.Context, req *connect.Request[triggersv1.ListR
 
 	triggers, err := s.triggers.List(ctx, filter)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("server error: %w", err))
+		return nil, sdkerrors.AsConnectError(fmt.Errorf("server error: %w", err))
 	}
 
 	triggersPB := kittehs.Transform(triggers, sdktypes.ToProto)

--- a/internal/manifest/exec.go
+++ b/internal/manifest/exec.go
@@ -61,7 +61,7 @@ func executeAction(ctx context.Context, action actions.Action, execContext *exec
 			return nil, err
 		}
 
-		iid, err := execContext.resolveIntegrationID(action.IntegrationKey)
+		iid, err := execContext.resolveIntegrationID(ctx, action.IntegrationKey)
 		if err != nil {
 			return nil, err
 		}
@@ -128,14 +128,14 @@ func executeAction(ctx context.Context, action actions.Action, execContext *exec
 	case actions.SetVarAction:
 		var scopeID sdktypes.VarScopeID
 		if action.Env != "" {
-			eid, err := execContext.resolveEnvID(action.Env)
+			eid, err := execContext.resolveEnvID(ctx, action.Env)
 			if err != nil {
 				return nil, err
 			}
 
 			scopeID = sdktypes.NewVarScopeID(eid)
 		} else {
-			cid, err := execContext.resolveConnectionID(action.Connection)
+			cid, err := execContext.resolveConnectionID(ctx, action.Connection)
 			if err != nil {
 				return nil, err
 			}
@@ -163,14 +163,14 @@ func executeAction(ctx context.Context, action actions.Action, execContext *exec
 		return &Effect{SubjectID: action.ScopeID, Type: Updated, Text: fmt.Sprintf("var %q deleted", n)}, nil
 
 	case actions.CreateTriggerAction:
-		eid, err := execContext.resolveEnvID(action.EnvKey)
+		eid, err := execContext.resolveEnvID(ctx, action.EnvKey)
 		if err != nil {
 			return nil, err
 		}
 		trigger := action.Trigger.WithEnvID(eid)
 
 		if action.ConnectionKey != "" {
-			cid, err := execContext.resolveConnectionID(action.ConnectionKey)
+			cid, err := execContext.resolveConnectionID(ctx, action.ConnectionKey)
 			if err != nil {
 				return nil, err
 			}
@@ -188,7 +188,7 @@ func executeAction(ctx context.Context, action actions.Action, execContext *exec
 		trigger := action.Trigger
 
 		if action.ConnectionKey != "" { // convert scheduler -> normal trigger, or just update connection
-			cid, err := execContext.resolveConnectionID(action.ConnectionKey)
+			cid, err := execContext.resolveConnectionID(ctx, action.ConnectionKey)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/manifest/exec_context.go
+++ b/internal/manifest/exec_context.go
@@ -40,18 +40,18 @@ func (c *execContext) resolveProjectID(ctx context.Context, name string) (sdktyp
 	return pid, nil
 }
 
-func (c *execContext) resolveIntegrationID(name string) (sdktypes.IntegrationID, error) {
+func (c *execContext) resolveIntegrationID(ctx context.Context, name string) (sdktypes.IntegrationID, error) {
 	if iid, ok := c.integrations[name]; ok {
 		return iid, nil
 	}
 
-	in, _, err := c.resolver.IntegrationNameOrID(name)
+	in, _, err := c.resolver.IntegrationNameOrID(ctx, name)
 	iid := in.ID()
 	c.integrations[name] = iid
 	return iid, err
 }
 
-func (c *execContext) resolveEnvID(envID string) (sdktypes.EnvID, error) {
+func (c *execContext) resolveEnvID(ctx context.Context, envID string) (sdktypes.EnvID, error) {
 	if eid, ok := c.envs[envID]; ok {
 		return eid, nil
 	}
@@ -61,7 +61,7 @@ func (c *execContext) resolveEnvID(envID string) (sdktypes.EnvID, error) {
 		return sdktypes.InvalidEnvID, fmt.Errorf("invalid env id %q", envID)
 	}
 
-	sdkEnv, _, err := c.resolver.EnvNameOrID(env, proj)
+	sdkEnv, _, err := c.resolver.EnvNameOrID(ctx, env, proj)
 	if err != nil {
 		return sdktypes.InvalidEnvID, err
 	}
@@ -71,12 +71,12 @@ func (c *execContext) resolveEnvID(envID string) (sdktypes.EnvID, error) {
 	return eid, nil
 }
 
-func (c *execContext) resolveConnectionID(connID string) (sdktypes.ConnectionID, error) {
+func (c *execContext) resolveConnectionID(ctx context.Context, connID string) (sdktypes.ConnectionID, error) {
 	if cid, ok := c.connections[connID]; ok {
 		return cid, nil
 	}
 
-	conn, _, err := c.resolver.ConnectionNameOrID(connID, "")
+	conn, _, err := c.resolver.ConnectionNameOrID(ctx, connID, "")
 	if err != nil {
 		return sdktypes.InvalidConnectionID, err
 	}

--- a/internal/manifest/plan.go
+++ b/internal/manifest/plan.go
@@ -9,6 +9,7 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/backend/fixtures"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/internal/manifest/internal/actions"
+	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdklogger"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
@@ -63,7 +64,7 @@ func planProject(ctx context.Context, mproj *Project, client sdkservices.Service
 
 	var curr sdktypes.Project
 	if !opts.fromScratch {
-		if curr, err = client.Projects().GetByName(ctx, name); err != nil {
+		if curr, err = sdkerrors.IgnoreNotFoundErr(client.Projects().GetByName(ctx, name)); err != nil {
 			return nil, fmt.Errorf("get: %w", err)
 		}
 	}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -7,15 +7,14 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
+	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 const (
 	separator = "/"
-	timeout   = 10 * time.Second
 )
 
 type Resolver struct {
@@ -36,17 +35,24 @@ func (e NotFoundError) Error() string {
 	return e.Type + name + " not found"
 }
 
-func limitedContext() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), timeout)
+func translateError[O sdktypes.Object](err error, obj O, typ, id string) error {
+	if err != nil {
+		if errors.Is(err, sdkerrors.ErrNotFound) {
+			return NotFoundError{Type: "event", Name: id}
+		}
+		return fmt.Errorf("get %s ID %q: %w", typ, id, err)
+	}
+	// no error. But most of the services.Get() methods filtering out notFound errors.
+	// check sdktype.IsValid() to cover this case
+	if !obj.IsValid() {
+		return NotFoundError{Type: "event", Name: id}
+	}
+	return nil
 }
 
 // BuildID returns a build, based on the given ID.
 // It does NOT accept empty input.
-//
-// Subtle note: the build is guaranteed to exist only if the FIRST
-// return value is non-nil. Example: if the input is a valid ID,
-// but it doesn't actually exist, we return (nil, ID, nil).
-func (r Resolver) BuildID(id string) (b sdktypes.Build, bid sdktypes.BuildID, err error) {
+func (r Resolver) BuildID(ctx context.Context, id string) (b sdktypes.Build, bid sdktypes.BuildID, err error) {
 	if id == "" {
 		err = errors.New("missing build ID")
 		return
@@ -57,14 +63,8 @@ func (r Resolver) BuildID(id string) (b sdktypes.Build, bid sdktypes.BuildID, er
 		return
 	}
 
-	ctx, cancel := limitedContext()
-	defer cancel()
-
-	if b, err = r.Client.Builds().Get(ctx, bid); err != nil {
-		err = fmt.Errorf("get build ID %q: %w", id, err)
-		return
-	}
-
+	b, err = r.Client.Builds().Get(ctx, bid)
+	err = translateError(err, b, "build", id)
 	return
 }
 
@@ -74,13 +74,13 @@ func (r Resolver) BuildID(id string) (b sdktypes.Build, bid sdktypes.BuildID, er
 // Subtle note: the connection is guaranteed to exist only if the FIRST
 // return value is non-nil. Example: if the input is a valid ID,
 // but it doesn't actually exist, we return (nil, ID, nil).
-func (r Resolver) ConnectionNameOrID(nameOrID, project string) (c sdktypes.Connection, cid sdktypes.ConnectionID, err error) {
+func (r Resolver) ConnectionNameOrID(ctx context.Context, nameOrID, project string) (c sdktypes.Connection, cid sdktypes.ConnectionID, err error) {
 	if nameOrID == "" {
 		return
 	}
 
 	if sdktypes.IsConnectionID(nameOrID) {
-		return r.connectionByID(nameOrID)
+		return r.connectionByID(ctx, nameOrID)
 	}
 
 	parts := strings.Split(nameOrID, separator)
@@ -89,25 +89,22 @@ func (r Resolver) ConnectionNameOrID(nameOrID, project string) (c sdktypes.Conne
 		if project == "" {
 			err = fmt.Errorf("invalid connection name %q: missing project prefix", nameOrID)
 		} else {
-			return r.connectionByFullName(project, parts[0], nameOrID)
+			return r.connectionByFullName(ctx, project, parts[0], nameOrID)
 		}
 		return
 	case 2:
-		return r.connectionByFullName(parts[0], parts[1], nameOrID)
+		return r.connectionByFullName(ctx, parts[0], parts[1], nameOrID)
 	default:
 		err = fmt.Errorf("invalid connection name %q: too many parts", nameOrID)
 		return
 	}
 }
 
-func (r Resolver) connectionByID(id string) (c sdktypes.Connection, cid sdktypes.ConnectionID, err error) {
+func (r Resolver) connectionByID(ctx context.Context, id string) (c sdktypes.Connection, cid sdktypes.ConnectionID, err error) {
 	if cid, err = sdktypes.StrictParseConnectionID(id); err != nil {
 		err = fmt.Errorf("invalid connection ID %q: %w", id, err)
 		return
 	}
-
-	ctx, cancel := limitedContext()
-	defer cancel()
 
 	if c, err = r.Client.Connections().Get(ctx, cid); err != nil {
 		err = fmt.Errorf("get connection ID %q: %w", id, err)
@@ -117,17 +114,14 @@ func (r Resolver) connectionByID(id string) (c sdktypes.Connection, cid sdktypes
 	return
 }
 
-func (r Resolver) connectionByFullName(projNameOrID, connName, fullName string) (sdktypes.Connection, sdktypes.ConnectionID, error) {
-	p, pid, err := r.ProjectNameOrID(projNameOrID)
+func (r Resolver) connectionByFullName(ctx context.Context, projNameOrID, connName, fullName string) (sdktypes.Connection, sdktypes.ConnectionID, error) {
+	p, pid, err := r.ProjectNameOrID(ctx, projNameOrID)
 	if err != nil {
 		return sdktypes.InvalidConnection, sdktypes.InvalidConnectionID, err
 	}
 	if !p.IsValid() {
 		return sdktypes.InvalidConnection, sdktypes.InvalidConnectionID, NotFoundError{Type: "project", Name: projNameOrID}
 	}
-
-	ctx, cancel := limitedContext()
-	defer cancel()
 
 	f := sdkservices.ListConnectionsFilter{ProjectID: pid}
 	cs, err := r.Client.Connections().List(ctx, f)
@@ -146,11 +140,7 @@ func (r Resolver) connectionByFullName(projNameOrID, connName, fullName string) 
 
 // DeploymentID returns a deployment, based on the given ID.
 // It does NOT accept empty input.
-//
-// Subtle note: the deployment is guaranteed to exist only if the FIRST
-// return value is non-nil. Example: if the input is a valid ID,
-// but it doesn't actually exist, we return (nil, ID, nil).
-func (r Resolver) DeploymentID(id string) (d sdktypes.Deployment, did sdktypes.DeploymentID, err error) {
+func (r Resolver) DeploymentID(ctx context.Context, id string) (d sdktypes.Deployment, did sdktypes.DeploymentID, err error) {
 	if id == "" {
 		err = errors.New("missing deployment ID")
 		return
@@ -161,14 +151,8 @@ func (r Resolver) DeploymentID(id string) (d sdktypes.Deployment, did sdktypes.D
 		return
 	}
 
-	ctx, cancel := limitedContext()
-	defer cancel()
-
-	if d, err = r.Client.Deployments().Get(ctx, did); err != nil {
-		err = fmt.Errorf("get deployment ID %q: %w", id, err)
-		return
-	}
-
+	d, err = r.Client.Deployments().Get(ctx, did)
+	err = translateError(err, d, "deployment", id)
 	return
 }
 
@@ -188,7 +172,7 @@ func (r Resolver) DeploymentID(id string) (d sdktypes.Deployment, did sdktypes.D
 // Subtle note: the environment is guaranteed to exist only if the FIRST
 // return value is non-nil. Example: if the input is a valid ID,
 // but it doesn't actually exist, we return (nil, ID, nil).
-func (r Resolver) EnvNameOrID(envNameOrID, projNameOrID string) (sdktypes.Env, sdktypes.EnvID, error) {
+func (r Resolver) EnvNameOrID(ctx context.Context, envNameOrID, projNameOrID string) (sdktypes.Env, sdktypes.EnvID, error) {
 	if envNameOrID == "" {
 		if projNameOrID == "" {
 			return sdktypes.InvalidEnv, sdktypes.InvalidEnvID, nil
@@ -198,26 +182,23 @@ func (r Resolver) EnvNameOrID(envNameOrID, projNameOrID string) (sdktypes.Env, s
 	}
 
 	// Project.
-	_, pid, err := r.ProjectNameOrID(projNameOrID)
+	_, pid, err := r.ProjectNameOrID(ctx, projNameOrID)
 	if err != nil {
 		return sdktypes.InvalidEnv, sdktypes.InvalidEnvID, err
 	}
 
 	// Environment.
 	if sdktypes.IsEnvID(envNameOrID) {
-		return r.envByID(envNameOrID, projNameOrID, pid)
+		return r.envByID(ctx, envNameOrID, projNameOrID, pid)
 	}
-	return r.envByName(envNameOrID, projNameOrID, pid)
+	return r.envByName(ctx, envNameOrID, projNameOrID, pid)
 }
 
-func (r Resolver) envByID(envID, projNameOrID string, pid sdktypes.ProjectID) (e sdktypes.Env, eid sdktypes.EnvID, err error) {
+func (r Resolver) envByID(ctx context.Context, envID, projNameOrID string, pid sdktypes.ProjectID) (e sdktypes.Env, eid sdktypes.EnvID, err error) {
 	if eid, err = sdktypes.StrictParseEnvID(envID); err != nil {
 		err = fmt.Errorf("invalid environment ID %q: %w", envID, err)
 		return
 	}
-
-	ctx, cancel := limitedContext()
-	defer cancel()
 
 	if e, err = r.Client.Envs().GetByID(ctx, eid); err != nil {
 		err = fmt.Errorf("get environment ID %q: %w", envID, err)
@@ -232,15 +213,15 @@ func (r Resolver) envByID(envID, projNameOrID string, pid sdktypes.ProjectID) (e
 	return
 }
 
-func (r Resolver) envByName(envName, projNameOrID string, pid sdktypes.ProjectID) (sdktypes.Env, sdktypes.EnvID, error) {
+func (r Resolver) envByName(ctx context.Context, envName, projNameOrID string, pid sdktypes.ProjectID) (sdktypes.Env, sdktypes.EnvID, error) {
 	parts := strings.Split(envName, separator)
 	if len(parts) == 1 {
-		return r.envByShortName(envName, pid)
+		return r.envByShortName(ctx, envName, pid)
 	}
-	return r.envByFullName(parts, projNameOrID, pid)
+	return r.envByFullName(ctx, parts, projNameOrID, pid)
 }
 
-func (r Resolver) envByShortName(envName string, pid sdktypes.ProjectID) (e sdktypes.Env, eid sdktypes.EnvID, err error) {
+func (r Resolver) envByShortName(ctx context.Context, envName string, pid sdktypes.ProjectID) (e sdktypes.Env, eid sdktypes.EnvID, err error) {
 	if !pid.IsValid() {
 		err = fmt.Errorf("invalid environment name %q: missing project prefix", envName)
 		return
@@ -253,9 +234,6 @@ func (r Resolver) envByShortName(envName string, pid sdktypes.ProjectID) (e sdkt
 		return
 	}
 
-	ctx, cancel := limitedContext()
-	defer cancel()
-
 	if e, err = r.Client.Envs().GetByName(ctx, pid, n); err != nil {
 		err = fmt.Errorf("get environment name %q: %w", envName, err)
 	}
@@ -264,10 +242,10 @@ func (r Resolver) envByShortName(envName string, pid sdktypes.ProjectID) (e sdkt
 	return
 }
 
-func (r Resolver) envByFullName(parts []string, projNameOrID string, pid sdktypes.ProjectID) (e sdktypes.Env, eid sdktypes.EnvID, err error) {
+func (r Resolver) envByFullName(ctx context.Context, parts []string, projNameOrID string, pid sdktypes.ProjectID) (e sdktypes.Env, eid sdktypes.EnvID, err error) {
 	prefix, envName := strings.Join(parts[:len(parts)-1], separator), parts[len(parts)-1]
 
-	if e, eid, err = r.EnvNameOrID(envName, prefix); err != nil {
+	if e, eid, err = r.EnvNameOrID(ctx, envName, prefix); err != nil {
 		return
 	}
 
@@ -282,11 +260,7 @@ func (r Resolver) envByFullName(parts []string, projNameOrID string, pid sdktype
 
 // EventID returns an event, based on the given ID.
 // It does NOT accept empty input.
-//
-// Subtle note: the event is guaranteed to exist only if the FIRST
-// return value is non-nil. Example: if the input is a valid ID,
-// but it doesn't actually exist, we return (nil, ID, nil).
-func (r Resolver) EventID(id string) (e sdktypes.Event, eid sdktypes.EventID, err error) {
+func (r Resolver) EventID(ctx context.Context, id string) (e sdktypes.Event, eid sdktypes.EventID, err error) {
 	if id == "" {
 		err = errors.New("missing event ID")
 		return
@@ -297,14 +271,8 @@ func (r Resolver) EventID(id string) (e sdktypes.Event, eid sdktypes.EventID, er
 		return
 	}
 
-	ctx, cancel := limitedContext()
-	defer cancel()
-
-	if e, err = r.Client.Events().Get(ctx, eid); err != nil {
-		err = fmt.Errorf("get event ID %q: %w", id, err)
-		return
-	}
-
+	e, err = r.Client.Events().Get(ctx, eid)
+	err = translateError(err, e, "event", id)
 	return
 }
 
@@ -314,26 +282,23 @@ func (r Resolver) EventID(id string) (e sdktypes.Event, eid sdktypes.EventID, er
 // Subtle note: the integration is guaranteed to exist only if the FIRST
 // return value is non-nil. Example: if the input is a valid ID,
 // but it doesn't actually exist, we return (nil, ID, nil).
-func (r Resolver) IntegrationNameOrID(nameOrID string) (sdktypes.Integration, sdktypes.IntegrationID, error) {
+func (r Resolver) IntegrationNameOrID(ctx context.Context, nameOrID string) (sdktypes.Integration, sdktypes.IntegrationID, error) {
 	if nameOrID == "" {
 		return sdktypes.InvalidIntegration, sdktypes.InvalidIntegrationID, nil
 	}
 
 	if sdktypes.IsIntegrationID(nameOrID) {
-		return r.integrationByID(nameOrID)
+		return r.integrationByID(ctx, nameOrID)
 	}
 
-	return r.integrationByName(nameOrID)
+	return r.integrationByName(ctx, nameOrID)
 }
 
-func (r Resolver) integrationByID(id string) (sdktypes.Integration, sdktypes.IntegrationID, error) {
+func (r Resolver) integrationByID(ctx context.Context, id string) (sdktypes.Integration, sdktypes.IntegrationID, error) {
 	iid, err := sdktypes.StrictParseIntegrationID(id)
 	if err != nil {
 		return sdktypes.InvalidIntegration, sdktypes.InvalidIntegrationID, fmt.Errorf("invalid integration ID %q: %w", id, err)
 	}
-
-	ctx, cancel := limitedContext()
-	defer cancel()
 
 	is, err := r.Client.Integrations().List(ctx, "")
 	if err != nil {
@@ -349,10 +314,7 @@ func (r Resolver) integrationByID(id string) (sdktypes.Integration, sdktypes.Int
 	return sdktypes.InvalidIntegration, iid, nil
 }
 
-func (r Resolver) integrationByName(name string) (sdktypes.Integration, sdktypes.IntegrationID, error) {
-	ctx, cancel := limitedContext()
-	defer cancel()
-
+func (r Resolver) integrationByName(ctx context.Context, name string) (sdktypes.Integration, sdktypes.IntegrationID, error) {
 	is, err := r.Client.Integrations().List(ctx, name)
 	if err != nil {
 		return sdktypes.InvalidIntegration, sdktypes.InvalidIntegrationID, fmt.Errorf("list integrations: %w", err)
@@ -376,7 +338,7 @@ func (r Resolver) integrationByName(name string) (sdktypes.Integration, sdktypes
 // Subtle note: the trigger is guaranteed to exist only if the FIRST
 // return value is non-nil. Example: if the input is a valid ID,
 // but it doesn't actually exist, we return (nil, ID, nil).
-func (r Resolver) TriggerID(id string) (t sdktypes.Trigger, tid sdktypes.TriggerID, err error) {
+func (r Resolver) TriggerID(ctx context.Context, id string) (t sdktypes.Trigger, tid sdktypes.TriggerID, err error) {
 	if id == "" {
 		err = errors.New("missing trigger ID")
 		return
@@ -387,14 +349,8 @@ func (r Resolver) TriggerID(id string) (t sdktypes.Trigger, tid sdktypes.Trigger
 		return
 	}
 
-	ctx, cancel := limitedContext()
-	defer cancel()
-
-	if t, err = r.Client.Triggers().Get(ctx, tid); err != nil {
-		err = fmt.Errorf("get trigger ID %q: %w", id, err)
-		return
-	}
-
+	t, err = r.Client.Triggers().Get(ctx, tid)
+	err = translateError(err, t, "trigger", id)
 	return
 }
 
@@ -404,27 +360,23 @@ func (r Resolver) TriggerID(id string) (t sdktypes.Trigger, tid sdktypes.Trigger
 // Subtle note: the project is guaranteed to exist only if the FIRST
 // return value is non-nil. Example: if the input is a valid ID,
 // but it doesn't actually exist, we return (nil, ID, nil).
-func (r Resolver) ProjectNameOrID(nameOrID string) (sdktypes.Project, sdktypes.ProjectID, error) {
+func (r Resolver) ProjectNameOrID(ctx context.Context, nameOrID string) (sdktypes.Project, sdktypes.ProjectID, error) {
 	if nameOrID == "" {
 		return sdktypes.InvalidProject, sdktypes.InvalidProjectID, nil
 	}
 
 	if sdktypes.IsProjectID(nameOrID) {
-		return r.projectByID(nameOrID)
+		return r.projectByID(ctx, nameOrID)
 	}
 
-	return r.projectByName(nameOrID)
+	return r.projectByName(ctx, nameOrID)
 }
 
-func (r Resolver) projectByID(id string) (p sdktypes.Project, pid sdktypes.ProjectID, err error) {
+func (r Resolver) projectByID(ctx context.Context, id string) (p sdktypes.Project, pid sdktypes.ProjectID, err error) {
 	if pid, err = sdktypes.StrictParseProjectID(id); err != nil {
 		err = fmt.Errorf("invalid project ID %q: %w", id, err)
 		return
 	}
-
-	ctx, cancel := limitedContext()
-	defer cancel()
-
 	p, err = r.Client.Projects().GetByID(ctx, pid)
 	if err != nil {
 		err = fmt.Errorf("get project ID %q: %w", id, err)
@@ -434,15 +386,12 @@ func (r Resolver) projectByID(id string) (p sdktypes.Project, pid sdktypes.Proje
 	return
 }
 
-func (r Resolver) projectByName(name string) (p sdktypes.Project, pid sdktypes.ProjectID, err error) {
+func (r Resolver) projectByName(ctx context.Context, name string) (p sdktypes.Project, pid sdktypes.ProjectID, err error) {
 	var n sdktypes.Symbol
 	if n, err = sdktypes.Strict(sdktypes.ParseSymbol(name)); err != nil {
 		err = fmt.Errorf("invalid project name %q: %w", name, err)
 		return
 	}
-
-	ctx, cancel := limitedContext()
-	defer cancel()
 
 	if p, err = r.Client.Projects().GetByName(ctx, n); err != nil {
 		err = fmt.Errorf("get project name %q: %w", name, err)
@@ -458,7 +407,7 @@ func (r Resolver) projectByName(name string) (p sdktypes.Project, pid sdktypes.P
 // Subtle note: the session is guaranteed to exist only if the FIRST
 // return value is non-nil. Example: if the input is a valid ID,
 // but it doesn't actually exist, we return (nil, ID, nil).
-func (r Resolver) SessionID(id string) (s sdktypes.Session, sid sdktypes.SessionID, err error) {
+func (r Resolver) SessionID(ctx context.Context, id string) (s sdktypes.Session, sid sdktypes.SessionID, err error) {
 	if id == "" {
 		err = errors.New("missing session ID")
 		return
@@ -468,9 +417,6 @@ func (r Resolver) SessionID(id string) (s sdktypes.Session, sid sdktypes.Session
 		err = fmt.Errorf("invalid session ID %q: %w", id, err)
 		return
 	}
-
-	ctx, cancel := limitedContext()
-	defer cancel()
 
 	if s, err = r.Client.Sessions().Get(ctx, sid); err != nil {
 		err = fmt.Errorf("get session ID %q: %w", id, err)

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -18,7 +18,7 @@ const (
 )
 
 type Resolver struct {
-	Client sdkservices.Services
+	Client sdkservices.DBServices
 }
 
 type NotFoundError struct {

--- a/sdk/sdkservices/services.go
+++ b/sdk/sdkservices/services.go
@@ -1,19 +1,24 @@
 package sdkservices
 
 type Services interface {
+	DBServices
+
 	Auth() Auth
-	Builds() Builds
-	Connections() Connections
-	Deployments() Deployments
 	Dispatcher() Dispatcher
-	Envs() Envs
-	Events() Events
-	Integrations() Integrations
 	OAuth() OAuth
-	Projects() Projects
 	Runtimes() Runtimes
-	Sessions() Sessions
 	Store() Store
+}
+
+type DBServices interface {
+	Integrations() Integrations
+	Projects() Projects
+	Builds() Builds
+	Deployments() Deployments
+	Envs() Envs
+	Connections() Connections
+	Sessions() Sessions
+	Events() Events
 	Triggers() Triggers
 	Vars() Vars
 }

--- a/tests/cli/builds.txt
+++ b/tests/cli/builds.txt
@@ -13,7 +13,7 @@ Error: build not found
 10
 $ echo hissss > ${tmp}/hissss
 $ ${AK} build upload ${tmp}/hissss; echo $?
-Error: save build: server error: read version: gzip: unexpected EOF
+Error: save build: read version: gzip: unexpected EOF
 1
 $ # upload build without build_file_path fail
 $ ${AK} build upload; echo $?

--- a/tests/cli/deployments.txt
+++ b/tests/cli/deployments.txt
@@ -29,7 +29,7 @@ Error: invalid deployment ID "dep_1": invalid suffix: 1. Suffix length is 1, exp
 1
 $ # activate deployment with not existing id return not found
 $ ${AK} deployment activate dep_00000000000000000000000001; echo $?
-Error: deployment "dep_00000000000000000000000001" not found
+Error: deployment not found
 10
 $ # drain deployment with inavlid id 1 return error
 $ ${AK} deployment drain 1; echo $?
@@ -41,7 +41,7 @@ Error: invalid deployment ID "dep_1": invalid suffix: 1. Suffix length is 1, exp
 1
 $ # drain deployment with not existing id return not found
 $ ${AK} deployment drain dep_00000000000000000000000001; echo $?
-Error: deployment "dep_00000000000000000000000001" not found
+Error: deployment not found
 10
 $ # deactivate deployment with inavlid id 1 return error
 $ ${AK} deployment deactivate 1; echo $?
@@ -53,7 +53,7 @@ Error: invalid deployment ID "dep_1": invalid suffix: 1. Suffix length is 1, exp
 1
 $ # deactivate deployment with not existing id return not found
 $ ${AK} deployment deactivate dep_00000000000000000000000001; echo $?
-Error: deployment "dep_00000000000000000000000001" not found
+Error: deployment not found
 10
 $ # create deployment without build-id or env fails
 $ ${AK} deployment create; echo $?

--- a/tests/system/testdata/deploy/deploy.txtar
+++ b/tests/system/testdata/deploy/deploy.txtar
@@ -5,11 +5,11 @@ return code == 10
 
 # Negative tests: deploy nonexistent project, by name/ID.
 ak deploy --project bad_project --file program.star
-output equals 'Error: project "bad_project" not found'
+output equals 'Error: project not found'
 return code == 10
 
 ak deploy --project prj_000000000000000bad0bad0bad --file program.star
-output equals 'Error: project "prj_000000000000000bad0bad0bad" not found'
+output equals 'Error: project not found'
 return code == 10
 
 # Deploy based on new manifest.

--- a/tests/system/testdata/deploy/project_deploy.txtar_
+++ b/tests/system/testdata/deploy/project_deploy.txtar_
@@ -1,10 +1,10 @@
 # Negative tests: deploy nonexistent project, by name/ID.
 ak project deploy bad_project --file program.star
-output equals 'Error: project not found'
+output equals 'Error: not found'
 return code == 10
 
 ak project deploy prj_000000000000000bad0bad0bad --file program.star
-output equals 'Error: project not found'
+output equals 'Error: not found'
 return code == 10
 
 # Preconditions: create project and environment.

--- a/tests/system/testdata/events/get.txtar
+++ b/tests/system/testdata/events/get.txtar
@@ -16,8 +16,16 @@ ak connection create my_connection --project my_project --integration http -q
 return code == 0
 output equals 'connection_id: con_00000000000000000000000003'
 
+# Negative test: invalid project name (dash disallowed)
+http get /http/my-project  
+resp code == 404
+
+# Negative test: unexisting project
+http get /http/my_project1
+resp code == 404
+
 # Send HTTP GET request to create new event.
-http get /http/my_url_path
+http get /http/my_project
 resp code == 200
 
 # Get first event, with/out JSON.

--- a/tests/system/testdata/events/list.txtar
+++ b/tests/system/testdata/events/list.txtar
@@ -17,13 +17,13 @@ return code == 0
 output equals 'connection_id: con_00000000000000000000000003'
 
 # Send HTTP GET request to create new events.
-http get /http/my_url_path
+http get /http/my_project
 resp code == 200
 
-http get /http/my_url_path
+http get /http/my_project
 resp code == 200
 
-http get /http/my_url_path
+http get /http/my_project
 resp code == 200
 
 # Negative test: list all events, without any filter.

--- a/tests/system/testdata/projects/build.txtar
+++ b/tests/system/testdata/projects/build.txtar
@@ -1,10 +1,10 @@
 # Negative tests: build nonexistent project, by name/ID.
 ak project build bad_project --file program.star
-output equals 'Error: project "bad_project" not found'
+output equals 'Error: project not found'
 return code == 10
 
 ak project build prj_000000000000000bad0bad0bad --file program.star
-output equals 'Error: project "prj_000000000000000bad0bad0bad" not found'
+output equals 'Error: project not found'
 return code == 10
 
 # Precondition: create project.


### PR DESCRIPTION
- pass existing context to resolver instead of using a new one
- stop filtering ErrNotFound on server/API side and let clients handle it

fixes ENG-1157