### PR TITLE
chore: don't log some HTTP requests, unless there's an error

### DIFF
--- a/internal/backend/httpsvc/config.go
+++ b/internal/backend/httpsvc/config.go
@@ -79,10 +79,10 @@ var Configs = configset.Set[Config]{
 			ErrorsLevel:      zap.NewAtomicLevelAt(zap.WarnLevel),
 			UnimportantRegexes: []string{
 				`^/autokitteh.+/(Get|List)$`, // gRPC Get and List methods
-				`/(healthz|readyz)$`,         // Kubernetes health checks
 				`^/oauth/|/oauth$|/save$`,    // Connection initialization
 			},
 			UnloggedRegexes: []string{
+				`/(healthz|readyz)$`,                           // Kubernetes health checks
 				`\.(css|html|ico|js|png|svg|txt|webmanifest)$`, // Static web content
 			},
 		},

--- a/internal/backend/httpsvc/intercept.go
+++ b/internal/backend/httpsvc/intercept.go
@@ -60,11 +60,6 @@ func intercept(z *zap.Logger, cfg *LoggerConfig, extractors []RequestLogExtracto
 	unlogged := regexp.MustCompile(strings.Join(cfg.UnloggedRegexes, `|`))
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		if unlogged.MatchString(r.URL.Path) {
-			next.ServeHTTP(w, r)
-			return
-		}
-
 		w.Header().Set("X-AutoKitteh-Process-ID", fixtures.ProcessID())
 
 		l := z.With(zap.String("method", r.Method), zap.String("path", r.URL.Path))
@@ -72,14 +67,22 @@ func intercept(z *zap.Logger, cfg *LoggerConfig, extractors []RequestLogExtracto
 
 		w.Header().Set("Trailer", "X-AutoKitteh-Duration")
 
+		// Call the next handler in the chain, and calculate the duration.
 		startTime := time.Now()
 		r = r.WithContext(context.WithValue(r.Context(), startTimeCtxKey, startTime))
 
 		next.ServeHTTP(rwi, r)
-		d := time.Since(startTime)
 
+		d := time.Since(startTime)
 		w.Header().Add("X-AutoKitteh-Duration", d.Truncate(time.Microsecond).String())
 
+		// Don't log some requests, unless they result in an error.
+		if unlogged.MatchString(r.URL.Path) && rwi.StatusCode < 400 {
+			return
+		}
+
+		// Otherwise, determine the log level based on the request's
+		// URL path and the response's HTTP status code.
 		level := cfg.ImportantLevel.Level()
 		if unimportant.MatchString(r.URL.Path) {
 			level = cfg.UnimportantLevel.Level()

--- a/internal/backend/httpsvc/intercept.go
+++ b/internal/backend/httpsvc/intercept.go
@@ -73,8 +73,8 @@ func intercept(z *zap.Logger, cfg *LoggerConfig, extractors []RequestLogExtracto
 
 		next.ServeHTTP(rwi, r)
 
-		d := time.Since(startTime)
-		w.Header().Add("X-AutoKitteh-Duration", d.Truncate(time.Microsecond).String())
+		duration := time.Since(startTime)
+		w.Header().Add("X-AutoKitteh-Duration", duration.Truncate(time.Microsecond).String())
 
 		// Don't log some requests, unless they result in an error.
 		if unlogged.MatchString(r.URL.Path) && rwi.StatusCode < 400 {
@@ -91,7 +91,7 @@ func intercept(z *zap.Logger, cfg *LoggerConfig, extractors []RequestLogExtracto
 			level = cfg.ErrorsLevel.Level()
 		}
 
-		l = l.With(zap.Int("statusCode", rwi.StatusCode), zap.Duration("duration", d))
+		l = l.With(zap.Int("statusCode", rwi.StatusCode), zap.Duration("duration", duration))
 		msg := fmt.Sprintf("Response to incoming HTTP request: %s %s", r.Method, r.URL.Path)
 		if ce := l.Check(level, msg); ce != nil {
 			var fields []zap.Field


### PR DESCRIPTION
We're logging about 720 `/healthz` requests per hour. This is both unhelpful and expensive - so don't log them at all.

However, obviously we do want to log them if there's an error.