### PR TITLE
fix(github): check webhook URL

### DIFF
--- a/integrations/github/pat.go
+++ b/integrations/github/pat.go
@@ -60,6 +60,12 @@ func (h handler) handlePAT(w http.ResponseWriter, r *http.Request) {
 	userJSON, _ := json.Marshal(user)
 	_, patKey := filepath.Split(webhook)
 
+	if patKey == "" {
+		l.Warn("Invalid webhook URL")
+		c.AbortBadRequest("invalid webhook key")
+		return
+	}
+
 	c.Finalize(sdktypes.NewVars().
 		Set(vars.PAT, pat, true).
 		Set(vars.PATKey, patKey, false).

--- a/integrations/github/pat.go
+++ b/integrations/github/pat.go
@@ -62,7 +62,7 @@ func (h handler) handlePAT(w http.ResponseWriter, r *http.Request) {
 
 	if patKey == "" {
 		l.Warn("Invalid webhook URL")
-		c.AbortBadRequest("invalid webhook key")
+		c.AbortBadRequest("invalid webhook URL")
 		return
 	}
 


### PR DESCRIPTION
The code that saves GitHub connections in the PAT + webhook mode assumed that the webhook URL is valid because we generate it in the connection page. But this is an optimistic assumption that needs to be verified, especially since the web frontend triggers this code.