### PR TITLE
ENG-1161: publish latest image on merge to main, publish stable image on release

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'  # Should be in sync with runtimes/pythonrt/pythonrt.go:minPyVersion
+          python-version: "3.11" # Should be in sync with runtimes/pythonrt/pythonrt.go:minPyVersion
       - name: Test
         run: make test-unit
 
@@ -104,3 +104,44 @@ jobs:
 
       - name: Session tests
         run: make bin/ak test-sessions
+
+  publish_docker_image:
+    needs:
+      - test-sessions
+      - test-runs
+      - test-cli
+      - static-analysis
+      - build-and-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup version info
+        run: |
+          # These are consumed in the Dockerfile.
+          echo "${GITHUB_REF#refs/tags/}" > .version
+          echo "${GITHUB_SHA}" > .commit
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_GITHUB_ROLE }}
+          role-session-name: Github_Action_Release_Autokitteh
+          aws-region: us-east-1
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Build And Push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64
+          tags: ${{ steps.login-ecr.outputs.registry }}/autokitteh:latest
+          push: true
+          provenance: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,6 @@ jobs:
         with:
           context: .
           platforms: linux/amd64
-          tags: ${{ steps.login-ecr.outputs.registry }}/autokitteh:${{github.ref_name}},${{ steps.login-ecr.outputs.registry }}/autokitteh:latest
+          tags: ${{ steps.login-ecr.outputs.registry }}/autokitteh:${{github.ref_name}},${{ steps.login-ecr.outputs.registry }}/autokitteh:stable
           push: true
           provenance: false


### PR DESCRIPTION
So we won't require a release just for testing purposes

latest images can be broken 
stable images are only on releases