### PR TITLE
feat(logger)!: configure min logging level by name, not ID

### DIFF
--- a/internal/backend/logger/logger.go
+++ b/internal/backend/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"strconv"
 	"time"
 
 	"go.uber.org/zap"
@@ -37,11 +38,17 @@ func (onPanicHook) OnWrite(ce *zapcore.CheckedEntry, fs []zapcore.Field) {
 }
 
 func New(cfg *Config) (*zap.Logger, error) {
-	// Optional override for the default level (info).
+	// Optional override for the default level (0 = info).
 	if cfg.Level != "" {
+		// Accept lower-case or all-caps level names, as defined by Zap.
 		level, err := zapcore.ParseLevel(cfg.Level)
 		if err != nil {
-			return nil, err
+			// Temporary: numeric level IDs, as used internally by Zap.
+			if n, e := strconv.Atoi(cfg.Level); e == nil {
+				level = zapcore.Level(n)
+			} else {
+				return nil, err
+			}
 		}
 		cfg.Zap.Level.SetLevel(level)
 	}

--- a/internal/backend/logger/logger.go
+++ b/internal/backend/logger/logger.go
@@ -13,7 +13,7 @@ import (
 
 type Config struct {
 	Zap      zap.Config `koanf:"zap"`
-	Level    int        `koanf:"level"`    // -1 = Debug, 0 = Info, etc.
+	Level    string     `koanf:"level"`    // Lower-case or all caps, default = "info".
 	Encoding string     `koanf:"encoding"` // "json" or "console".
 }
 
@@ -37,7 +37,14 @@ func (onPanicHook) OnWrite(ce *zapcore.CheckedEntry, fs []zapcore.Field) {
 }
 
 func New(cfg *Config) (*zap.Logger, error) {
-	cfg.Zap.Level.SetLevel(zapcore.Level(cfg.Level)) // Default = 0 = Info.
+	// Optional override for the default level (info).
+	if cfg.Level != "" {
+		level, err := zapcore.ParseLevel(cfg.Level)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Zap.Level.SetLevel(level)
+	}
 
 	// Optional override for the default encoding:
 	// AK default mode = Zap production config = "json" encoding,


### PR DESCRIPTION
The default minimum logging level is [Info](https://pkg.go.dev/go.uber.org/zap#pkg-constants). To change this, set the following config value to the lower-case or all-caps name of the level you want.

For example:

- CLI: `ak config set logger.level debug`

- Config YAML file:

  ```yaml
  logger:
    level: debug
  ```

- Environment variable: `AK_LOGGER__LEVEL=DEBUG`

Per @itayd and according to the principle of least surprise, invalid names result in an error.

BREAKING CHANGE: Expected values are now strings instead of integers! This PR still accepts old numeric values (e.g. -1 = debug), but this is temporary and will be removed after all existing servers migrate.