### PR TITLE
bug(python): trim logs

### DIFF
--- a/runtimes/pythonrt/ak_runner/call.py
+++ b/runtimes/pythonrt/ak_runner/call.py
@@ -84,15 +84,11 @@ class AKCall:
 
         if not self.should_run_as_activity(func):
             log.info(
-                "calling %s (args=%r, kw=%r) directly (in_activity=%s)",
-                func.__name__,
-                args,
-                kw,
-                self.in_activity,
+                "calling %s directly (in_activity=%s)", func.__name__, self.in_activity
             )
             return func(*args, **kw)
 
-        log.info("ACTION: activity call %s(%r, %r)", func.__name__, args, kw)
+        log.info("ACTION: activity call %s", func.__name__)
         self.in_activity = True
         try:
             self.call_info = CallInfo(func, args, kw)


### PR DESCRIPTION
Currently the logs from Python are too spammy, mostly since they emit the messages running between Python & Go. This PR reduces the amount of logging.

Fixes ENG-1443