### PR TITLE
Improve logging of intercepted HTTP

### DIFF
--- a/internal/backend/httpsvc/config.go
+++ b/internal/backend/httpsvc/config.go
@@ -18,13 +18,17 @@ type ngrokConfig struct {
 }
 
 type LoggerConfig struct {
-	ImportantLevel    zap.AtomicLevel `koanf:"important_log_level"`
-	NonimportantLevel zap.AtomicLevel `koanf:"nonimportant_log_level"`
-	ErrorsLevel       zap.AtomicLevel `koanf:"trace_errors_log_level"`
+	ImportantLevel   zap.AtomicLevel `koanf:"important_log_level"`
+	UnimportantLevel zap.AtomicLevel `koanf:"unimportant_log_level"`
+	ErrorsLevel      zap.AtomicLevel `koanf:"trace_errors_log_level"`
 
-	// Requests that their paths matches any one of these regexes will be
-	// logged in the nonimportant log level.
-	NonimportantRegexes []string `koanf:"nonimportant_regexes"`
+	// URL requests with paths that match any one of these regular
+	// expressions will be logged in the nonimportant log level.
+	UnimportantRegexes []string `koanf:"nonimportant_regexes"`
+
+	// URL requests with paths that match any one of these
+	// regular expressions will not be logged at all.
+	UnloggedRegexes []string `koanf:"unlogged_regexes"`
 }
 
 type CORSConfig struct {
@@ -70,14 +74,15 @@ var Configs = configset.Set[Config]{
 			AllowCredentials: true,
 		},
 		Logger: LoggerConfig{
-			NonimportantLevel: zap.NewAtomicLevelAt(zap.DebugLevel),
-			ImportantLevel:    zap.NewAtomicLevelAt(zap.InfoLevel),
-			ErrorsLevel:       zap.NewAtomicLevelAt(zap.WarnLevel),
-			NonimportantRegexes: []string{
-				`\.(css|html|ico|js|png|svg|txt)$`, // Static web content
-				`^/autokitteh.+/(Get|List)$`,       // gRPC Get and List methods
-				`/(healthz|readyz)$`,               // Kubernetes health checks
-				`/$`,                               // Dynamic web content and webhooks
+			UnimportantLevel: zap.NewAtomicLevelAt(zap.DebugLevel),
+			ImportantLevel:   zap.NewAtomicLevelAt(zap.InfoLevel),
+			ErrorsLevel:      zap.NewAtomicLevelAt(zap.WarnLevel),
+			UnimportantRegexes: []string{
+				`^/autokitteh.+/(Get|List)$`, // gRPC Get and List methods
+				`/(healthz|readyz)$`,         // Kubernetes health checks
+			},
+			UnloggedRegexes: []string{
+				`\.(css|html|ico|js|png|svg|txt|webmanifest)$`, // Static web content
 			},
 		},
 	},

--- a/internal/backend/httpsvc/config.go
+++ b/internal/backend/httpsvc/config.go
@@ -74,11 +74,10 @@ var Configs = configset.Set[Config]{
 			ImportantLevel:    zap.NewAtomicLevelAt(zap.InfoLevel),
 			ErrorsLevel:       zap.NewAtomicLevelAt(zap.WarnLevel),
 			NonimportantRegexes: []string{
-				`.*/List.*`,
-				`.*/Get.*`,
-				`/healthz`,
-				`/readyz`,
-				`/`,
+				`\.(css|html|ico|js|png|svg|txt)$`, // Static web content
+				`^/autokitteh.+/(Get|List)$`,       // gRPC Get and List methods
+				`/(healthz|readyz)$`,               // Kubernetes health checks
+				`/$`,                               // Dynamic web content and webhooks
 			},
 		},
 	},

--- a/internal/backend/httpsvc/intercept.go
+++ b/internal/backend/httpsvc/intercept.go
@@ -60,6 +60,7 @@ func intercept(z *zap.Logger, cfg *LoggerConfig, extractors []RequestLogExtracto
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		if unlogged.MatchString(r.URL.Path) {
+			next.ServeHTTP(w, r)
 			return
 		}
 

--- a/internal/backend/httpsvc/intercept.go
+++ b/internal/backend/httpsvc/intercept.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/fixtures"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
 )
 
 type ctxKey string
@@ -51,26 +51,24 @@ func (r *responseInterceptor) Flush() {
 type RequestLogExtractor func(*http.Request) []zap.Field
 
 func intercept(z *zap.Logger, cfg *LoggerConfig, extractors []RequestLogExtractor, next http.Handler) (http.HandlerFunc, error) {
-	res, err := kittehs.TransformError(cfg.NonimportantRegexes, regexp.Compile)
-	if err != nil {
-		return nil, fmt.Errorf("compiling important regexes: %w", err)
-	}
+	// MustCompile is appropriate here because the patterns are static
+	// and errors in them should be caught at startup. Furthermore, we
+	// combine them into a single regular expression, because efficiency is
+	// critical when we delay each and every incoming HTTP and gRPC request.
+	re := regexp.MustCompile(strings.Join(cfg.NonimportantRegexes, `|`))
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-AutoKitteh-Process-ID", fixtures.ProcessID())
 
 		z := z.With(zap.String("method", r.Method), zap.String("path", r.URL.Path))
+		msg := fmt.Sprintf("HTTP request: %s %s", r.Method, r.URL.Path)
 
 		level := cfg.ImportantLevel.Level()
-
-		for _, re := range res {
-			if re.MatchString(r.URL.Path) {
-				level = cfg.NonimportantLevel.Level()
-				break
-			}
+		if re.MatchString(r.URL.Path) {
+			level = cfg.NonimportantLevel.Level()
 		}
 
-		if ce := z.Check(level, "HTTP Request"); ce != nil {
+		if ce := z.Check(level, msg); ce != nil {
 			var fields []zap.Field
 			for _, x := range extractors {
 				fields = append(fields, x(r)...)
@@ -95,8 +93,9 @@ func intercept(z *zap.Logger, cfg *LoggerConfig, extractors []RequestLogExtracto
 			level = cfg.ErrorsLevel.Level()
 		}
 
-		if ce := z.Check(level, "HTTP Response"); ce != nil {
-			ce.Write(zap.Int("status_code", rwi.StatusCode), zap.Duration("duration", d))
+		msg = strings.Replace(msg, "request", "response", 1)
+		if ce := z.Check(level, msg); ce != nil {
+			ce.Write(zap.Int("statusCode", rwi.StatusCode), zap.Duration("duration", d))
 		}
 	}, nil
 }


### PR DESCRIPTION
1. Add the URL path to the log message (better when exploring logs in DD)
2. Fix: not everything that **contains** "/" is unimportant
3. Optimize specification of unimportant HTTP request URLs
4. Don't log static web content at all - it's unnecessary spam