### PR TITLE
ENG-1187: session log record duplicate key on insert

### DIFF
--- a/internal/backend/db/dbgorm/dbgorm.go
+++ b/internal/backend/db/dbgorm/dbgorm.go
@@ -73,6 +73,7 @@ func (db *gormdb) Connect(ctx context.Context) error {
 	client, err := gormkitteh.OpenZ(db.z.Named("gorm"), db.cfg, func(cfg *gorm.Config) {
 		cfg.SkipDefaultTransaction = true
 		cfg.Logger = logger.Default
+		cfg.TranslateError = true
 	})
 	if err != nil {
 		return fmt.Errorf("opendb: %w", err)


### PR DESCRIPTION
log records has a primary key of session_id,sequence
if we try to insert the same sequence twice it will fail
on duplicate and we need to retry
sequence is calculated again on each insertion so it has
to succeed in the end
we try for 10 times instead of indefinite but we might
want to consider it in the future