### PR TITLE
fix: session log record describe properly print call return values

### DIFF
--- a/sdk/sdktypes/session_log_record_describe.go
+++ b/sdk/sdktypes/session_log_record_describe.go
@@ -249,6 +249,7 @@ func describeFunctionValue(opts *SessionLogRecordDescribeOptions, w io.Writer, v
 }
 
 var sessionLogDescUnwrapper = ValueWrapper{
+	SafeForJSON: true,
 	Preunwrap: func(v Value) (Value, error) {
 		if v.IsFunction() {
 			return NewStringValuef("|function: %v|", v.GetFunction().Name()), nil


### PR DESCRIPTION
need to specify `SafeForJSON` so JSON encoder could serialize the data properly, otherwise it tries to serialize `map[any]any` and fails.