### PR TITLE
fix: duplicate log records

### DIFF
--- a/internal/backend/db/dbgorm/sessions_test.go
+++ b/internal/backend/db/dbgorm/sessions_test.go
@@ -411,7 +411,7 @@ func TestSessionLogRecordNextPageTokenNotEmpty(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(res.Log.Records()), 2)
 	assert.Equal(t, res.TotalCount, int64(3))
-	assert.Equal(t, res.PaginationResult.NextPageToken, "2")
+	assert.NotEmpty(t, res.NextPageToken)
 
 	// Get Next Batch to exhaust next page token
 	res, err = f.gormdb.GetSessionLog(context.Background(),


### PR DESCRIPTION
this fix assumes all log records are sequentials
and that time.micro is fine grained enough

closes ENG-1187 
might require a new design later