### PR TITLE
Refactor: log only intercepted HTTP responses, not requests

### DIFF
--- a/integrations/atlassian/confluence/event.go
+++ b/integrations/atlassian/confluence/event.go
@@ -117,7 +117,7 @@ var simpleEntities = []string{
 
 func extractEntityType(l *zap.Logger, atlassianEvent map[string]any, category string) (string, bool) {
 	if category == "" {
-		l.Warn("Unexpected Confluence event callback: missing category in URL")
+		l.Warn("Unexpected Confluence event callback: missing category in URL ")
 		return "", false
 	}
 
@@ -142,10 +142,7 @@ func extractEntityType(l *zap.Logger, atlassianEvent map[string]any, category st
 		}
 	}
 
-	l.Error("Unrecognized Confluence event",
-		zap.String("category", category),
-		zap.Any("event", atlassianEvent),
-	)
+	l.Error("Unrecognized Confluence event", zap.Any("event", atlassianEvent))
 	return "", false
 }
 

--- a/integrations/atlassian/confluence/event.go
+++ b/integrations/atlassian/confluence/event.go
@@ -117,7 +117,7 @@ var simpleEntities = []string{
 
 func extractEntityType(l *zap.Logger, atlassianEvent map[string]any, category string) (string, bool) {
 	if category == "" {
-		l.Warn("Unexpected Confluence event callback: missing category in URL ")
+		l.Warn("Unexpected Confluence event callback: missing category in URL")
 		return "", false
 	}
 
@@ -142,7 +142,10 @@ func extractEntityType(l *zap.Logger, atlassianEvent map[string]any, category st
 		}
 	}
 
-	l.Error("Unrecognized Confluence event", zap.Any("event", atlassianEvent))
+	l.Error("Unrecognized Confluence event",
+		zap.String("category", category),
+		zap.Any("event", atlassianEvent),
+	)
 	return "", false
 }
 

--- a/internal/backend/httpsvc/intercept.go
+++ b/internal/backend/httpsvc/intercept.go
@@ -15,14 +15,15 @@ import (
 
 type ctxKey string
 
-var t0CtxKey = ctxKey("t0")
+var startTimeCtxKey = ctxKey("t0")
 
-func GetT0(ctx context.Context) time.Time {
-	if t0, ok := ctx.Value(t0CtxKey).(time.Time); ok {
-		return t0
+func GetStartTime(ctx context.Context) time.Time {
+	if startTime, ok := ctx.Value(startTimeCtxKey).(time.Time); ok {
+		return startTime
 	}
 
-	return time.Time{}
+	// No start time? Duration = 0, not start time = 0.
+	return time.Now()
 }
 
 type responseInterceptor struct {
@@ -66,42 +67,36 @@ func intercept(z *zap.Logger, cfg *LoggerConfig, extractors []RequestLogExtracto
 
 		w.Header().Set("X-AutoKitteh-Process-ID", fixtures.ProcessID())
 
-		z := z.With(zap.String("method", r.Method), zap.String("path", r.URL.Path))
-		msg := fmt.Sprintf("HTTP request: %s %s", r.Method, r.URL.Path)
+		l := z.With(zap.String("method", r.Method), zap.String("path", r.URL.Path))
+		rwi := &responseInterceptor{ResponseWriter: w, StatusCode: http.StatusOK, logger: l}
+
+		w.Header().Set("Trailer", "X-AutoKitteh-Duration")
+
+		startTime := time.Now()
+		r = r.WithContext(context.WithValue(r.Context(), startTimeCtxKey, startTime))
+
+		next.ServeHTTP(rwi, r)
+		d := time.Since(startTime)
+
+		w.Header().Add("X-AutoKitteh-Duration", d.Truncate(time.Microsecond).String())
 
 		level := cfg.ImportantLevel.Level()
 		if unimportant.MatchString(r.URL.Path) {
 			level = cfg.UnimportantLevel.Level()
 		}
+		if rwi.StatusCode >= 400 {
+			level = cfg.ErrorsLevel.Level()
+		}
 
-		if ce := z.Check(level, msg); ce != nil {
+		l = l.With(zap.Int("statusCode", rwi.StatusCode), zap.Duration("duration", d))
+		msg := fmt.Sprintf("Response to incoming HTTP request: %s %s", r.Method, r.URL.Path)
+		if ce := l.Check(level, msg); ce != nil {
 			var fields []zap.Field
 			for _, x := range extractors {
 				fields = append(fields, x(r)...)
 			}
 
 			ce.Write(fields...)
-		}
-
-		rwi := &responseInterceptor{ResponseWriter: w, StatusCode: http.StatusOK, logger: z}
-
-		w.Header().Set("Trailer", "X-AutoKitteh-Duration")
-
-		t0 := time.Now()
-		r = r.WithContext(context.WithValue(r.Context(), t0CtxKey, t0))
-
-		next.ServeHTTP(rwi, r)
-		d := time.Since(t0)
-
-		w.Header().Add("X-AutoKitteh-Duration", d.Truncate(time.Microsecond).String())
-
-		if rwi.StatusCode >= 400 {
-			level = cfg.ErrorsLevel.Level()
-		}
-
-		msg = strings.Replace(msg, "request", "response", 1)
-		if ce := z.Check(level, msg); ce != nil {
-			ce.Write(zap.Int("statusCode", rwi.StatusCode), zap.Duration("duration", d))
 		}
 	}, nil
 }

--- a/web/webdashboard/web.go
+++ b/web/webdashboard/web.go
@@ -32,7 +32,7 @@ func Tmpl(r *http.Request) *template.Template {
 			"ProcessID": func() any { return fixtures.ProcessID() },
 			"Version":   func() any { return version.Version },
 			"Uptime":    func() any { return fixtures.Uptime().Truncate(time.Second) },
-			"Duration":  func() time.Duration { return time.Since(httpsvc.GetT0(r.Context())).Truncate(time.Microsecond) },
+			"Duration":  func() time.Duration { return time.Since(httpsvc.GetStartTime(r.Context())).Truncate(time.Microsecond) },
 		}).
 		ParseFS(tmplFS, "*.html"))
 }


### PR DESCRIPTION
This merges two log lines into one.

The diff looks confusing for no reason, the best way to review this PR is to compare the entire function before and after this PR:

Before: https://github.com/autokitteh/autokitteh/blob/main/internal/backend/httpsvc/intercept.go#L62-L106

After: `https://github.com/autokitteh/autokitteh/blob/5d3d36b40043f38d737d3ef970bfd3e29e6b1018/internal/backend/httpsvc/intercept.go#L63-L101`

