### PR TITLE
fix: next_event can now process multiple sequential events

### DIFF
--- a/internal/backend/db/dbgorm/events.go
+++ b/internal/backend/db/dbgorm/events.go
@@ -56,7 +56,7 @@ func (gdb *gormdb) listEvents(ctx context.Context, filter sdkservices.ListEvents
 		q = q.Limit(filter.Limit)
 	}
 
-	q = q.Where("seq > ?", filter.MinSequenceNumber)
+	q = q.Where("seq >= ?", filter.MinSequenceNumber)
 
 	if filter.Order == sdkservices.ListOrderAscending {
 		q = q.Order("seq asc")

--- a/tests/system/actions.go
+++ b/tests/system/actions.go
@@ -33,7 +33,8 @@ func runAction(t *testing.T, akPath, akAddr, step string) (any, error) {
 		return runClient(akPath, args)
 	case "http get", "http post":
 		method := strings.ToUpper(match[2])
-		return &httpRequest{method: method, url: match[3]}, nil
+		url, body, _ := strings.Cut(match[3], " ")
+		return &httpRequest{method: method, url: url, body: body}, nil
 	case "wait":
 		return waitForSession(akPath, akAddr, step)
 	default:

--- a/tests/system/testdata/sessions/events.txtar
+++ b/tests/system/testdata/sessions/events.txtar
@@ -1,0 +1,46 @@
+ak deploy --manifest project.yaml
+return code == 0
+
+http get /http/myproject/start
+resp code == 200
+
+ak session watch ses_0000000000000000000000000a --end-state RUNNING
+return code == 0
+
+http post /http/myproject/meow 1
+resp code == 200
+
+http post /http/myproject/meow 2
+resp code == 200
+
+ak session watch ses_0000000000000000000000000a --end-state COMPLETED
+return code == 0
+
+ak session log --prints-only --no-timestamps
+output equals file prints.txt
+
+-- prints.txt --
+1
+2
+
+-- project.yaml --
+version: v1
+
+project:
+  name: myproject
+  connections:
+    - name: myhttp
+      integration: http
+  triggers:
+    - name: http_start
+      connection: myhttp
+      event_type: get
+      data:
+        path: start
+      call: program.star:on_http_start
+
+-- program.star --
+def on_http_start():
+  s = subscribe("myhttp", "data.url.path == '/meow'")
+  print(next_event(s)['body'].text())
+  print(next_event(s)['body'].text())


### PR DESCRIPTION
there was a problem where next_event skipped events. this change the name of the last event read in sessions to be more explicit, as well as the condition in the db to be more appropriate with the filter meaning. also increase the seq number in the filter given to List as needed.