### PR TITLE
fix(github): handle user-webhook events correctly

### DIFF
--- a/integrations/github/server.go
+++ b/integrations/github/server.go
@@ -31,9 +31,7 @@ func Start(l *zap.Logger, mux *http.ServeMux, v sdkservices.Vars, o sdkservices.
 	mux.HandleFunc("POST "+patPath, h.handlePAT)
 
 	// Event webhooks.
-	// TODO: Use Go 1.22's pattern wildcards to have 2 separate event
-	// handler functions (https://go.dev/blog/routing-enhancements).
 	eventHandler := webhooks.NewHandler(l, v, d, integrationID)
-	mux.Handle("POST "+webhooks.WebhookPath+"/", eventHandler) // User events.
-	mux.Handle("POST "+webhooks.WebhookPath, eventHandler)     // App events.
+	mux.Handle("POST "+webhooks.WebhookPath+"/{id}", eventHandler) // User events.
+	mux.Handle("POST "+webhooks.WebhookPath, eventHandler)         // App events.
 }

--- a/integrations/github/webhooks/webhook.go
+++ b/integrations/github/webhooks/webhook.go
@@ -98,7 +98,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 			if payload != nil {
 				userCID = cid
-				break // Successful validation with non-empty payload - no need to retry.
+				break // Successful validation with non-empty payload - no need to repeat.
 			}
 		}
 

--- a/integrations/github/webhooks/webhook.go
+++ b/integrations/github/webhooks/webhook.go
@@ -102,6 +102,10 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		// The loop above tries to validate and parse the event, by finding the
+		// AK connection corresponding to the webhook ID and using its secret.
+		// If the payload is still nil at this point, then either the event is
+		// fake, or a relevant connection could not be found.
 		if payload == nil {
 			l.Info("Received GitHub event from user webhook, but no relevant connection found")
 			return

--- a/integrations/github/webhooks/webhook.go
+++ b/integrations/github/webhooks/webhook.go
@@ -105,7 +105,8 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// The loop above tries to validate and parse the event, by finding the
 		// AK connection corresponding to the webhook ID and using its secret.
 		// If the payload is still nil at this point, then either the event is
-		// fake, or a relevant connection could not be found.
+		// fake (not from GitHub), or a relevant connection could not be found.
+		// Either way, we report success (HTTP 200) and do nothing.
 		if payload == nil {
 			l.Info("Received GitHub event from user webhook, but no relevant connection found")
 			return


### PR DESCRIPTION
"Correctly" means the following:

- If there are no relevant connections for the event, respond with HTTP 200 and do nothing, don't respond with an HTTP error
- If there are multiple PAT & webhook connections, and we succeed in validating and parsing an incoming event with one of these connection, no need to repeat this with more connections

On the way, use new Go mux patterns instead of parsing webhook URL paths.

Refs: ENG-1224