### PR TITLE
test: allow to capture jq expressions from output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -178,6 +178,8 @@ require (
 	github.com/inconshreveable/log15 v3.0.0-testing.5+incompatible // indirect
 	github.com/inconshreveable/log15/v3 v3.0.0-testing.5 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/itchyny/gojq v0.12.16 // indirect
+	github.com/itchyny/timefmt-go v0.1.6 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.6.0 // indirect
@@ -198,6 +200,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/microsoft/go-mssqldb v1.7.2 // indirect
@@ -212,6 +215,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/robfig/cron v1.2.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -368,6 +368,10 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.12.0 h1:6ovsNSuvn9wEQVOyc72aycBMVQFKz7cPdMJn10CvzRI=
 github.com/invopop/jsonschema v0.12.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
+github.com/itchyny/gojq v0.12.16 h1:yLfgLxhIr/6sJNVmYfQjTIv0jGctu6/DgDoivmxTr7g=
+github.com/itchyny/gojq v0.12.16/go.mod h1:6abHbdC2uB9ogMS38XsErnfqJ94UlngIJGlRAIj4jTM=
+github.com/itchyny/timefmt-go v0.1.6 h1:ia3s54iciXDdzWzwaVKXZPbiXzxxnv1SPGFfM/myJ5Q=
+github.com/itchyny/timefmt-go v0.1.6/go.mod h1:RRDZYC5s9ErkjQvTvvU7keJjxUYzIISJGxm9/mAERQg=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
@@ -451,6 +455,8 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
+github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
+github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=
@@ -505,6 +511,9 @@ github.com/redis/go-redis/v9 v9.5.3/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/tests/system/ak_test.go
+++ b/tests/system/ak_test.go
@@ -44,10 +44,6 @@ func TestSuite(t *testing.T) {
 			return nil // Skip directories and non-test files.
 		}
 
-		if !strings.HasSuffix(path, "build.txtar") {
-			return nil
-		}
-
 		// Each .txtar file is a test-case, with potentially
 		// multiple actions, checks, and embedded files.
 		t.Run(strings.TrimPrefix(path, rootDir), func(t *testing.T) {

--- a/tests/system/ak_test.go
+++ b/tests/system/ak_test.go
@@ -44,6 +44,10 @@ func TestSuite(t *testing.T) {
 			return nil // Skip directories and non-test files.
 		}
 
+		if !strings.HasSuffix(path, "build.txtar") {
+			return nil
+		}
+
 		// Each .txtar file is a test-case, with potentially
 		// multiple actions, checks, and embedded files.
 		t.Run(strings.TrimPrefix(path, rootDir), func(t *testing.T) {
@@ -103,6 +107,8 @@ func runTestSteps(t *testing.T, steps []string, akPath, akAddr string) {
 			continue
 		}
 
+		step = expandCapture(step)
+
 		// Actions: ak, http, wait.
 		if actions.MatchString(step) {
 			// Before starting a new action, if there's a pending HTTP
@@ -160,7 +166,7 @@ func runTestSteps(t *testing.T, steps []string, akPath, akAddr string) {
 		}
 
 		// Checks: ak output, ak return code, http resp.
-		if err := runCheck(step, ak, httpResp); err != nil {
+		if err := runCheck(t, step, ak, httpResp); err != nil {
 			t.Errorf("line %d: %s", actionIndex+1, steps[actionIndex])
 			t.Errorf("line %d: %s", i+1, step)
 			// Fail-fast, don't run subsequent test steps.

--- a/tests/system/checks.go
+++ b/tests/system/checks.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"testing"
 
 	"github.com/hexops/gotextdiff"
 	"github.com/hexops/gotextdiff/myers"
@@ -14,7 +15,7 @@ import (
 	jd "github.com/josephburnett/jd/lib"
 )
 
-func runCheck(step string, ak *akResult, resp *httpResponse) error {
+func runCheck(t *testing.T, step string, ak *akResult, resp *httpResponse) error {
 	match := steps.FindStringSubmatch(step)
 	switch match[1] {
 	case "output":
@@ -23,6 +24,8 @@ func runCheck(step string, ak *akResult, resp *httpResponse) error {
 		return checkAKReturnCode(step, ak)
 	case "resp":
 		return checkHTTPResponse(step, resp)
+	case "capture_jq":
+		return captureJQ(t, step, ak, resp)
 	default:
 		return errors.New("unhandled check")
 	}

--- a/tests/system/jq.go
+++ b/tests/system/jq.go
@@ -1,0 +1,60 @@
+package systest
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/itchyny/gojq"
+)
+
+var captures = make(map[string]string)
+
+// TODO: parse http response.
+
+func captureJQ(t *testing.T, step string, ak *akResult, _ *httpResponse) error {
+	match := jqCheck.FindStringSubmatch(step)
+	name, query := match[1], match[2]
+
+	q, err := gojq.Parse(query)
+	if err != nil {
+		return fmt.Errorf("invalid jq query: %w", err)
+	}
+
+	var x any
+	if err := json.Unmarshal([]byte(ak.output), &x); err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	iter := q.Run(x)
+
+	var (
+		vs []string
+		ok = true
+	)
+
+	for ok {
+		var v any
+		if v, ok = iter.Next(); ok {
+			vs = append(vs, fmt.Sprint(v))
+		}
+	}
+
+	if len(vs) == 0 {
+		return fmt.Errorf("jq query returned no results: %s", query)
+	}
+
+	t.Logf("captured %q into %q", vs, name)
+
+	captures[name] = strings.Join(vs, ",")
+
+	return nil
+}
+
+func expandCapture(s string) string {
+	return os.Expand(s, func(key string) string {
+		return captures[key]
+	})
+}

--- a/tests/system/parse.go
+++ b/tests/system/parse.go
@@ -16,13 +16,16 @@ const (
 )
 
 var (
-	steps = regexp.MustCompile(`^(ak|http|output|req|resp|return|wait|setenv)\s`)
+	steps = regexp.MustCompile(`^(ak|http|output|req|resp|return|wait|setenv|capture_jq)\s`)
 
 	// ak *
 	// http <get|post> *
 	actions = regexp.MustCompile(`^(ak|http\s+(get|post)|wait|setenv)\s+(.+)`)
 	// wait <duration> for session <session ID>
 	waitAction = regexp.MustCompile(`^wait\s+(.+)\s+(for|unless)\s+session\s+(.+)`)
+
+	// capture_jq <name> <jq expression>
+	jqCheck = regexp.MustCompile(`^capture_jq\s+(\w+)\s+(.+)`)
 
 	// output <equals|equals_json|contains|regex> [file] *
 	akCheckOutput = regexp.MustCompile(`^output\s+(equals|equals_json|contains|regex)\s+(file\s+)?(.+|'.*')`)
@@ -140,6 +143,11 @@ func parseTestFile(t *testing.T, a *txtar.Archive) []string {
 		case "resp":
 			if !httpCheckOutput.MatchString(line) && !httpCheckStatus.MatchString(line) && !httpCheckHeader.MatchString(line) {
 				t.Errorf("invalid HTTP response check in line %d: %s", i+1, line)
+				errors++
+			}
+		case "capture_jq":
+			if !jqCheck.MatchString(line) {
+				t.Errorf("invalid jq capture in line %d: %s", i+1, line)
 				errors++
 			}
 		}

--- a/tests/system/testdata/builds/build.txtar
+++ b/tests/system/testdata/builds/build.txtar
@@ -1,14 +1,14 @@
 # Precondition: create project.
-ak project create --name my_project
+ak project create --name my_project -j
 return code == 0
-output equals 'project_id: prj_00000000000000000000000001'
+capture_jq pid .project_id
 
 # Build project from a single file.
-ak project build my_project --file meow.star
+ak project build my_project --file meow.star -j
 return code == 0
-output equals 'build_id: bld_00000000000000000000000003'
+capture_jq bid .build_id
 
-ak build describe bld_00000000000000000000000003 -j
+ak build describe $bid -j
 return code == 0
 output equals_json file build.json
 


### PR DESCRIPTION
this is a proposal that can lead to getting rid of "test mode" in ak. this allows to capture results from ak commands using jq queries, and then use them later. the same can be done with regexps.