### PR TITLE
Fix(atlassian): bug in #499 - extra \n in base URL

### DIFF
--- a/integrations/atlassian/confluence/save.go
+++ b/integrations/atlassian/confluence/save.go
@@ -59,7 +59,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Ensure the base URL is formatted as we expect.
-	b = fmt.Sprintf("%s://%s\n", u.Scheme, u.Host)
+	b = fmt.Sprintf("%s://%s", u.Scheme, u.Host)
 
 	initData := sdktypes.NewVars().Set(baseURL, b, false).Set(token, t, true)
 	if e != "" {

--- a/integrations/atlassian/jira/save.go
+++ b/integrations/atlassian/jira/save.go
@@ -46,7 +46,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Ensure the base URL is formatted as we expect.
-	b = fmt.Sprintf("%s://%s\n", u.Scheme, u.Host)
+	b = fmt.Sprintf("%s://%s", u.Scheme, u.Host)
 
 	initData := sdktypes.NewVars().Set(baseURL, b, false).Set(token, t, true)
 	if e != "" {


### PR DESCRIPTION
Detected in the AK server log during testing:

```
2024-07-24 22:33:11 WARN confluence/webhooks.go:199 Failed to construct HTTP request to register Confluence webhook {"urlPath": "/confluence/save", "connectionID": "con_01j3m5ws9wf5b9dayd0cw4m6w4", "origin": "dash", "category": "added", "error": "parse \"https://autokitteh.atlassian.net\\n/wiki/rest/webhooks/1.0/webhook\": net/url: invalid control character in URL"}
```

Refs: ENG-1179