### PR TITLE
feat: allow showing banner in prod logs

### DIFF
--- a/internal/backend/svc/banner.go
+++ b/internal/backend/svc/banner.go
@@ -14,7 +14,7 @@ import (
 )
 
 type bannerConfig struct {
-	Show bool
+	Show bool `koanf:"show"`
 }
 
 var bannerConfigs = configset.Set[bannerConfig]{


### PR DESCRIPTION
Users may now configure AK to display the banner in the default (non-dev) server mode too (`banner.show = true`). This provides useful server stats: PID, ports, addresses, etc.

Anyway, no behavioral change: by default, the banner is printed in the AK logs only in dev mode.

This also allows users to hide the banner in dev mode, but I'm assuming no one needs this aspect.