### PR TITLE
feat(login): support client side only logout

### DIFF
--- a/internal/backend/auth/authhttpmiddleware/authmiddleware.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware.go
@@ -83,6 +83,11 @@ func newSessionsMiddleware(next http.Handler, sessions authsessions.Store) http.
 				return
 			}
 
+			if session == nil {
+				http.Error(w, "invalid session", http.StatusUnauthorized)
+				return
+			}
+
 			if session != nil {
 				r = r.WithContext(authcontext.SetAuthnUser(ctx, session.User))
 			}

--- a/internal/backend/auth/authhttpmiddleware/authmiddleware.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware.go
@@ -79,7 +79,7 @@ func newSessionsMiddleware(next http.Handler, sessions authsessions.Store) http.
 		if user := authcontext.GetAuthnUser(ctx); !user.IsValid() {
 			session, err := sessions.Get(r)
 			if err != nil {
-				http.Redirect(w, r, "/login", http.StatusFound)
+				http.Error(w, "invalid session", http.StatusUnauthorized)
 				return
 			}
 

--- a/internal/backend/auth/authhttpmiddleware/authmiddleware.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware.go
@@ -83,11 +83,6 @@ func newSessionsMiddleware(next http.Handler, sessions authsessions.Store) http.
 				return
 			}
 
-			if session == nil {
-				http.Error(w, "invalid session", http.StatusUnauthorized)
-				return
-			}
-
 			if session != nil {
 				r = r.WithContext(authcontext.SetAuthnUser(ctx, session.User))
 			}

--- a/internal/backend/auth/authhttpmiddleware/authmiddleware.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware.go
@@ -7,7 +7,6 @@ import (
 	"go.uber.org/fx"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authcontext"
-	"go.autokitteh.dev/autokitteh/internal/backend/auth/authloginhttpsvc"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authsessions"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authtokens"
 	"go.autokitteh.dev/autokitteh/internal/backend/configset"
@@ -97,7 +96,7 @@ func New(deps Deps) AuthMiddlewareDecorator {
 		f := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if deps.Cfg.Required {
 				if user := authcontext.GetAuthnUser(r.Context()); !user.IsValid() {
-					authloginhttpsvc.RedirectToLogin(w, r, r.URL)
+					http.Error(w, "invalid session", http.StatusUnauthorized)
 					return
 				}
 			}

--- a/internal/backend/auth/authhttpmiddleware/authmiddleware.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware.go
@@ -96,7 +96,7 @@ func New(deps Deps) AuthMiddlewareDecorator {
 		f := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if deps.Cfg.Required {
 				if user := authcontext.GetAuthnUser(r.Context()); !user.IsValid() {
-					http.Error(w, "invalid session", http.StatusUnauthorized)
+					http.Error(w, "unauthorized user", http.StatusUnauthorized)
 					return
 				}
 			}

--- a/internal/backend/auth/authhttpmiddleware/authmiddleware.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware.go
@@ -79,7 +79,7 @@ func newSessionsMiddleware(next http.Handler, sessions authsessions.Store) http.
 		if user := authcontext.GetAuthnUser(ctx); !user.IsValid() {
 			session, err := sessions.Get(r)
 			if err != nil {
-				http.Error(w, "invalid session", http.StatusUnauthorized)
+				http.Redirect(w, r, "/login", http.StatusFound)
 				return
 			}
 

--- a/internal/backend/auth/authloginhttpsvc/svc.go
+++ b/internal/backend/auth/authloginhttpsvc/svc.go
@@ -191,7 +191,7 @@ func (a *svc) newSuccessLoginHandler(user sdktypes.User) http.Handler {
 			return
 		}
 
-		sd := authsessions.SessionData{User: user}
+		sd := authsessions.NewSessionData(user)
 
 		if err := a.Deps.Sessions.Set(w, &sd); err != nil {
 			a.Z.Error("failed storing session", zap.Error(err))

--- a/internal/backend/auth/authsessions/store.go
+++ b/internal/backend/auth/authsessions/store.go
@@ -94,6 +94,9 @@ func (s store) Set(w http.ResponseWriter, data *sessionData) error {
 func (s store) Get(req *http.Request) (*sessionData, error) {
 	loggedIn, err := req.Cookie(loggedInCookie)
 	if err != nil {
+		if errors.Is(err, http.ErrNoCookie) {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/internal/backend/auth/authsessions/store.go
+++ b/internal/backend/auth/authsessions/store.go
@@ -66,7 +66,7 @@ func (s store) Set(w http.ResponseWriter, data *SessionData) error {
 
 	http.SetCookie(w, &http.Cookie{
 		Name:  loggedInCookie,
-		Value: "",
+		Value: "true",
 		Path:  "/",
 	})
 

--- a/internal/backend/auth/authsessions/store_test.go
+++ b/internal/backend/auth/authsessions/store_test.go
@@ -43,12 +43,12 @@ func (b baseMockSessionStore) Destroy(w http.ResponseWriter, name string) {
 	b.destroy(w, name)
 }
 
-func TestStoreGetNoLoggedinCookieReturnError(t *testing.T) {
+func TestStoreGetNoLoggedinCookie(t *testing.T) {
 	s := store{store: baseMockSessionStore{}}
 	r := http.Request{}
 	sd, err := s.Get(&r)
 	assert.Nil(t, sd)
-	assert.ErrorIs(t, err, http.ErrNoCookie)
+	assert.Nil(t, err)
 }
 
 func TestStoreGetInvalidLoggedInCookie(t *testing.T) {

--- a/internal/backend/auth/authsessions/store_test.go
+++ b/internal/backend/auth/authsessions/store_test.go
@@ -1,50 +1,32 @@
 package authsessions
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
-	"github.com/dghubble/sessions"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-// A type used as a mocked underlying sessions store
-// With this we can control in each test what each dependent function would return
-// So we can test for edge cases easily
-type baseMockSessionStore struct {
-	sessions.Store[[]byte]
-	nnew    func(name string) *sessions.Session[[]byte]
-	get     func(*http.Request, string) (*sessions.Session[[]byte], error)
-	save    func(http.ResponseWriter, *sessions.Session[[]byte]) error
-	destroy func(http.ResponseWriter, string)
+func newStore(t *testing.T) Store {
+	cfg := Configs.Dev
+	s, err := New(cfg)
+	assert.NoError(t, err)
+	return s
 }
 
-func (b baseMockSessionStore) New(name string) *sessions.Session[[]byte] {
-	return b.nnew(name)
-}
-
-func (b baseMockSessionStore) Get(req *http.Request, name string) (*sessions.Session[[]byte], error) {
-	return b.get(req, name)
-}
-
-// Save writes a Session to the ResponseWriter
-func (b baseMockSessionStore) Save(w http.ResponseWriter, session *sessions.Session[[]byte]) error {
-	return b.save(w, session)
-}
-
-// Destroy removes (expires) a named Session
-func (b baseMockSessionStore) Destroy(w http.ResponseWriter, name string) {
-	b.destroy(w, name)
+func newRequestWithLoggedInCookie(value int64) http.Request {
+	return http.Request{
+		Header: http.Header{
+			"Cookie": []string{fmt.Sprintf("ak_logged_in=%d", value)},
+		},
+	}
 }
 
 func TestStoreGetNoLoggedinCookie(t *testing.T) {
-	s := store{store: baseMockSessionStore{}}
+	s := newStore(t)
 	r := http.Request{}
 	sd, err := s.Get(&r)
 	assert.Nil(t, sd)
@@ -52,10 +34,10 @@ func TestStoreGetNoLoggedinCookie(t *testing.T) {
 }
 
 func TestStoreGetInvalidLoggedInCookie(t *testing.T) {
-	s := store{store: baseMockSessionStore{}}
+	s := newStore(t)
 	r := http.Request{
 		Header: http.Header{
-			"Cookie": []string{"ak_logged_in=kjs"},
+			"Cookie": []string{"ak_logged_in=k1k2"},
 		},
 	}
 	sd, err := s.Get(&r)
@@ -64,187 +46,64 @@ func TestStoreGetInvalidLoggedInCookie(t *testing.T) {
 }
 
 func TestStoreGetNoSessionCookie(t *testing.T) {
-	baseStore := baseMockSessionStore{
-		get: func(r *http.Request, s string) (*sessions.Session[[]byte], error) {
-			return nil, http.ErrNoCookie
-		},
-	}
-
-	s := store{store: baseStore}
-	r := http.Request{
-		Header: http.Header{
-			"Cookie": []string{"ak_logged_in=8383"},
-		},
-	}
+	s := newStore(t)
+	r := newRequestWithLoggedInCookie(8383)
 	sd, err := s.Get(&r)
 	assert.Nil(t, sd)
 	assert.Nil(t, err)
 }
 
 func TestStoreGetInvalidSessionCookie(t *testing.T) {
-	baseStore := baseMockSessionStore{
-		get: func(r *http.Request, s string) (*sessions.Session[[]byte], error) {
-			return nil, errors.New("something")
-		},
-	}
+	s := newStore(t)
+	r := newRequestWithLoggedInCookie(8383)
 
-	s := store{store: baseStore}
-	r := http.Request{
-		Header: http.Header{
-			"Cookie": []string{"ak_logged_in=8383"},
-		},
-	}
+	r.AddCookie(&http.Cookie{
+		Name:  sessionName,
+		Value: "invalid_value",
+	})
+
 	sd, err := s.Get(&r)
 	assert.Nil(t, sd)
 	assert.Error(t, err)
 }
 
-func TestStoreGetInvalidSessionCookieStructure(t *testing.T) {
-	baseStore := baseMockSessionStore{
-		get: func(r *http.Request, s string) (*sessions.Session[[]byte], error) {
-			return &sessions.Session[[]byte]{}, nil
-		},
-	}
+func TestStoreGetValidatorMismatch(t *testing.T) {
+	s := newStore(t)
+	w := httptest.NewRecorder()
+	validator := int64(123)
+	err := s.Set(w, &sessionData{
+		User:      sdktypes.DefaultUser,
+		Validator: validator,
+	})
+	assert.Nil(t, err)
 
-	s := store{store: baseStore}
-	r := http.Request{
-		Header: http.Header{
-			"Cookie": []string{"ak_logged_in=8383"},
-		},
-	}
+	otherValidator := validator + 1
+	r := newRequestWithLoggedInCookie(otherValidator)
+	r.AddCookie(w.Result().Cookies()[0])
+
 	sd, err := s.Get(&r)
 	assert.Nil(t, sd)
 	assert.Error(t, err)
 }
 
-func TestStoreGetInvalidValidator(t *testing.T) {
-	baseStore := baseMockSessionStore{}
-
-	var mockSession *sessions.Session[[]byte]
-
-	baseStore.nnew = func(name string) *sessions.Session[[]byte] {
-		mockSession = sessions.NewSession(baseStore, sessionName)
-		return mockSession
+func TestStoreSetGetSuccess(t *testing.T) {
+	s := newStore(t)
+	w := httptest.NewRecorder()
+	validator := int64(123)
+	expectedSessionData := &sessionData{
+		User:      sdktypes.DefaultUser,
+		Validator: validator,
 	}
-	s := store{store: &baseStore}
-	validator := int64(111)
-	invalidValidator := validator + 1
-	session, err := s.newSessionWithData(&sessionData{Validator: validator, User: sdktypes.DefaultUser})
-	require.Nil(t, err)
+	err := s.Set(w, expectedSessionData)
+	assert.Nil(t, err)
 
-	baseStore.get = func(r *http.Request, s string) (*sessions.Session[[]byte], error) {
-		return session, nil
-	}
+	securedCookie := w.Result().Cookies()[0]
 
-	r := http.Request{
-		Header: http.Header{
-			"Cookie": []string{fmt.Sprintf("ak_logged_in=%d", invalidValidator)},
-		},
-	}
-	sd, err := s.Get(&r)
-	assert.Nil(t, sd)
-	assert.Error(t, err)
-}
+	r := newRequestWithLoggedInCookie(validator)
+	r.AddCookie(securedCookie)
 
-func TestStoreGetSuccess(t *testing.T) {
-	baseStore := baseMockSessionStore{}
-
-	var mockSession *sessions.Session[[]byte]
-
-	baseStore.nnew = func(name string) *sessions.Session[[]byte] {
-		mockSession = sessions.NewSession(baseStore, sessionName)
-		return mockSession
-	}
-	s := store{store: &baseStore}
-	validator := int64(111)
-	mockedSessionData := &sessionData{Validator: validator, User: sdktypes.DefaultUser}
-	session, err := s.newSessionWithData(mockedSessionData)
-	require.Nil(t, err)
-
-	baseStore.get = func(r *http.Request, s string) (*sessions.Session[[]byte], error) {
-		return session, nil
-	}
-
-	r := http.Request{
-		Header: http.Header{
-			"Cookie": []string{fmt.Sprintf("ak_logged_in=%d", validator)},
-		},
-	}
 	sd, err := s.Get(&r)
 	assert.Nil(t, err)
-	assert.Equal(t, sd, mockedSessionData)
-}
-
-// Set Tests
-func TestStoreSetSessionSuccess(t *testing.T) {
-	// Prepare
-	w := httptest.NewRecorder()
-	didSaveHTTPOnlyCookie := false
-	baseStore := baseMockSessionStore{
-		save: func(w http.ResponseWriter, s *sessions.Session[[]byte]) error {
-			// If this is called, it means the session save method was called
-			// meaning the cookie is saved to the http request
-			didSaveHTTPOnlyCookie = true
-			return nil
-		},
-	}
-
-	var mockSession *sessions.Session[[]byte]
-
-	baseStore.nnew = func(name string) *sessions.Session[[]byte] {
-		mockSession = sessions.NewSession(baseStore, sessionName)
-		return mockSession
-	}
-
-	s := store{store: baseStore}
-
-	validator := time.Now().Unix()
-	// Test
-	err := s.Set(w, &sessionData{Validator: validator, User: sdktypes.DefaultUser})
-
-	// Assert
-	assert.Nil(t, err)
-	responseCookies := w.Result().Cookies()
-
-	// Verify is logged in cookie
-	assert.Equal(t, len(responseCookies), 1) // http only cookie ie not fully set since we mock the session store
-	cookie := responseCookies[0]
-	assert.Equal(t, cookie.Name, loggedInCookie)
-	assert.Equal(t, cookie.Value, fmt.Sprintf("%d", validator))
-	assert.Equal(t, cookie.Path, "/")
-
-	// verify session cookie
-	assert.True(t, didSaveHTTPOnlyCookie)
-	assert.Equal(t, mockSession.Name(), sessionName)
-}
-
-func TestStoreSetSessionSaveFailed(t *testing.T) {
-	// Prepare
-	w := httptest.NewRecorder()
-	baseStore := baseMockSessionStore{
-		save: func(w http.ResponseWriter, s *sessions.Session[[]byte]) error {
-			return errors.New("something")
-		},
-	}
-
-	var mockSession *sessions.Session[[]byte]
-
-	baseStore.nnew = func(name string) *sessions.Session[[]byte] {
-		mockSession = sessions.NewSession(baseStore, sessionName)
-		return mockSession
-	}
-
-	s := store{store: baseStore}
-
-	validator := time.Now().Unix()
-
-	// Test
-	err := s.Set(w, &sessionData{Validator: validator, User: sdktypes.DefaultUser})
-
-	// Assert
-	assert.Error(t, err)
-	responseCookies := w.Result().Cookies()
-
-	// Verify is logged in cookie
-	assert.Equal(t, len(responseCookies), 0) // http only cookie ie not fully set since we mock the session store
+	assert.Equal(t, sd.Validator, expectedSessionData.Validator)
+	assert.Equal(t, sd.User, expectedSessionData.User)
 }

--- a/internal/backend/auth/authsessions/store_test.go
+++ b/internal/backend/auth/authsessions/store_test.go
@@ -1,0 +1,250 @@
+package authsessions
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dghubble/sessions"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+// A type used as a mocked underlying sessions store
+// With this we can control in each test what each dependent function would return
+// So we can test for edge cases easily
+type baseMockSessionStore struct {
+	sessions.Store[[]byte]
+	nnew    func(name string) *sessions.Session[[]byte]
+	get     func(*http.Request, string) (*sessions.Session[[]byte], error)
+	save    func(http.ResponseWriter, *sessions.Session[[]byte]) error
+	destroy func(http.ResponseWriter, string)
+}
+
+func (b baseMockSessionStore) New(name string) *sessions.Session[[]byte] {
+	return b.nnew(name)
+}
+
+func (b baseMockSessionStore) Get(req *http.Request, name string) (*sessions.Session[[]byte], error) {
+	return b.get(req, name)
+}
+
+// Save writes a Session to the ResponseWriter
+func (b baseMockSessionStore) Save(w http.ResponseWriter, session *sessions.Session[[]byte]) error {
+	return b.save(w, session)
+}
+
+// Destroy removes (expires) a named Session
+func (b baseMockSessionStore) Destroy(w http.ResponseWriter, name string) {
+	b.destroy(w, name)
+}
+
+func TestStoreGetNoLoggedinCookieReturnError(t *testing.T) {
+	s := store{store: baseMockSessionStore{}}
+	r := http.Request{}
+	sd, err := s.Get(&r)
+	assert.Nil(t, sd)
+	assert.ErrorIs(t, err, http.ErrNoCookie)
+}
+
+func TestStoreGetInvalidLoggedInCookie(t *testing.T) {
+	s := store{store: baseMockSessionStore{}}
+	r := http.Request{
+		Header: http.Header{
+			"Cookie": []string{"ak_logged_in=kjs"},
+		},
+	}
+	sd, err := s.Get(&r)
+	assert.Nil(t, sd)
+	assert.Equal(t, err.Error(), "invalid logged in cookie")
+}
+
+func TestStoreGetNoSessionCookie(t *testing.T) {
+	baseStore := baseMockSessionStore{
+		get: func(r *http.Request, s string) (*sessions.Session[[]byte], error) {
+			return nil, http.ErrNoCookie
+		},
+	}
+
+	s := store{store: baseStore}
+	r := http.Request{
+		Header: http.Header{
+			"Cookie": []string{"ak_logged_in=8383"},
+		},
+	}
+	sd, err := s.Get(&r)
+	assert.Nil(t, sd)
+	assert.Nil(t, err)
+}
+
+func TestStoreGetInvalidSessionCookie(t *testing.T) {
+	baseStore := baseMockSessionStore{
+		get: func(r *http.Request, s string) (*sessions.Session[[]byte], error) {
+			return nil, errors.New("something")
+		},
+	}
+
+	s := store{store: baseStore}
+	r := http.Request{
+		Header: http.Header{
+			"Cookie": []string{"ak_logged_in=8383"},
+		},
+	}
+	sd, err := s.Get(&r)
+	assert.Nil(t, sd)
+	assert.Error(t, err)
+}
+
+func TestStoreGetInvalidSessionCookieStructure(t *testing.T) {
+	baseStore := baseMockSessionStore{
+		get: func(r *http.Request, s string) (*sessions.Session[[]byte], error) {
+			return &sessions.Session[[]byte]{}, nil
+		},
+	}
+
+	s := store{store: baseStore}
+	r := http.Request{
+		Header: http.Header{
+			"Cookie": []string{"ak_logged_in=8383"},
+		},
+	}
+	sd, err := s.Get(&r)
+	assert.Nil(t, sd)
+	assert.Error(t, err)
+}
+
+func TestStoreGetInvalidValidator(t *testing.T) {
+	baseStore := baseMockSessionStore{}
+
+	var mockSession *sessions.Session[[]byte]
+
+	baseStore.nnew = func(name string) *sessions.Session[[]byte] {
+		mockSession = sessions.NewSession(baseStore, sessionName)
+		return mockSession
+	}
+	s := store{store: &baseStore}
+	validator := int64(111)
+	invalidValidator := validator + 1
+	session, err := s.newSessionWithData(&sessionData{Validator: validator, User: sdktypes.DefaultUser})
+	require.Nil(t, err)
+
+	baseStore.get = func(r *http.Request, s string) (*sessions.Session[[]byte], error) {
+		return session, nil
+	}
+
+	r := http.Request{
+		Header: http.Header{
+			"Cookie": []string{fmt.Sprintf("ak_logged_in=%d", invalidValidator)},
+		},
+	}
+	sd, err := s.Get(&r)
+	assert.Nil(t, sd)
+	assert.Error(t, err)
+}
+
+func TestStoreGetSuccess(t *testing.T) {
+	baseStore := baseMockSessionStore{}
+
+	var mockSession *sessions.Session[[]byte]
+
+	baseStore.nnew = func(name string) *sessions.Session[[]byte] {
+		mockSession = sessions.NewSession(baseStore, sessionName)
+		return mockSession
+	}
+	s := store{store: &baseStore}
+	validator := int64(111)
+	mockedSessionData := &sessionData{Validator: validator, User: sdktypes.DefaultUser}
+	session, err := s.newSessionWithData(mockedSessionData)
+	require.Nil(t, err)
+
+	baseStore.get = func(r *http.Request, s string) (*sessions.Session[[]byte], error) {
+		return session, nil
+	}
+
+	r := http.Request{
+		Header: http.Header{
+			"Cookie": []string{fmt.Sprintf("ak_logged_in=%d", validator)},
+		},
+	}
+	sd, err := s.Get(&r)
+	assert.Nil(t, err)
+	assert.Equal(t, sd, mockedSessionData)
+}
+
+// Set Tests
+func TestStoreSetSessionSuccess(t *testing.T) {
+	// Prepare
+	w := httptest.NewRecorder()
+	didSaveHTTPOnlyCookie := false
+	baseStore := baseMockSessionStore{
+		save: func(w http.ResponseWriter, s *sessions.Session[[]byte]) error {
+			// If this is called, it means the session save method was called
+			// meaning the cookie is saved to the http request
+			didSaveHTTPOnlyCookie = true
+			return nil
+		},
+	}
+
+	var mockSession *sessions.Session[[]byte]
+
+	baseStore.nnew = func(name string) *sessions.Session[[]byte] {
+		mockSession = sessions.NewSession(baseStore, sessionName)
+		return mockSession
+	}
+
+	s := store{store: baseStore}
+
+	validator := time.Now().Unix()
+	// Test
+	err := s.Set(w, &sessionData{Validator: validator, User: sdktypes.DefaultUser})
+
+	// Assert
+	assert.Nil(t, err)
+	responseCookies := w.Result().Cookies()
+
+	// Verify is logged in cookie
+	assert.Equal(t, len(responseCookies), 1) // http only cookie ie not fully set since we mock the session store
+	cookie := responseCookies[0]
+	assert.Equal(t, cookie.Name, loggedInCookie)
+	assert.Equal(t, cookie.Value, fmt.Sprintf("%d", validator))
+	assert.Equal(t, cookie.Path, "/")
+
+	// verify session cookie
+	assert.True(t, didSaveHTTPOnlyCookie)
+	assert.Equal(t, mockSession.Name(), sessionName)
+}
+
+func TestStoreSetSessionSaveFailed(t *testing.T) {
+	// Prepare
+	w := httptest.NewRecorder()
+	baseStore := baseMockSessionStore{
+		save: func(w http.ResponseWriter, s *sessions.Session[[]byte]) error {
+			return errors.New("something")
+		},
+	}
+
+	var mockSession *sessions.Session[[]byte]
+
+	baseStore.nnew = func(name string) *sessions.Session[[]byte] {
+		mockSession = sessions.NewSession(baseStore, sessionName)
+		return mockSession
+	}
+
+	s := store{store: baseStore}
+
+	validator := time.Now().Unix()
+
+	// Test
+	err := s.Set(w, &sessionData{Validator: validator, User: sdktypes.DefaultUser})
+
+	// Assert
+	assert.Error(t, err)
+	responseCookies := w.Result().Cookies()
+
+	// Verify is logged in cookie
+	assert.Equal(t, len(responseCookies), 0) // http only cookie ie not fully set since we mock the session store
+}


### PR DESCRIPTION
we add a non http only cookie named ak_logged_in
so frontend can remove it when user logs out
we always validate both cookies exists
in this way we keep the authenticated cookie secured and allow the frontend to logout without additional api on the backend side

