### PR TITLE
python: Don't run user code when building

### DIFF
--- a/runtimes/pythonrt/py_test.go
+++ b/runtimes/pythonrt/py_test.go
@@ -200,7 +200,7 @@ func Test_pyExports(t *testing.T) {
 
 	expected := []Export{
 		{File: "simple.py", Name: "greet", Line: 11},
-		{File: "simple.py", Name: "printer", Line: 22},
+		{File: "simple.py", Name: "printer", Line: 23},
 	}
 	require.Equal(t, expected, exports)
 


### PR DESCRIPTION
Users can run code on module level, say start connections. Changed inspect to use the ast instead of importing the user module.

Fixes ENG-1211