### PR TITLE
Fix(confluence): "content_updated" events not recognized

### DIFF
--- a/integrations/atlassian/confluence/event.go
+++ b/integrations/atlassian/confluence/event.go
@@ -108,16 +108,17 @@ func (h handler) handleEvent(w http.ResponseWriter, r *http.Request) {
 }
 
 // All non-"content" event types (with the created/updated/removed suffix).
+// "content" is actually included, to support "content_updated" events.
 // https://developer.atlassian.com/cloud/confluence/modules/webhook/
 // https://confluence.atlassian.com/conf715/managing-webhooks-1096098349.html
 var simpleEntities = []string{
 	"attachment", "blog", "blueprint_page", "comment",
-	"group", "label", "page", "relation", "space",
+	"content", "group", "label", "page", "relation", "space",
 }
 
 func extractEntityType(l *zap.Logger, atlassianEvent map[string]any, category string) (string, bool) {
 	if category == "" {
-		l.Warn("Unexpected Confluence event callback: missing category in URL ")
+		l.Warn("Unexpected Confluence event callback: missing category in URL")
 		return "", false
 	}
 
@@ -142,7 +143,10 @@ func extractEntityType(l *zap.Logger, atlassianEvent map[string]any, category st
 		}
 	}
 
-	l.Error("Unrecognized Confluence event", zap.Any("event", atlassianEvent))
+	l.Error("Unrecognized Confluence event",
+		zap.String("category", category),
+		zap.Any("event", atlassianEvent),
+	)
 	return "", false
 }
 

--- a/integrations/atlassian/confluence/webhooks.go
+++ b/integrations/atlassian/confluence/webhooks.go
@@ -98,10 +98,8 @@ var webhookEvents = map[string][]string{
 		"blog_updated",
 		"comment_updated",
 		"content_updated",
-		"content_permissions_updated",
 		"page_updated",
 		"space_logo_updated",
-		"space_permissions_updated",
 		"space_updated",
 	},
 }


### PR DESCRIPTION
Also removed permission update events because we can't test them currently, and improved error log entry.

Refs: ENG-1264