### PR TITLE
ENG-1103 Part 1: accept optional form ID in Google Forms connections

### DIFF
--- a/integrations/google/creds.go
+++ b/integrations/google/creds.go
@@ -83,6 +83,7 @@ func (h handler) saveFormID(ctx context.Context, c sdkintegrations.ConnectionIni
 		return nil
 	}
 
+	// Sanity check: the connection ID is valid.
 	cid, err := sdktypes.StrictParseConnectionID(c.ConnectionID)
 	if err != nil {
 		return fmt.Errorf("connection ID parsing error: %w", err)

--- a/integrations/google/creds.go
+++ b/integrations/google/creds.go
@@ -1,7 +1,10 @@
 package google
 
 import (
+	"fmt"
 	"net/http"
+	"net/url"
+	"regexp"
 	"strings"
 
 	"go.uber.org/zap"
@@ -16,11 +19,11 @@ const (
 	contentTypeForm   = "application/x-www-form-urlencoded"
 )
 
-// HandleCreds saves a new autokitteh connection with a user-submitted token.
+// HandleCreds saves a new AutoKitteh connection with a user-submitted JSON key.
+// It also acts as a passthrough for the OAuth connection mode, to save optional
+// details (e.g. Google Form ID), to support and manage incoming events.
 func (h handler) HandleCreds(w http.ResponseWriter, r *http.Request) {
 	c, l := sdkintegrations.NewConnectionInit(h.logger, w, r, desc)
-
-	l.Warn("HEADERS", zap.Any("headers", r.Header)) // TODO: Remove this debug line.
 
 	// Check "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
@@ -36,5 +39,44 @@ func (h handler) HandleCreds(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c.Finalize(sdktypes.EncodeVars(&vars.Vars{JSON: r.Form.Get("json")}))
+	// Validate input: Google Forms ID.
+	formID := r.PostFormValue("form_id")
+	if formID != "" {
+		ok, err := regexp.MatchString(`[\w-]{20,}`, formID)
+		if err != nil {
+			l.Error("Failed to validate form ID", zap.Error(err))
+			c.Abort(fmt.Sprintf("form ID validation error: %v", err))
+			return
+		}
+		if !ok {
+			c.Abort(fmt.Sprintf("invalid Google Forms ID %q", formID))
+			return
+		}
+	}
+
+	switch r.PostFormValue("auth_type") {
+	// GCP service-account JSON-key connection? Save the JSON key.
+	case "json":
+		c.Finalize(sdktypes.EncodeVars(&vars.Vars{JSON: r.PostFormValue("json"), FormID: formID}))
+		// TODO(ENG-1103): Create watches for the form's event, if the ID isn't empty.
+
+	// User OAuth connect? Redirect to AutoKitteh's OAuth starting point.
+	case "oauth":
+		// TODO(ENG-1103): Save the form ID.
+		http.Redirect(w, r, oauthURL(c, r.PostForm), http.StatusFound)
+
+	// Unknown mode.
+	default:
+		c.Abort(fmt.Sprintf("unexpected authentication type %q", r.PostFormValue("auth_type")))
+	}
+}
+
+func oauthURL(c sdkintegrations.ConnectionInit, form url.Values) string {
+	urlPath := "/oauth/start/google%s?cid=%s&origin=%s"
+
+	// Narrow down the requested scopes?
+	oauthScopes := form.Get("auth_scopes")
+
+	// Remember the AutoKitteh connection ID and connection origin.
+	return fmt.Sprintf(urlPath, oauthScopes, c.ConnectionID, c.Origin)
 }

--- a/integrations/google/creds.go
+++ b/integrations/google/creds.go
@@ -20,6 +20,8 @@ const (
 func (h handler) HandleCreds(w http.ResponseWriter, r *http.Request) {
 	c, l := sdkintegrations.NewConnectionInit(h.logger, w, r, desc)
 
+	l.Warn("HEADERS", zap.Any("headers", r.Header)) // TODO: Remove this debug line.
+
 	// Check "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
 	if !strings.HasPrefix(contentType, contentTypeForm) {

--- a/integrations/google/internal/vars/vars.go
+++ b/integrations/google/internal/vars/vars.go
@@ -7,9 +7,11 @@ import (
 type Vars struct {
 	OAuthData string `var:"secret"`
 	JSON      string `var:"secret"`
+	FormID    string
 }
 
 var (
 	OAuthData = sdktypes.NewSymbol("OAuthData")
 	JSON      = sdktypes.NewSymbol("JSON")
+	FormID    = sdktypes.NewSymbol("FormID")
 )

--- a/integrations/google/oauth.go
+++ b/integrations/google/oauth.go
@@ -21,10 +21,11 @@ import (
 type handler struct {
 	logger *zap.Logger
 	oauth  sdkservices.OAuth
+	vars   sdkservices.Vars
 }
 
-func NewHTTPHandler(l *zap.Logger, o sdkservices.OAuth) handler {
-	return handler{logger: l, oauth: o}
+func NewHTTPHandler(l *zap.Logger, o sdkservices.OAuth, v sdkservices.Vars) handler {
+	return handler{logger: l, oauth: o, vars: v}
 }
 
 // HandleOAuth receives an inbound redirect request from autokitteh's OAuth
@@ -75,6 +76,8 @@ func (h handler) HandleOAuth(w http.ResponseWriter, r *http.Request) {
 		c.Abort("Google user details error")
 		return
 	}
+
+	// TODO(ENG-1103): Create watches for a form's events, if we have its ID.
 
 	c.Finalize(sdktypes.EncodeVars(&vars.Vars{OAuthData: raw}).
 		Append(data.ToVars()...).

--- a/integrations/google/oauth.go
+++ b/integrations/google/oauth.go
@@ -79,9 +79,10 @@ func (h handler) HandleOAuth(w http.ResponseWriter, r *http.Request) {
 
 	// TODO(ENG-1103): Create watches for a form's events, if we have its ID.
 
-	c.Finalize(sdktypes.EncodeVars(&vars.Vars{OAuthData: raw}).
-		Append(data.ToVars()...).
-		Append(user...))
+	// Encoding "OAuthData" and "JSON", but not "FormID", so we don't overwrite
+	// the value that was already written there by the creds.go passthrough.
+	c.Finalize(sdktypes.NewVars(sdktypes.NewVar(vars.OAuthData, raw, true)).
+		Set(vars.JSON, "", true).Append(data.ToVars()...).Append(user...))
 }
 
 func (h handler) tokenSource(ctx context.Context, t *oauth2.Token) oauth2.TokenSource {

--- a/integrations/google/server.go
+++ b/integrations/google/server.go
@@ -19,11 +19,11 @@ const (
 	oauthPath = "/google/oauth"
 )
 
-func Start(l *zap.Logger, mux *http.ServeMux, o sdkservices.OAuth, d sdkservices.Dispatcher) {
+func Start(l *zap.Logger, mux *http.ServeMux, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.Dispatcher) {
 	uiPath := "GET " + desc.ConnectionURL().Path + "/"
 
 	// New connection UIs + handlers.
-	h := NewHTTPHandler(l, o)
+	h := NewHTTPHandler(l, o, v)
 	mux.Handle(uiPath, http.FileServer(http.FS(static.GoogleWebContent)))
 
 	urlPath := strings.ReplaceAll(uiPath, "google", "gmail")

--- a/internal/backend/integrations/integrations.go
+++ b/internal/backend/integrations/integrations.go
@@ -71,7 +71,7 @@ func Start(_ context.Context, l *zap.Logger, mux *http.ServeMux, vars sdkservice
 	confluence.Start(l, mux, vars, o, d)
 	github.Start(l, mux, vars, o, d)
 	gemini.Start(l, mux)
-	google.Start(l, mux, o, d)
+	google.Start(l, mux, vars, o, d)
 	httpint.Start(l, mux, d, c, p)
 	jira.Start(l, mux, vars, o, d)
 	slack.Start(l, mux, vars, d)

--- a/web/static/googleforms/connect/form.js
+++ b/web/static/googleforms/connect/form.js
@@ -9,6 +9,17 @@ function toggleTab(id) {
   }
   document.getElementById("toggle" + id).classList.add("active");
 
+  // Synchronize the form ID text fields.
+  if (id === "tab1") {
+    jsonValue = document.getElementById("formIdJson").value;
+    document.getElementById("formIdOauth").value = jsonValue;
+    document.getElementById("formIdJson").value = "";
+  } else {
+    oauthValue = document.getElementById("formIdOauth").value;
+    document.getElementById("formIdJson").value = jsonValue;
+    document.getElementById("formIdOauth").value = "";
+  }
+
   // Update the tab contents.
   const tabs = document.getElementsByClassName("tab");
   for (let i = 0; i < tabs.length; i++) {

--- a/web/static/googleforms/connect/index.html
+++ b/web/static/googleforms/connect/index.html
@@ -49,40 +49,38 @@
       </button>
     </div>
 
-    <!-- TODO(ENG-799): remove ID once its unused -->
-    <form id="save-form" method="post" action="/google/save">
-      <div class="tab" id="tab1">
-        <p class="info">Information:</p>
-        <ul class="links">
-          <li>
-            Guide:
-            <a
-              href="https://docs.autokitteh.com/config/integrations/google"
-              target="_blank"
-              class="info"
-            >
-              configuring the Google integration
-            </a>
-          </li>
-          <li>
-            <a
-              href="https://developers.google.com/workspace/guides/auth-overview"
-              target="_blank"
-              class="info"
-            >
-              Learn about authentication and authorization
-            </a>
-          </li>
-        </ul>
+    <div class="tab" id="tab1">
+      <p class="info">Information:</p>
+      <ul class="links">
+        <li>
+          Guide:
+          <a
+            href="https://docs.autokitteh.com/config/integrations/google"
+            target="_blank"
+            class="info"
+          >
+            configuring the Google integration
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://developers.google.com/workspace/guides/auth-overview"
+            target="_blank"
+            class="info"
+          >
+            Learn about authentication and authorization
+          </a>
+        </li>
+      </ul>
 
+      <!-- TODO(ENG-799): remove ID once its unused -->
+      <form id="save-form-oauth" method="post" action="/google/save">
         <div class="form-group">
-          <label for="form_id_oauth">
-            Optional: Form ID (To Receive Events)
-          </label>
+          <label for="form_id">Optional: Form ID (To Receive Events)</label>
           <input
             type="text"
             id="formIdOauth"
-            name="form_id_oauth"
+            name="form_id"
             autocomplete="off"
             spellcheck="false"
             pattern="[\w-]{20,}"
@@ -97,57 +95,58 @@
         </div>
 
         <button type="submit" class="submit-btn">Start OAuth Flow</button>
-      </div>
+      </form>
+    </div>
 
-      <div class="tab" id="tab2">
-        <p class="info">Information:</p>
-        <ul class="links">
-          <li>
-            <a
-              href="https://cloud.google.com/iam/docs/service-account-overview"
-              target="_blank"
-              class="info"
-            >
-              GCP service accounts overview
-            </a>
-          </li>
-          <li>
-            <a
-              href="https://cloud.google.com/iam/docs/service-account-creds"
-              target="_blank"
-              class="info"
-            >
-              Service account credentials
-            </a>
-          </li>
-          <li>
-            <a
-              href="https://cloud.google.com/iam/docs/keys-create-delete"
-              target="_blank"
-              class="info"
-            >
-              Create and delete service account keys
-            </a>
-          </li>
-          <li>
-            <a
-              href="https://cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys"
-              target="_blank"
-              class="info"
-            >
-              Best practices for managing service account keys
-            </a>
-          </li>
-        </ul>
+    <div class="tab" id="tab2">
+      <p class="info">Information:</p>
+      <ul class="links">
+        <li>
+          <a
+            href="https://cloud.google.com/iam/docs/service-account-overview"
+            target="_blank"
+            class="info"
+          >
+            GCP service accounts overview
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://cloud.google.com/iam/docs/service-account-creds"
+            target="_blank"
+            class="info"
+          >
+            Service account credentials
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://cloud.google.com/iam/docs/keys-create-delete"
+            target="_blank"
+            class="info"
+          >
+            Create and delete service account keys
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys"
+            target="_blank"
+            class="info"
+          >
+            Best practices for managing service account keys
+          </a>
+        </li>
+      </ul>
 
+      <!-- TODO(ENG-799): remove ID once its unused -->
+      <form id="save-form-json" method="post" action="/google/save">
         <div class="form-group">
-          <label for="form_id_json">
-            Optional: Form ID (To Receive Events)
-          </label>
+          <label for="form_id">Optional: Form ID (To Receive Events)</label>
           <input
             type="text"
             id="formIdJson"
-            name="form_id_json"
+            name="form_id"
             autocomplete="off"
             spellcheck="false"
             pattern="[\w-]{20,}"
@@ -168,14 +167,17 @@
         </div>
 
         <button type="submit" class="submit-btn">Save Connection</button>
-      </div>
-    </form>
+      </form>
+    </div>
 
     <!-- TODO(ENG-799) -->
     <script>
       const queryString = window.location.search;
       document
-        .getElementById("save-form")
+        .getElementById("save-form-json")
+        .setAttribute("action", "/google/save" + queryString);
+      document
+        .getElementById("save-form-oauth")
         .setAttribute("action", "/google/save" + queryString);
     </script>
   </body>

--- a/web/static/googleforms/connect/index.html
+++ b/web/static/googleforms/connect/index.html
@@ -75,6 +75,9 @@
 
       <!-- TODO(ENG-799): remove ID once its unused -->
       <form id="save-form-oauth" method="post" action="/google/save">
+        <input type="hidden" name="auth_scopes" value="forms" />
+        <input type="hidden" name="auth_type" value="oauth" />
+
         <div class="form-group">
           <label for="form_id">Optional: Form ID (To Receive Events)</label>
           <input
@@ -141,6 +144,9 @@
 
       <!-- TODO(ENG-799): remove ID once its unused -->
       <form id="save-form-json" method="post" action="/google/save">
+        <input type="hidden" name="auth_scopes" value="forms" />
+        <input type="hidden" name="auth_types" value="json" />
+
         <div class="form-group">
           <label for="form_id">Optional: Form ID (To Receive Events)</label>
           <input

--- a/web/static/googleforms/connect/index.html
+++ b/web/static/googleforms/connect/index.html
@@ -49,89 +49,117 @@
       </button>
     </div>
 
-    <div class="tab" id="tab1">
-      <p class="info">Information:</p>
-      <ul class="links">
-        <li>
-          Guide:
-          <a
-            href="https://docs.autokitteh.com/config/integrations/google"
-            target="_blank"
-            class="info"
-          >
-            configuring the Google integration
-          </a>
-        </li>
-        <li>
-          <a
-            href="https://developers.google.com/workspace/guides/auth-overview"
-            target="_blank"
-            class="info"
-          >
-            Learn about authentication and authorization
-          </a>
-        </li>
-      </ul>
+    <!-- TODO(ENG-799): remove ID once its unused -->
+    <form id="save-form" method="post" action="/google/save">
+      <div class="tab" id="tab1">
+        <p class="info">Information:</p>
+        <ul class="links">
+          <li>
+            Guide:
+            <a
+              href="https://docs.autokitteh.com/config/integrations/google"
+              target="_blank"
+              class="info"
+            >
+              configuring the Google integration
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://developers.google.com/workspace/guides/auth-overview"
+              target="_blank"
+              class="info"
+            >
+              Learn about authentication and authorization
+            </a>
+          </li>
+        </ul>
 
-      <p class="info">
-        Click the button below to authorize the
-        <strong>AutoKitteh</strong> service
-      </p>
-      <!-- TODO(ENG-799): remove ID once its unused -->
-      <a id="oauth-link" href="/oauth/start/googleforms" class="clickable"
-        >Start OAuth Flow</a
-      >
-    </div>
+        <div class="form-group">
+          <label for="form_id_oauth">
+            Optional: Form ID (To Receive Events)
+          </label>
+          <input
+            type="text"
+            id="formIdOauth"
+            name="form_id_oauth"
+            autocomplete="off"
+            spellcheck="false"
+            pattern="[\w-]{20,}"
+          />
+        </div>
 
-    <div class="tab" id="tab2">
-      <p class="info">Information:</p>
-      <ul class="links">
-        <li>
-          <a
-            href="https://cloud.google.com/iam/docs/service-account-overview"
-            target="_blank"
-            class="info"
-          >
-            GCP service accounts overview
-          </a>
-        </li>
-        <li>
-          <a
-            href="https://cloud.google.com/iam/docs/service-account-creds"
-            target="_blank"
-            class="info"
-          >
-            Service account credentials
-          </a>
-        </li>
-        <li>
-          <a
-            href="https://cloud.google.com/iam/docs/keys-create-delete"
-            target="_blank"
-            class="info"
-          >
-            Create and delete service account keys
-          </a>
-        </li>
-        <li>
-          <a
-            href="https://cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys"
-            target="_blank"
-            class="info"
-          >
-            Best practices for managing service account keys
-          </a>
-        </li>
-      </ul>
+        <div class="form-group">
+          <p class="info">
+            Click the button below to authorize the
+            <strong>AutoKitteh</strong> service
+          </p>
+        </div>
 
-      <!-- TODO(ENG-799): remove ID once its unused -->
-      <form id="save-json-form" method="post" action="/google/save">
+        <button type="submit" class="submit-btn">Start OAuth Flow</button>
+      </div>
+
+      <div class="tab" id="tab2">
+        <p class="info">Information:</p>
+        <ul class="links">
+          <li>
+            <a
+              href="https://cloud.google.com/iam/docs/service-account-overview"
+              target="_blank"
+              class="info"
+            >
+              GCP service accounts overview
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://cloud.google.com/iam/docs/service-account-creds"
+              target="_blank"
+              class="info"
+            >
+              Service account credentials
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://cloud.google.com/iam/docs/keys-create-delete"
+              target="_blank"
+              class="info"
+            >
+              Create and delete service account keys
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys"
+              target="_blank"
+              class="info"
+            >
+              Best practices for managing service account keys
+            </a>
+          </li>
+        </ul>
+
+        <div class="form-group">
+          <label for="form_id_json">
+            Optional: Form ID (To Receive Events)
+          </label>
+          <input
+            type="text"
+            id="formIdJson"
+            name="form_id_json"
+            autocomplete="off"
+            spellcheck="false"
+            pattern="[\w-]{20,}"
+          />
+        </div>
+
         <div class="form-group">
           <label for="json">JSON Key</label>
           <textarea
             name="json"
-            rows="14"
-            cols="65"
+            rows="8"
+            cols="64"
             wrap="soft"
             autocomplete="off"
             spellcheck="false"
@@ -140,17 +168,14 @@
         </div>
 
         <button type="submit" class="submit-btn">Save Connection</button>
-      </form>
-    </div>
+      </div>
+    </form>
 
     <!-- TODO(ENG-799) -->
     <script>
       const queryString = window.location.search;
       document
-        .getElementById("oauth-link")
-        .setAttribute("href", "/oauth/start/google" + queryString);
-      document
-        .getElementById("save-json-form")
+        .getElementById("save-form")
         .setAttribute("action", "/google/save" + queryString);
     </script>
   </body>

--- a/web/static/googleforms/connect/styles.css
+++ b/web/static/googleforms/connect/styles.css
@@ -98,9 +98,21 @@ a.info:hover {
   background-color: #2980b9;
 }
 
+.form-group {
+  margin-bottom: 32px;
+}
+
 .form-group label {
   display: block;
   margin-bottom: 4px;
+}
+
+.form-group input {
+  width: 530px;
+  padding: 8px;
+  margin-bottom: 4px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
 }
 
 .form-group textarea {
@@ -111,7 +123,6 @@ a.info:hover {
 
 .submit-btn {
   display: inline-block;
-  margin-top: 32px;
   padding: 10px 20px;
   background-color: #3498db;
   color: white;


### PR DESCRIPTION
Changes in the Google Forms connection initialization flow, to allow the user to specify an optional form ID.

This will let AK create event watches for this form (in the next PR - part 2), to enable incoming events.

@RonenMars - FYI changes in the connection UI for Google Forms.