### PR TITLE
add a domain to both ui cookies

### DIFF
--- a/internal/backend/auth/authsessions/config.go
+++ b/internal/backend/auth/authsessions/config.go
@@ -22,6 +22,5 @@ var Configs = configset.Set[Config]{
 		Secure:     false,
 		SameSite:   http.SameSiteLaxMode,
 		CookieKeys: "0000000000000000000000000000000000000000000000000000000000000000,0000000000000000000000000000000000000000000000000000000000000000",
-		Domain:     "localhost",
 	},
 }

--- a/internal/backend/auth/authsessions/config.go
+++ b/internal/backend/auth/authsessions/config.go
@@ -17,7 +17,6 @@ var Configs = configset.Set[Config]{
 	Default: &Config{
 		SameSite: http.SameSiteNoneMode,
 		Secure:   true,
-		Domain:   "autokitteh.cloud",
 	},
 	Dev: &Config{
 		Secure:     false,

--- a/internal/backend/auth/authsessions/config.go
+++ b/internal/backend/auth/authsessions/config.go
@@ -3,26 +3,26 @@ package authsessions
 import (
 	"net/http"
 
-	"github.com/dghubble/sessions"
-
 	"go.autokitteh.dev/autokitteh/internal/backend/configset"
 )
 
 type Config struct {
-	Cookie     *sessions.CookieConfig
+	SameSite   http.SameSite
 	CookieKeys string `koanf:"cookie_keys"` // pairs of hash and block keys.
+	Domain     string `koanf:"ui_domain"`
+	Secure     bool
 }
 
 var Configs = configset.Set[Config]{
 	Default: &Config{
-		Cookie: func() *sessions.CookieConfig {
-			c := sessions.DefaultCookieConfig
-			c.SameSite = http.SameSiteNoneMode
-			return c
-		}(),
+		SameSite: http.SameSiteNoneMode,
+		Secure:   true,
+		Domain:   "autokitteh.cloud",
 	},
 	Dev: &Config{
-		Cookie:     sessions.DebugCookieConfig,
+		Secure:     false,
+		SameSite:   http.SameSiteLaxMode,
 		CookieKeys: "0000000000000000000000000000000000000000000000000000000000000000,0000000000000000000000000000000000000000000000000000000000000000",
+		Domain:     "localhost",
 	},
 }

--- a/internal/backend/auth/authsessions/store.go
+++ b/internal/backend/auth/authsessions/store.go
@@ -35,9 +35,10 @@ func NewSessionData(user sdktypes.User) sessionData {
 }
 
 type store struct {
-	store  sessions.Store[[]byte]
-	domain string
-	secure bool
+	store    sessions.Store[[]byte]
+	domain   string
+	secure   bool
+	sameSite http.SameSite
 }
 
 type Store interface {
@@ -71,9 +72,10 @@ func New(cfg *Config) (Store, error) {
 	}
 
 	return &store{
-		store:  sessions.NewCookieStore[[]byte](&cookieConfig, keyPairs...),
-		domain: domain,
-		secure: cfg.Secure,
+		store:    sessions.NewCookieStore[[]byte](&cookieConfig, keyPairs...),
+		domain:   domain,
+		secure:   cfg.Secure,
+		sameSite: cfg.SameSite,
 	}, nil
 }
 
@@ -104,7 +106,7 @@ func (s store) Set(w http.ResponseWriter, data *sessionData) error {
 		Value:    fmt.Sprintf("%d", data.Validator),
 		Path:     "/",
 		Domain:   s.domain,
-		SameSite: http.SameSiteNoneMode,
+		SameSite: s.sameSite,
 		Secure:   s.secure,
 	})
 

--- a/internal/backend/auth/authsessions/store.go
+++ b/internal/backend/auth/authsessions/store.go
@@ -58,7 +58,7 @@ func New(cfg *Config) (Store, error) {
 	}
 
 	domain := cfg.Domain
-	if !strings.HasPrefix(domain, ".") {
+	if len(domain) > 0 && !strings.HasPrefix(domain, ".") {
 		domain = fmt.Sprintf(".%s", cfg.Domain)
 	}
 


### PR DESCRIPTION
backend and frontend might be served from different subdomains, 
we need to set the cookie for the top level domain (.autokitteh.cloud)
but it might be another in on prem installations

this sets some defaults and allow setting the values