### PR TITLE
Refactor: improve connection-init abort errors

### DIFF
--- a/integrations/atlassian/confluence/oauth.go
+++ b/integrations/atlassian/confluence/oauth.go
@@ -27,41 +27,41 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 	e := r.FormValue("error")
 	if e != "" {
 		l.Warn("OAuth redirect reported an error", zap.Error(errors.New(e)))
-		c.Abort(e)
+		c.AbortBadRequest(e)
 		return
 	}
 
 	_, data, err := sdkintegrations.GetOAuthDataFromURL(r.URL)
 	if err != nil {
 		l.Warn("Invalid data in OAuth redirect request", zap.Error(err))
-		c.Abort("invalid data parameter")
+		c.AbortBadRequest("invalid data parameter")
 		return
 	}
 
 	oauthToken := data.Token
 	if oauthToken == nil {
 		l.Warn("Missing token in OAuth redirect request", zap.Any("data", data))
-		c.Abort("missing OAuth token")
+		c.AbortBadRequest("missing OAuth token")
 		return
 	}
 
 	url, err := apiBaseURL()
 	if err != nil {
 		l.Warn("Invalid Atlassian base URL", zap.Error(err))
-		c.Abort("invalid Atlassian base URL")
+		c.AbortBadRequest("invalid Atlassian base URL")
 		return
 	}
 
 	// Test the OAuth token's usability and get authoritative installation details.
 	res, err := accessibleResources(l, url, oauthToken.AccessToken)
 	if err != nil {
-		c.Abort(err.Error())
+		c.AbortBadRequest(err.Error())
 		return
 	}
 
 	if len(res) > 1 {
 		l.Warn("Multiple accessible resources for single OAuth token", zap.Any("resources", res))
-		c.Abort("multiple Atlassian accessible resources")
+		c.AbortBadRequest("multiple Atlassian accessible resources")
 		return
 	}
 

--- a/integrations/atlassian/confluence/save.go
+++ b/integrations/atlassian/confluence/save.go
@@ -36,14 +36,14 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 	// Check "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
 	if !strings.HasPrefix(contentType, contentTypeForm) {
-		c.Abort("unexpected content type")
+		c.AbortBadRequest("unexpected content type")
 		return
 	}
 
 	// Read and parse POST request body.
 	if err := r.ParseForm(); err != nil {
 		l.Warn("Failed to parse incoming HTTP request", zap.Error(err))
-		c.Abort("form parsing error")
+		c.AbortBadRequest("form parsing error")
 		return
 	}
 
@@ -54,7 +54,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 	u, err := url.Parse(b)
 	if err != nil {
 		l.Warn("Failed to parse base URL", zap.Error(err))
-		c.Abort("failed to parse base URL")
+		c.AbortBadRequest("base URL parsing error")
 		return
 	}
 
@@ -76,8 +76,8 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 			// initData = initData.Set(webhookID, fmt.Sprintf("%d", id), false)
 
 			if err := deleteWebhook(l, b, e, t, id); err != nil {
-				l.Warn("Failed to delete existing webhook", zap.Error(err))
-				c.Abort("failed to delete existing webhook")
+				l.Error("Failed to delete existing webhook", zap.Error(err))
+				c.AbortISE("failed to delete existing webhook")
 				return
 			}
 		} // else {
@@ -85,8 +85,8 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 		var err error
 		id, secret, err = registerWebhook(l, b, e, t, category)
 		if err != nil {
-			l.Warn("Failed to register webhook", zap.Error(err))
-			c.Abort("failed to register webhook")
+			l.Error("Failed to register webhook", zap.Error(err))
+			c.AbortISE("failed to register webhook")
 			return
 		}
 		initData = initData.Set(webhookSecret(category), secret, true)

--- a/integrations/atlassian/confluence/save.go
+++ b/integrations/atlassian/confluence/save.go
@@ -77,7 +77,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 
 			if err := deleteWebhook(l, b, e, t, id); err != nil {
 				l.Error("Failed to delete existing webhook", zap.Error(err))
-				c.AbortISE("failed to delete existing webhook")
+				c.AbortServerError("failed to delete existing webhook")
 				return
 			}
 		} // else {
@@ -86,7 +86,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 		id, secret, err = registerWebhook(l, b, e, t, category)
 		if err != nil {
 			l.Error("Failed to register webhook", zap.Error(err))
-			c.AbortISE("failed to register webhook")
+			c.AbortServerError("failed to register webhook")
 			return
 		}
 		initData = initData.Set(webhookSecret(category), secret, true)

--- a/integrations/atlassian/jira/oauth.go
+++ b/integrations/atlassian/jira/oauth.go
@@ -79,13 +79,13 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		id, ok = registerWebhook(l, url, oauthToken.AccessToken)
 		if !ok {
-			c.AbortISE("failed to register webhook")
+			c.AbortServerError("failed to register webhook")
 			return
 		}
 	} else {
 		t, ok = extendWebhookLife(l, url, oauthToken.AccessToken, id)
 		if !ok {
-			c.AbortISE("failed to extend webhook life")
+			c.AbortServerError("failed to extend webhook life")
 			return
 		}
 	}

--- a/integrations/atlassian/jira/save.go
+++ b/integrations/atlassian/jira/save.go
@@ -23,14 +23,14 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 	// Check "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
 	if !strings.HasPrefix(contentType, contentTypeForm) {
-		c.Abort("unexpected content type")
+		c.AbortBadRequest("unexpected content type")
 		return
 	}
 
 	// Read and parse POST request body.
 	if err := r.ParseForm(); err != nil {
 		l.Warn("Failed to parse incoming HTTP request", zap.Error(err))
-		c.Abort("form parsing error")
+		c.AbortBadRequest("form parsing error")
 		return
 	}
 
@@ -41,7 +41,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 	u, err := url.Parse(b)
 	if err != nil {
 		l.Warn("Failed to parse base URL", zap.Error(err))
-		c.Abort("failed to parse base URL")
+		c.AbortBadRequest("base URL parsing error")
 		return
 	}
 

--- a/integrations/aws/save.go
+++ b/integrations/aws/save.go
@@ -32,14 +32,14 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Check "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
 	if !strings.HasPrefix(contentType, contentTypeForm) {
-		c.Abort("unexpected content type")
+		c.AbortBadRequest("unexpected content type")
 		return
 	}
 
 	// Read and parse POST request body.
 	if err := r.ParseForm(); err != nil {
 		l.Warn("Failed to parse incoming HTTP request", zap.Error(err))
-		c.Abort("form parsing error")
+		c.AbortBadRequest("form parsing error")
 		return
 	}
 

--- a/integrations/chatgpt/save.go
+++ b/integrations/chatgpt/save.go
@@ -34,14 +34,14 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Check "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
 	if !strings.HasPrefix(contentType, contentTypeForm) {
-		c.Abort("unexpected content type")
+		c.AbortBadRequest("unexpected content type")
 		return
 	}
 
 	// Read and parse POST request body.
 	if err := r.ParseForm(); err != nil {
 		l.Warn("Failed to parse incoming HTTP request", zap.Error(err))
-		c.Abort("form parsing error")
+		c.AbortBadRequest("form parsing error")
 		return
 	}
 

--- a/integrations/discord/save.go
+++ b/integrations/discord/save.go
@@ -34,14 +34,14 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Check "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
 	if !strings.HasPrefix(contentType, contentTypeForm) {
-		c.Abort("unexpected content type")
+		c.AbortBadRequest("unexpected content type")
 		return
 	}
 
 	// Read and parse POST request body.
 	if err := r.ParseForm(); err != nil {
 		l.Warn("Failed to parse incoming HTTP request", zap.Error(err))
-		c.Abort("form parsing error")
+		c.AbortBadRequest("form parsing error")
 		return
 	}
 

--- a/integrations/github/pat.go
+++ b/integrations/github/pat.go
@@ -26,14 +26,14 @@ func (h handler) handlePAT(w http.ResponseWriter, r *http.Request) {
 	// Check "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
 	if !strings.HasPrefix(contentType, contentTypeForm) {
-		c.Abort("unexpected content type")
+		c.AbortBadRequest("unexpected content type")
 		return
 	}
 
 	// Read and parse POST request body.
 	if err := r.ParseForm(); err != nil {
 		l.Warn("Failed to parse incoming HTTP request", zap.Error(err))
-		c.Abort("form parsing error")
+		c.AbortBadRequest("form parsing error")
 		return
 	}
 
@@ -47,13 +47,13 @@ func (h handler) handlePAT(w http.ResponseWriter, r *http.Request) {
 	user, _, err := client.Users.Get(ctx, "")
 	if err != nil {
 		l.Warn("Unusable GitHub PAT", zap.Error(err))
-		c.Abort("unusable PAT error: " + err.Error())
+		c.AbortBadRequest("unusable PAT error: " + err.Error())
 		return
 	}
 
 	if user == nil || user.Login == nil {
 		l.Warn("Unexpected response from GitHub API", zap.Any("user", user))
-		c.Abort("unexpected response from GitHub API")
+		c.AbortBadRequest("unexpected response from GitHub API")
 		return
 	}
 

--- a/integrations/google/creds.go
+++ b/integrations/google/creds.go
@@ -50,7 +50,7 @@ func (h handler) handleCreds(w http.ResponseWriter, r *http.Request) {
 		ok, err := regexp.MatchString(`[\w-]{20,}`, formID)
 		if err != nil {
 			l.Error("Google Forms form ID validation error", zap.Error(err))
-			c.AbortISE(fmt.Sprintf("form ID validation error: %v", err))
+			c.AbortServerError(fmt.Sprintf("form ID validation error: %v", err))
 			return
 		}
 		if !ok {
@@ -61,7 +61,7 @@ func (h handler) handleCreds(w http.ResponseWriter, r *http.Request) {
 
 		if err := h.saveFormID(r.Context(), c, formID); err != nil {
 			l.Error("Google Forms form ID saving error", zap.Error(err))
-			c.AbortISE("form ID saving error")
+			c.AbortServerError("form ID saving error")
 			return
 		}
 	}
@@ -80,7 +80,7 @@ func (h handler) handleCreds(w http.ResponseWriter, r *http.Request) {
 	// Unknown mode.
 	default:
 		l.Error("Unexpected auth type", zap.String("auth_type", r.PostFormValue("auth_type")))
-		c.AbortISE(fmt.Sprintf("unexpected auth type %q", r.PostFormValue("auth_type")))
+		c.AbortServerError(fmt.Sprintf("unexpected auth type %q", r.PostFormValue("auth_type")))
 	}
 }
 
@@ -119,19 +119,19 @@ func (h handler) finalize(ctx context.Context, c sdkintegrations.ConnectionInit,
 
 	if err := h.vars.Set(ctx, vsl...); err != nil {
 		l.Error("Connection data saving error", zap.Error(err))
-		c.AbortISE("connection data saving error")
+		c.AbortServerError("connection data saving error")
 		return
 	}
 
 	if err := forms.UpdateWatches(ctx, h.vars, cid); err != nil {
 		l.Error("Google Forms watches creation error", zap.Error(err))
-		c.AbortISE("Google Forms watches creation error")
+		c.AbortServerError("form watches creation error")
 		return
 	}
 
 	if err := gmail.UpdateWatch(ctx, h.vars, cid); err != nil {
 		l.Error("Gmail watch creation error", zap.Error(err))
-		c.AbortISE("Gmail watch creation error")
+		c.AbortServerError("Gmail watch creation error")
 		return
 	}
 

--- a/integrations/google/gemini/save.go
+++ b/integrations/google/gemini/save.go
@@ -34,14 +34,14 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Check "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
 	if !strings.HasPrefix(contentType, contentTypeForm) {
-		c.Abort("unexpected content type")
+		c.AbortBadRequest("unexpected content type")
 		return
 	}
 
 	// Read and parse POST request body.
 	if err := r.ParseForm(); err != nil {
 		l.Warn("Failed to parse incoming HTTP request", zap.Error(err))
-		c.Abort("form parsing error")
+		c.AbortBadRequest("form parsing error")
 		return
 	}
 

--- a/integrations/google/oauth.go
+++ b/integrations/google/oauth.go
@@ -87,19 +87,19 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.vars.Set(ctx, vsl...); err != nil {
 		l.Error("Connection data saving error", zap.Error(err))
-		c.AbortISE("connection data saving error")
+		c.AbortServerError("connection data saving error")
 		return
 	}
 
 	if err := forms.UpdateWatches(ctx, h.vars, cid); err != nil {
 		l.Error("Google Forms watches creation error", zap.Error(err))
-		c.AbortISE("Google Forms watches creation error")
+		c.AbortServerError("form watches creation error")
 		return
 	}
 
 	if err := gmail.UpdateWatch(ctx, h.vars, cid); err != nil {
 		l.Error("Gmail watch creation error", zap.Error(err))
-		c.AbortISE("Gmail watch creation error")
+		c.AbortServerError("Gmail watch creation error")
 		return
 	}
 

--- a/integrations/http/save.go
+++ b/integrations/http/save.go
@@ -24,14 +24,14 @@ func (h handler) handleAuth(w http.ResponseWriter, r *http.Request) {
 	// Check "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
 	if !strings.HasPrefix(contentType, contentTypeForm) {
-		c.Abort("unexpected content type")
+		c.AbortBadRequest("unexpected content type")
 		return
 	}
 
 	// Read and parse POST request body.
 	if err := r.ParseForm(); err != nil {
 		l.Warn("Failed to parse incoming HTTP request", zap.Error(err))
-		c.Abort("form parsing error")
+		c.AbortBadRequest("form parsing error")
 		return
 	}
 

--- a/integrations/slack/oauth.go
+++ b/integrations/slack/oauth.go
@@ -37,21 +37,21 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	e := r.FormValue("error")
 	if e != "" {
 		l.Warn("OAuth redirect request reported an error", zap.Error(errors.New(e)))
-		c.Abort(e)
+		c.AbortBadRequest(e)
 		return
 	}
 
 	raw, data, err := sdkintegrations.GetOAuthDataFromURL(r.URL)
 	if err != nil {
 		l.Warn("Invalid data in OAuth redirect request", zap.Error(err))
-		c.Abort("invalid data parameter")
+		c.AbortBadRequest("invalid data parameter")
 		return
 	}
 
 	oauthToken := data.Token
 	if oauthToken == nil {
 		l.Warn("Missing token in OAuth redirect request", zap.Any("data", data))
-		c.Abort("missing OAuth token")
+		c.AbortBadRequest("missing OAuth token")
 		return
 	}
 
@@ -61,7 +61,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		l.Warn("Slack OAuth token test failed", zap.Error(err))
 		e := "token auth test failed: " + err.Error()
-		c.Abort(e)
+		c.AbortBadRequest(e)
 		return
 	}
 
@@ -69,7 +69,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		l.Warn("Slack bot info request failed", zap.Error(err))
 		e := "bot info request failed: " + err.Error()
-		c.Abort(e)
+		c.AbortBadRequest(e)
 		return
 	}
 

--- a/integrations/slack/websockets/form.go
+++ b/integrations/slack/websockets/form.go
@@ -27,14 +27,14 @@ func (h handler) HandleForm(w http.ResponseWriter, r *http.Request) {
 	// Check "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
 	if !strings.HasPrefix(contentType, contentTypeForm) {
-		c.Abort("unexpected content type")
+		c.AbortBadRequest("unexpected content type")
 		return
 	}
 
 	// Read and parse POST request body.
 	if err := r.ParseForm(); err != nil {
 		l.Warn("Failed to parse incoming HTTP request", zap.Error(err))
-		c.Abort("form parsing error")
+		c.AbortBadRequest("form parsing error")
 		return
 	}
 
@@ -46,21 +46,21 @@ func (h handler) HandleForm(w http.ResponseWriter, r *http.Request) {
 	authTest, err := auth.TestWithToken(ctx, botToken)
 	if err != nil {
 		l.Warn("Slack OAuth token test failed", zap.Error(err))
-		c.Abort("token auth test failed: " + err.Error())
+		c.AbortBadRequest("token auth test failed: " + err.Error())
 		return
 	}
 
 	botInfo, err := bots.InfoWithToken(ctx, botToken, authTest)
 	if err != nil {
 		l.Warn("Slack bot info request failed", zap.Error(err))
-		c.Abort("bot info request failed: " + err.Error())
+		c.AbortBadRequest("bot info request failed: " + err.Error())
 		return
 	}
 
 	_, err = apps.ConnectionsOpenWithToken(ctx, h.vars, appToken)
 	if err != nil {
 		l.Warn("Slack websocket connection error", zap.Error(err))
-		c.Abort("websocket connection error: " + err.Error())
+		c.AbortBadRequest("websocket connection error: " + err.Error())
 		return
 	}
 

--- a/integrations/twilio/webhooks/auth.go
+++ b/integrations/twilio/webhooks/auth.go
@@ -32,14 +32,14 @@ func (h handler) HandleAuth(w http.ResponseWriter, r *http.Request) {
 	// Check "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
 	if !strings.HasPrefix(contentType, contentTypeForm) {
-		c.Abort("unexpected content type")
+		c.AbortBadRequest("unexpected content type")
 		return
 	}
 
 	// Read and parse POST request body.
 	if err := r.ParseForm(); err != nil {
 		l.Warn("Failed to parse incoming HTTP request", zap.Error(err))
-		c.Abort("form parsing error")
+		c.AbortBadRequest("form parsing error")
 		return
 	}
 

--- a/sdk/sdkintegrations/initconn.go
+++ b/sdk/sdkintegrations/initconn.go
@@ -45,8 +45,8 @@ func (c ConnectionInit) AbortBadRequest(err string) {
 	c.AbortWithStatus(http.StatusBadRequest, err)
 }
 
-// AbortISE is the same as [AbortWithStatus] with HTTP 500 (Internal Server Error).
-func (c ConnectionInit) AbortISE(err string) {
+// AbortServerError is the same as [AbortWithStatus] with HTTP 500 (Internal Server Error).
+func (c ConnectionInit) AbortServerError(err string) {
 	c.AbortWithStatus(http.StatusInternalServerError, err)
 }
 
@@ -79,7 +79,7 @@ func (c ConnectionInit) Finalize(data []sdktypes.Var) {
 	vars, err := kittehs.EncodeURLData(data)
 	if err != nil {
 		c.logger.Error("Connection data encoding error", zap.Error(err))
-		c.AbortISE("connection data encoding error")
+		c.AbortServerError("connection data encoding error")
 		return
 	}
 

--- a/sdk/sdkintegrations/initconn.go
+++ b/sdk/sdkintegrations/initconn.go
@@ -40,9 +40,14 @@ func NewConnectionInit(l *zap.Logger, w http.ResponseWriter, r *http.Request, i 
 	}, l
 }
 
-// Abort is the same as [AbortWithStatus] with HTTP 400 (Bad Request).
-func (c ConnectionInit) Abort(err string) {
+// AbortBadRequest is the same as [AbortWithStatus] with HTTP 400 (Bad Request).
+func (c ConnectionInit) AbortBadRequest(err string) {
 	c.AbortWithStatus(http.StatusBadRequest, err)
+}
+
+// AbortISE is the same as [AbortWithStatus] with HTTP 500 (Internal Server Error).
+func (c ConnectionInit) AbortISE(err string) {
+	c.AbortWithStatus(http.StatusInternalServerError, err)
 }
 
 // Abort aborts the connection initialization flow due to
@@ -73,14 +78,14 @@ func (c ConnectionInit) AbortWithStatus(status int, err string) {
 func (c ConnectionInit) Finalize(data []sdktypes.Var) {
 	vars, err := kittehs.EncodeURLData(data)
 	if err != nil {
-		c.logger.Warn("Connection data encoding error", zap.Error(err))
-		c.AbortWithStatus(http.StatusInternalServerError, "connection data encoding error")
+		c.logger.Error("Connection data encoding error", zap.Error(err))
+		c.AbortISE("connection data encoding error")
 		return
 	}
 
 	if _, err = sdktypes.StrictParseConnectionID(c.ConnectionID); err != nil {
 		c.logger.Warn("Invalid connection ID")
-		c.Abort("invalid connection ID")
+		c.AbortBadRequest("invalid connection ID")
 		return
 	}
 


### PR DESCRIPTION
Instead of `Abort` and `AbortWithStatusCode`, use these clearer function names: `AbortBadRequest` and `AbortISE` (Internal Server Error).

We still have `AbortWithStatusCode` in case integrations want to use other less-common HTTP status codes.

This PR is stacked over #521, but only because it touches some of the same code. It's not strictly related. Anyway, merge this PR only after #521 is merged.