### PR TITLE
fix(oauth): google oauth init fails due to unknown db user 

### DIFF
--- a/integrations/google/server.go
+++ b/integrations/google/server.go
@@ -24,35 +24,35 @@ const (
 	gmailWebhookPath = "/gmail/notif"
 )
 
-func Start(l *zap.Logger, mux *http.ServeMux, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.Dispatcher) {
+func Start(l *zap.Logger, muxNoAuth *http.ServeMux, muxAuth *http.ServeMux, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.Dispatcher) {
 	uiPath := "GET " + desc.ConnectionURL().Path + "/"
 
 	// New connection UIs + handlers.
-	mux.Handle(uiPath, http.FileServer(http.FS(static.GoogleWebContent)))
+	muxNoAuth.Handle(uiPath, http.FileServer(http.FS(static.GoogleWebContent)))
 
 	urlPath := strings.ReplaceAll(uiPath, "google", "gmail")
-	mux.Handle(urlPath, http.FileServer(http.FS(static.GmailWebContent)))
+	muxNoAuth.Handle(urlPath, http.FileServer(http.FS(static.GmailWebContent)))
 
 	urlPath = strings.ReplaceAll(uiPath, "google", "googlecalendar")
-	mux.Handle(urlPath, http.FileServer(http.FS(static.GoogleCalendarWebContent)))
+	muxNoAuth.Handle(urlPath, http.FileServer(http.FS(static.GoogleCalendarWebContent)))
 
 	urlPath = strings.ReplaceAll(uiPath, "google", "googlechat")
-	mux.Handle(urlPath, http.FileServer(http.FS(static.GoogleChatWebContent)))
+	muxNoAuth.Handle(urlPath, http.FileServer(http.FS(static.GoogleChatWebContent)))
 
 	urlPath = strings.ReplaceAll(uiPath, "google", "googledrive")
-	mux.Handle(urlPath, http.FileServer(http.FS(static.GoogleDriveWebContent)))
+	muxNoAuth.Handle(urlPath, http.FileServer(http.FS(static.GoogleDriveWebContent)))
 
 	urlPath = strings.ReplaceAll(uiPath, "google", "googleforms")
-	mux.Handle(urlPath, http.FileServer(http.FS(static.GoogleFormsWebContent)))
+	muxNoAuth.Handle(urlPath, http.FileServer(http.FS(static.GoogleFormsWebContent)))
 
 	urlPath = strings.ReplaceAll(uiPath, "google", "googlesheets")
-	mux.Handle(urlPath, http.FileServer(http.FS(static.GoogleSheetsWebContent)))
+	muxNoAuth.Handle(urlPath, http.FileServer(http.FS(static.GoogleSheetsWebContent)))
 
 	h := NewHTTPHandler(l, o, v, d)
-	mux.HandleFunc("GET "+oauthPath, h.handleOAuth)
-	mux.HandleFunc("POST "+credsPath, h.handleCreds)
+	muxAuth.HandleFunc("GET "+oauthPath, h.handleOAuth)
+	muxNoAuth.HandleFunc("POST "+credsPath, h.handleCreds)
 
 	// Event webhooks.
-	mux.HandleFunc("POST "+formsWebhookPath, h.handleFormsNotification)
-	mux.HandleFunc("POST "+gmailWebhookPath, h.handleGmailNotification)
+	muxNoAuth.HandleFunc("POST "+formsWebhookPath, h.handleFormsNotification)
+	muxNoAuth.HandleFunc("POST "+gmailWebhookPath, h.handleGmailNotification)
 }

--- a/integrations/google/server.go
+++ b/integrations/google/server.go
@@ -25,6 +25,11 @@ const (
 )
 
 func Start(l *zap.Logger, muxNoAuth *http.ServeMux, muxAuth *http.ServeMux, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.Dispatcher) {
+	// Note: there is a need to set some variable before calling `finalize' in `handleOauth'.
+	// This could be possible only if there is authenticated user present in context (otherwise DB layer will reject the operations).
+	// Therefore, oauthPath is routed via muxAuth, which will pass through auth middleware and extract authenticated user
+	// from the cookie to update the context.
+
 	uiPath := "GET " + desc.ConnectionURL().Path + "/"
 
 	// New connection UIs + handlers.

--- a/internal/backend/integrations/integrations.go
+++ b/internal/backend/integrations/integrations.go
@@ -67,18 +67,18 @@ func New(cfg *Config, vars sdkservices.Vars) sdkservices.Integrations {
 	return sdkintegrations.New(ints)
 }
 
-func Start(_ context.Context, l *zap.Logger, mux *http.ServeMux, vars sdkservices.Vars, o sdkservices.OAuth, d sdkservices.Dispatcher, c sdkservices.Connections, p sdkservices.Projects) error {
-	aws.Start(l, mux)
-	chatgpt.Start(l, mux)
-	confluence.Start(l, mux, vars, o, d)
-	discord.Start(l, mux)
-	github.Start(l, mux, vars, o, d)
-	gemini.Start(l, mux)
-	google.Start(l, mux, vars, o, d)
-	httpint.Start(l, mux, d, c, p)
-	jira.Start(l, mux, vars, o, d)
-	slack.Start(l, mux, vars, d)
-	twilio.Start(l, mux, vars, d)
+func Start(_ context.Context, l *zap.Logger, muxNoAuth *http.ServeMux, muxAuth *http.ServeMux, vars sdkservices.Vars, o sdkservices.OAuth, d sdkservices.Dispatcher, c sdkservices.Connections, p sdkservices.Projects) error {
+	aws.Start(l, muxNoAuth)
+	chatgpt.Start(l, muxNoAuth)
+	confluence.Start(l, muxNoAuth, vars, o, d)
+	discord.Start(l, muxNoAuth)
+	github.Start(l, muxNoAuth, vars, o, d)
+	gemini.Start(l, muxNoAuth)
+	google.Start(l, muxNoAuth, muxAuth, vars, o, d)
+	httpint.Start(l, muxNoAuth, d, c, p)
+	jira.Start(l, muxNoAuth, vars, o, d)
+	slack.Start(l, muxNoAuth, vars, d)
+	twilio.Start(l, muxNoAuth, vars, d)
 
 	return nil
 }

--- a/internal/backend/svc/svc.go
+++ b/internal/backend/svc/svc.go
@@ -309,7 +309,7 @@ func makeFxOpts(cfg *Config, opts RunOptions) []fx.Option {
 		Component("integrations", integrations.Configs, fx.Provide(integrations.New)),
 		fx.Invoke(func(lc fx.Lifecycle, l *zap.Logger, muxes *muxes.Muxes, vs sdkservices.Vars, o sdkservices.OAuth, d dispatcher.Dispatcher, c sdkservices.Connections, p sdkservices.Projects) {
 			HookOnStart(lc, func(ctx context.Context) error {
-				return integrations.Start(ctx, l, muxes.NoAuth, vs, o, d, c, p)
+				return integrations.Start(ctx, l, muxes.NoAuth, muxes.Auth, vs, o, d, c, p)
 			})
 		}),
 		fx.Invoke(func(z *zap.Logger, muxes *muxes.Muxes) {


### PR DESCRIPTION
google oauth fails due to recent changes when it tries to save vars via vars service.
This happens since there is no db user in context (nether via token or session).
Solution - access oauth via authMux, thus passing via auth middleware and adding user to the context  