### PR TITLE
Fix: retain CID and origin when retrying connection init

### DIFF
--- a/web/static/chatgpt/connect/error.html
+++ b/web/static/chatgpt/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AutoKitteh / OpenAI ChatGPT - Connection Error</title>
+    <title>AutoKitteh - OpenAI ChatGPT - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -27,7 +27,7 @@
 
   <body>
     <a href="/" target="_self">
-      <img class="banner" src="/static/banner.svg" alt="autokitteh" />
+      <img class="banner" src="/static/banner.svg" alt="AutoKitteh" />
     </a>
 
     <table class="title">

--- a/web/static/chatgpt/connect/error.html
+++ b/web/static/chatgpt/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>autokitteh OpenAI ChatGPT Integration - Error!</title>
+    <title>AutoKitteh / OpenAI ChatGPT - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -38,7 +38,7 @@
     <p class="error" id="error"></p>
 
     <p class="info">
-      <a href="../connect" class="info">Try to create another connection</a>
+      <button class="submit-btn" id="retry">Try Again</button>
     </p>
   </body>
 </html>

--- a/web/static/chatgpt/connect/error.js
+++ b/web/static/chatgpt/connect/error.js
@@ -1,8 +1,14 @@
-// Display the error message in the page too, not just as a URL parameter.
-
-const param = new URLSearchParams(window.location.search).get("error");
+// Display the error message in the page, not just as a URL parameter.
+const err = new URLSearchParams(window.location.search).get("error");
 const elem = document.getElementById("error");
 
-if (param) {
-  elem.textContent = param;
+if (err) {
+  elem.textContent = err;
 }
+
+// Allow the user to retry initializing the connection.
+document.getElementById("retry").onclick = function () {
+  const id = new URLSearchParams(window.location.search).get("cid");
+  const origin = new URLSearchParams(window.location.search).get("origin");
+  window.location.href = "./?cid=".concat(id, "&origin=", origin);
+};

--- a/web/static/confluence/connect/error.html
+++ b/web/static/confluence/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AutoKitteh / Atlassian Confluence - Connection Error</title>
+    <title>AutoKitteh - Atlassian Confluence - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"

--- a/web/static/confluence/connect/error.html
+++ b/web/static/confluence/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AutoKitteh Atlassian Confluence Integration - Error!</title>
+    <title>AutoKitteh / Atlassian Confluence - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -40,7 +40,7 @@
     <p class="error" id="error"></p>
 
     <p class="info">
-      <a href="../connect" class="info">Try to create another connection</a>
+      <button class="submit-btn" id="retry">Try Again</button>
     </p>
   </body>
 </html>

--- a/web/static/confluence/connect/error.js
+++ b/web/static/confluence/connect/error.js
@@ -1,8 +1,14 @@
-// Display the error message in the page too, not just as a URL parameter.
-
-const param = new URLSearchParams(window.location.search).get("error");
+// Display the error message in the page, not just as a URL parameter.
+const err = new URLSearchParams(window.location.search).get("error");
 const elem = document.getElementById("error");
 
-if (param) {
-  elem.textContent = param;
+if (err) {
+  elem.textContent = err;
 }
+
+// Allow the user to retry initializing the connection.
+document.getElementById("retry").onclick = function () {
+  const id = new URLSearchParams(window.location.search).get("cid");
+  const origin = new URLSearchParams(window.location.search).get("origin");
+  window.location.href = "./?cid=".concat(id, "&origin=", origin);
+};

--- a/web/static/confluence/connect/index.html
+++ b/web/static/confluence/connect/index.html
@@ -123,7 +123,7 @@
 
         <div class="form-group">
           <label for="email">
-            User email address (API tokens only, not PATs!)
+            API token owner's email address (API tokens only, not PATs)
           </label>
           <input
             type="email"

--- a/web/static/confluence/connect/index.html
+++ b/web/static/confluence/connect/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AutoKitteh Atlassian Confluence Integration</title>
+    <title>AutoKitteh - Atlassian Confluence - New Connection</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"

--- a/web/static/github/connect/error.html
+++ b/web/static/github/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AutoKitteh / GitHub - Connection Error</title>
+    <title>AutoKitteh - GitHub - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -27,7 +27,7 @@
 
   <body>
     <a href="/" target="_self">
-      <img class="banner" src="/static/banner.svg" alt="autokitteh" />
+      <img class="banner" src="/static/banner.svg" alt="AutoKitteh" />
     </a>
 
     <table class="title">

--- a/web/static/github/connect/error.html
+++ b/web/static/github/connect/error.html
@@ -1,10 +1,24 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>autokitteh GitHub Integration - Error!</title>
-    <link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png" />
+    <title>AutoKitteh / GitHub - Connection Error</title>
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/static/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/static/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/static/favicon-16x16.png"
+    />
     <link rel="manifest" href="/static/site.webmanifest" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <meta name="robots" content="noindex, nofollow" />
@@ -21,10 +35,10 @@
       <td><h1>GitHub - Connection Error</h1></td>
     </table>
 
-    <p class="error" id="error"></textarea>
+    <p class="error" id="error"></p>
 
     <p class="info">
-      <a href="../connect" class="info">Try to create another connection</a>
+      <button class="submit-btn" id="retry">Try Again</button>
     </p>
   </body>
 </html>

--- a/web/static/github/connect/error.js
+++ b/web/static/github/connect/error.js
@@ -1,8 +1,14 @@
-// Display the error message in the page too, not just as a URL parameter.
-
-const param = new URLSearchParams(window.location.search).get("error");
+// Display the error message in the page, not just as a URL parameter.
+const err = new URLSearchParams(window.location.search).get("error");
 const elem = document.getElementById("error");
 
-if (param) {
-  elem.textContent = param;
+if (err) {
+  elem.textContent = err;
 }
+
+// Allow the user to retry initializing the connection.
+document.getElementById("retry").onclick = function () {
+  const id = new URLSearchParams(window.location.search).get("cid");
+  const origin = new URLSearchParams(window.location.search).get("origin");
+  window.location.href = "./?cid=".concat(id, "&origin=", origin);
+};

--- a/web/static/gmail/connect/error.html
+++ b/web/static/gmail/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>autokitteh Gmail Integration - Error!</title>
+    <title>AutoKitteh / Gmail - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -38,7 +38,7 @@
     <p class="error" id="error"></p>
 
     <p class="info">
-      <a href="../connect" class="info">Try to create another connection</a>
+      <button class="submit-btn" id="retry">Try Again</button>
     </p>
   </body>
 </html>

--- a/web/static/gmail/connect/error.html
+++ b/web/static/gmail/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AutoKitteh / Gmail - Connection Error</title>
+    <title>AutoKitteh - Gmail - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -27,7 +27,7 @@
 
   <body>
     <a href="/" target="_self">
-      <img class="banner" src="/static/banner.svg" alt="autokitteh" />
+      <img class="banner" src="/static/banner.svg" alt="AutoKitteh" />
     </a>
 
     <table class="title">

--- a/web/static/gmail/connect/error.js
+++ b/web/static/gmail/connect/error.js
@@ -1,8 +1,14 @@
-// Display the error message in the page too, not just as a URL parameter.
-
-const param = new URLSearchParams(window.location.search).get("error");
+// Display the error message in the page, not just as a URL parameter.
+const err = new URLSearchParams(window.location.search).get("error");
 const elem = document.getElementById("error");
 
-if (param) {
-  elem.textContent = param;
+if (err) {
+  elem.textContent = err;
 }
+
+// Allow the user to retry initializing the connection.
+document.getElementById("retry").onclick = function () {
+  const id = new URLSearchParams(window.location.search).get("cid");
+  const origin = new URLSearchParams(window.location.search).get("origin");
+  window.location.href = "./?cid=".concat(id, "&origin=", origin);
+};

--- a/web/static/google/connect/error.html
+++ b/web/static/google/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AutoKitteh / Google - Connection Error</title>
+    <title>AutoKitteh - Google - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -27,7 +27,7 @@
 
   <body>
     <a href="/" target="_self">
-      <img class="banner" src="/static/banner.svg" alt="autokitteh" />
+      <img class="banner" src="/static/banner.svg" alt="AutoKitteh" />
     </a>
 
     <table class="title">

--- a/web/static/google/connect/error.html
+++ b/web/static/google/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>autokitteh Google Integration - Error!</title>
+    <title>AutoKitteh / Google - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -38,7 +38,7 @@
     <p class="error" id="error"></p>
 
     <p class="info">
-      <a href="../connect" class="info">Try to create another connection</a>
+      <button class="submit-btn" id="retry">Try Again</button>
     </p>
   </body>
 </html>

--- a/web/static/google/connect/error.js
+++ b/web/static/google/connect/error.js
@@ -1,8 +1,14 @@
-// Display the error message in the page too, not just as a URL parameter.
-
-const param = new URLSearchParams(window.location.search).get("error");
+// Display the error message in the page, not just as a URL parameter.
+const err = new URLSearchParams(window.location.search).get("error");
 const elem = document.getElementById("error");
 
-if (param) {
-  elem.textContent = param;
+if (err) {
+  elem.textContent = err;
 }
+
+// Allow the user to retry initializing the connection.
+document.getElementById("retry").onclick = function () {
+  const id = new URLSearchParams(window.location.search).get("cid");
+  const origin = new URLSearchParams(window.location.search).get("origin");
+  window.location.href = "./?cid=".concat(id, "&origin=", origin);
+};

--- a/web/static/googlecalendar/connect/error.html
+++ b/web/static/googlecalendar/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AutoKitteh / Google Calendar - Connection Error</title>
+    <title>AutoKitteh - Google Calendar - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -27,7 +27,7 @@
 
   <body>
     <a href="/" target="_self">
-      <img class="banner" src="/static/banner.svg" alt="autokitteh" />
+      <img class="banner" src="/static/banner.svg" alt="AutoKitteh" />
     </a>
 
     <table class="title">

--- a/web/static/googlecalendar/connect/error.html
+++ b/web/static/googlecalendar/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>autokitteh Google Calendar Integration - Error!</title>
+    <title>AutoKitteh / Google Calendar - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -40,7 +40,7 @@
     <p class="error" id="error"></p>
 
     <p class="info">
-      <a href="../connect" class="info">Try to create another connection</a>
+      <button class="submit-btn" id="retry">Try Again</button>
     </p>
   </body>
 </html>

--- a/web/static/googlecalendar/connect/error.js
+++ b/web/static/googlecalendar/connect/error.js
@@ -1,8 +1,14 @@
-// Display the error message in the page too, not just as a URL parameter.
-
-const param = new URLSearchParams(window.location.search).get("error");
+// Display the error message in the page, not just as a URL parameter.
+const err = new URLSearchParams(window.location.search).get("error");
 const elem = document.getElementById("error");
 
-if (param) {
-  elem.textContent = param;
+if (err) {
+  elem.textContent = err;
 }
+
+// Allow the user to retry initializing the connection.
+document.getElementById("retry").onclick = function () {
+  const id = new URLSearchParams(window.location.search).get("cid");
+  const origin = new URLSearchParams(window.location.search).get("origin");
+  window.location.href = "./?cid=".concat(id, "&origin=", origin);
+};

--- a/web/static/googledrive/connect/error.html
+++ b/web/static/googledrive/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AutoKitteh / Google Drive - Connection Error</title>
+    <title>AutoKitteh - Google Drive - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -27,7 +27,7 @@
 
   <body>
     <a href="/" target="_self">
-      <img class="banner" src="/static/banner.svg" alt="autokitteh" />
+      <img class="banner" src="/static/banner.svg" alt="AutoKitteh" />
     </a>
 
     <table class="title">

--- a/web/static/googledrive/connect/error.html
+++ b/web/static/googledrive/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>autokitteh Google Drive Integration - Error!</title>
+    <title>AutoKitteh / Google Drive - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -40,7 +40,7 @@
     <p class="error" id="error"></p>
 
     <p class="info">
-      <a href="../connect" class="info">Try to create another connection</a>
+      <button class="submit-btn" id="retry">Try Again</button>
     </p>
   </body>
 </html>

--- a/web/static/googledrive/connect/error.js
+++ b/web/static/googledrive/connect/error.js
@@ -1,8 +1,14 @@
-// Display the error message in the page too, not just as a URL parameter.
-
-const param = new URLSearchParams(window.location.search).get("error");
+// Display the error message in the page, not just as a URL parameter.
+const err = new URLSearchParams(window.location.search).get("error");
 const elem = document.getElementById("error");
 
-if (param) {
-  elem.textContent = param;
+if (err) {
+  elem.textContent = err;
 }
+
+// Allow the user to retry initializing the connection.
+document.getElementById("retry").onclick = function () {
+  const id = new URLSearchParams(window.location.search).get("cid");
+  const origin = new URLSearchParams(window.location.search).get("origin");
+  window.location.href = "./?cid=".concat(id, "&origin=", origin);
+};

--- a/web/static/googleforms/connect/error.html
+++ b/web/static/googleforms/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>autokitteh Google Forms Integration - Error!</title>
+    <title>AutoKitteh / Google Forms - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -40,7 +40,7 @@
     <p class="error" id="error"></p>
 
     <p class="info">
-      <a href="../connect" class="info">Try to create another connection</a>
+      <button class="submit-btn" id="retry">Try Again</button>
     </p>
   </body>
 </html>

--- a/web/static/googleforms/connect/error.html
+++ b/web/static/googleforms/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AutoKitteh / Google Forms - Connection Error</title>
+    <title>AutoKitteh - Google Forms - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -27,7 +27,7 @@
 
   <body>
     <a href="/" target="_self">
-      <img class="banner" src="/static/banner.svg" alt="autokitteh" />
+      <img class="banner" src="/static/banner.svg" alt="AutoKitteh" />
     </a>
 
     <table class="title">

--- a/web/static/googleforms/connect/error.js
+++ b/web/static/googleforms/connect/error.js
@@ -1,8 +1,14 @@
-// Display the error message in the page too, not just as a URL parameter.
-
-const param = new URLSearchParams(window.location.search).get("error");
+// Display the error message in the page, not just as a URL parameter.
+const err = new URLSearchParams(window.location.search).get("error");
 const elem = document.getElementById("error");
 
-if (param) {
-  elem.textContent = param;
+if (err) {
+  elem.textContent = err;
 }
+
+// Allow the user to retry initializing the connection.
+document.getElementById("retry").onclick = function () {
+  const id = new URLSearchParams(window.location.search).get("cid");
+  const origin = new URLSearchParams(window.location.search).get("origin");
+  window.location.href = "./?cid=".concat(id, "&origin=", origin);
+};

--- a/web/static/googlesheets/connect/error.html
+++ b/web/static/googlesheets/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AutoKitteh / Google Sheets - Connection Error</title>
+    <title>AutoKitteh - Google Sheets - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -27,7 +27,7 @@
 
   <body>
     <a href="/" target="_self">
-      <img class="banner" src="/static/banner.svg" alt="autokitteh" />
+      <img class="banner" src="/static/banner.svg" alt="AutoKitteh" />
     </a>
 
     <table class="title">

--- a/web/static/googlesheets/connect/error.html
+++ b/web/static/googlesheets/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>autokitteh Google Sheets Integration - Error!</title>
+    <title>AutoKitteh / Google Sheets - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -40,7 +40,7 @@
     <p class="error" id="error"></p>
 
     <p class="info">
-      <a href="../connect" class="info">Try to create another connection</a>
+      <button class="submit-btn" id="retry">Try Again</button>
     </p>
   </body>
 </html>

--- a/web/static/googlesheets/connect/error.js
+++ b/web/static/googlesheets/connect/error.js
@@ -1,8 +1,14 @@
-// Display the error message in the page too, not just as a URL parameter.
-
-const param = new URLSearchParams(window.location.search).get("error");
+// Display the error message in the page, not just as a URL parameter.
+const err = new URLSearchParams(window.location.search).get("error");
 const elem = document.getElementById("error");
 
-if (param) {
-  elem.textContent = param;
+if (err) {
+  elem.textContent = err;
 }
+
+// Allow the user to retry initializing the connection.
+document.getElementById("retry").onclick = function () {
+  const id = new URLSearchParams(window.location.search).get("cid");
+  const origin = new URLSearchParams(window.location.search).get("origin");
+  window.location.href = "./?cid=".concat(id, "&origin=", origin);
+};

--- a/web/static/i/http/connect/error.html
+++ b/web/static/i/http/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>autokitteh HTTP Integration - Error!</title>
+    <title>AutoKitteh / HTTP - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -40,7 +40,7 @@
     <p class="error" id="error"></p>
 
     <p class="info">
-      <a href="../connect" class="info">Try to create another connection</a>
+      <button class="submit-btn" id="retry">Try Again</button>
     </p>
   </body>
 </html>

--- a/web/static/i/http/connect/error.html
+++ b/web/static/i/http/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AutoKitteh / HTTP - Connection Error</title>
+    <title>AutoKitteh - HTTP - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -27,7 +27,7 @@
 
   <body>
     <a href="/" target="_self">
-      <img class="banner" src="/static/banner.svg" alt="autokitteh" />
+      <img class="banner" src="/static/banner.svg" alt="AutoKitteh" />
     </a>
 
     <table class="title">

--- a/web/static/i/http/connect/error.js
+++ b/web/static/i/http/connect/error.js
@@ -1,8 +1,14 @@
-// Display the error message in the page too, not just as a URL parameter.
-
-const param = new URLSearchParams(window.location.search).get("error");
+// Display the error message in the page, not just as a URL parameter.
+const err = new URLSearchParams(window.location.search).get("error");
 const elem = document.getElementById("error");
 
-if (param) {
-  elem.textContent = param;
+if (err) {
+  elem.textContent = err;
 }
+
+// Allow the user to retry initializing the connection.
+document.getElementById("retry").onclick = function () {
+  const id = new URLSearchParams(window.location.search).get("cid");
+  const origin = new URLSearchParams(window.location.search).get("origin");
+  window.location.href = "./?cid=".concat(id, "&origin=", origin);
+};

--- a/web/static/jira/connect/error.html
+++ b/web/static/jira/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AutoKitteh / Atlassian Jira - Connection Error</title>
+    <title>AutoKitteh - Atlassian Jira - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"

--- a/web/static/jira/connect/error.html
+++ b/web/static/jira/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AutoKitteh Atlassian Jira Integration - Error!</title>
+    <title>AutoKitteh / Atlassian Jira - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -38,7 +38,7 @@
     <p class="error" id="error"></p>
 
     <p class="info">
-      <a href="../connect" class="info">Try to create another connection</a>
+      <button class="submit-btn" id="retry">Try Again</button>
     </p>
   </body>
 </html>

--- a/web/static/jira/connect/error.js
+++ b/web/static/jira/connect/error.js
@@ -1,8 +1,14 @@
-// Display the error message in the page too, not just as a URL parameter.
-
-const param = new URLSearchParams(window.location.search).get("error");
+// Display the error message in the page, not just as a URL parameter.
+const err = new URLSearchParams(window.location.search).get("error");
 const elem = document.getElementById("error");
 
-if (param) {
-  elem.textContent = param;
+if (err) {
+  elem.textContent = err;
 }
+
+// Allow the user to retry initializing the connection.
+document.getElementById("retry").onclick = function () {
+  const id = new URLSearchParams(window.location.search).get("cid");
+  const origin = new URLSearchParams(window.location.search).get("origin");
+  window.location.href = "./?cid=".concat(id, "&origin=", origin);
+};

--- a/web/static/slack/connect/error.html
+++ b/web/static/slack/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>autokitteh Slack Integration - Error!</title>
+    <title>AutoKitteh / Slack - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -38,7 +38,7 @@
     <p class="error" id="error"></p>
 
     <p class="info">
-      <a href="../connect" class="info">Try to create another connection</a>
+      <button class="submit-btn" id="retry">Try Again</button>
     </p>
   </body>
 </html>

--- a/web/static/slack/connect/error.html
+++ b/web/static/slack/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AutoKitteh / Slack - Connection Error</title>
+    <title>AutoKitteh - Slack - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -27,7 +27,7 @@
 
   <body>
     <a href="/" target="_self">
-      <img class="banner" src="/static/banner.svg" alt="autokitteh" />
+      <img class="banner" src="/static/banner.svg" alt="AutoKitteh" />
     </a>
 
     <table class="title">

--- a/web/static/slack/connect/error.js
+++ b/web/static/slack/connect/error.js
@@ -1,8 +1,14 @@
-// Display the error message in the page too, not just as a URL parameter.
-
-const param = new URLSearchParams(window.location.search).get("error");
+// Display the error message in the page, not just as a URL parameter.
+const err = new URLSearchParams(window.location.search).get("error");
 const elem = document.getElementById("error");
 
-if (param) {
-  elem.textContent = param;
+if (err) {
+  elem.textContent = err;
 }
+
+// Allow the user to retry initializing the connection.
+document.getElementById("retry").onclick = function () {
+  const id = new URLSearchParams(window.location.search).get("cid");
+  const origin = new URLSearchParams(window.location.search).get("origin");
+  window.location.href = "./?cid=".concat(id, "&origin=", origin);
+};

--- a/web/static/twilio/connect/error.html
+++ b/web/static/twilio/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AutoKitteh / Twilio - Connection Error</title>
+    <title>AutoKitteh - Twilio - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -27,7 +27,7 @@
 
   <body>
     <a href="/" target="_self">
-      <img class="banner" src="/static/banner.svg" alt="autokitteh" />
+      <img class="banner" src="/static/banner.svg" alt="AutoKitteh" />
     </a>
 
     <table class="title">

--- a/web/static/twilio/connect/error.html
+++ b/web/static/twilio/connect/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>autokitteh Twilio Integration - Error!</title>
+    <title>AutoKitteh / Twilio - Connection Error</title>
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -38,7 +38,7 @@
     <p class="error" id="error"></p>
 
     <p class="info">
-      <a href="../connect" class="info">Try to create another connection</a>
+      <button class="submit-btn" id="retry">Try Again</button>
     </p>
   </body>
 </html>

--- a/web/static/twilio/connect/error.js
+++ b/web/static/twilio/connect/error.js
@@ -1,8 +1,14 @@
-// Display the error message in the page too, not just as a URL parameter.
-
-const param = new URLSearchParams(window.location.search).get("error");
+// Display the error message in the page, not just as a URL parameter.
+const err = new URLSearchParams(window.location.search).get("error");
 const elem = document.getElementById("error");
 
-if (param) {
-  elem.textContent = param;
+if (err) {
+  elem.textContent = err;
 }
+
+// Allow the user to retry initializing the connection.
+document.getElementById("retry").onclick = function () {
+  const id = new URLSearchParams(window.location.search).get("cid");
+  const origin = new URLSearchParams(window.location.search).get("origin");
+  window.location.href = "./?cid=".concat(id, "&origin=", origin);
+};


### PR DESCRIPTION
I wish we could reuse a single copy of these files - but Go file embedding doesn't support symbolic links.

We might use in the future a single dynamic `error.html` file - single template but different titles and logos.

Also, there's a tiny fix and auto-formatting by Prettier in `web/static/github/connect/error.html`