### PR TITLE
fix(github)!: remove owner from OAuth connection var names

### DIFF
--- a/integrations/github/actions.go
+++ b/integrations/github/actions.go
@@ -32,7 +32,7 @@ func (i integration) listWorkflowRuns(ctx context.Context, args []sdktypes.Value
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}

--- a/integrations/github/checks.go
+++ b/integrations/github/checks.go
@@ -24,7 +24,7 @@ func (i integration) createCheckRun(ctx context.Context, args []sdktypes.Value, 
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -54,7 +54,7 @@ func (i integration) updateCheckRun(ctx context.Context, args []sdktypes.Value, 
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}

--- a/integrations/github/commits.go
+++ b/integrations/github/commits.go
@@ -26,7 +26,7 @@ func (i integration) listCommits(ctx context.Context, args []sdktypes.Value, kwa
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}

--- a/integrations/github/copilot.go
+++ b/integrations/github/copilot.go
@@ -16,7 +16,7 @@ func (i integration) getCopilotBilling(ctx context.Context, args []sdktypes.Valu
 		return sdktypes.InvalidValue, err
 	}
 
-	gh, err := i.NewClient(ctx, org)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -39,7 +39,7 @@ func (i integration) listCopilotSeats(ctx context.Context, args []sdktypes.Value
 		return sdktypes.InvalidValue, err
 	}
 
-	gh, err := i.NewClient(ctx, org)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -62,7 +62,7 @@ func (i integration) addCopilotTeams(ctx context.Context, args []sdktypes.Value,
 		return sdktypes.InvalidValue, err
 	}
 
-	gh, err := i.NewClient(ctx, org)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -85,7 +85,7 @@ func (i integration) removeCopilotTeams(ctx context.Context, args []sdktypes.Val
 		return sdktypes.InvalidValue, err
 	}
 
-	gh, err := i.NewClient(ctx, org)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -108,7 +108,7 @@ func (i integration) addCopilotUsers(ctx context.Context, args []sdktypes.Value,
 		return sdktypes.InvalidValue, err
 	}
 
-	gh, err := i.NewClient(ctx, org)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -131,7 +131,7 @@ func (i integration) removeCopilotUsers(ctx context.Context, args []sdktypes.Val
 		return sdktypes.InvalidValue, err
 	}
 
-	gh, err := i.NewClient(ctx, org)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -151,7 +151,7 @@ func (i integration) getCopilotSeatDetails(ctx context.Context, args []sdktypes.
 		return sdktypes.InvalidValue, err
 	}
 
-	gh, err := i.NewClient(ctx, org)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}

--- a/integrations/github/git_refs.go
+++ b/integrations/github/git_refs.go
@@ -31,7 +31,7 @@ func (i integration) createRef(ctx context.Context, args []sdktypes.Value, kwarg
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -58,7 +58,7 @@ func (i integration) getRef(ctx context.Context, args []sdktypes.Value, kwargs m
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}

--- a/integrations/github/internal/vars/vars.go
+++ b/integrations/github/internal/vars/vars.go
@@ -2,31 +2,21 @@ package vars
 
 import (
 	"fmt"
-	"strings"
 
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 var (
-	UserAppID     = varKey("app_id")
-	UserInstallID = varKey("install_id")
+	// GitHub app (OAuth)
+	AppID     = sdktypes.NewSymbol("app_id")
+	InstallID = sdktypes.NewSymbol("install_id")
 
+	// PAT + webhook
 	PATKey    = sdktypes.NewSymbol("pat_key")
 	PATSecret = sdktypes.NewSymbol("pat_secret")
 	PAT       = sdktypes.NewSymbol("pat")
 	PATUser   = sdktypes.NewSymbol("pat_user")
 )
-
-func varKey(kind string) func(string) sdktypes.Symbol {
-	return func(user string) sdktypes.Symbol {
-		return sdktypes.NewSymbol(fmt.Sprintf("%s__%s", kind, encodeUser(user)))
-	}
-}
-
-func encodeUser(user string) string {
-	// Username may only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen.
-	return strings.ReplaceAll(user, "-", "_")
-}
 
 func InstallKey(appID, installID string) sdktypes.Symbol {
 	return sdktypes.NewSymbol(fmt.Sprintf("install_key__%s__%s", appID, installID))

--- a/integrations/github/issue_comments.go
+++ b/integrations/github/issue_comments.go
@@ -26,7 +26,7 @@ func (i integration) createIssueComment(ctx context.Context, args []sdktypes.Val
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}

--- a/integrations/github/issue_labels.go
+++ b/integrations/github/issue_labels.go
@@ -23,7 +23,7 @@ func (i integration) addIssueLabels(ctx context.Context, args []sdktypes.Value, 
 		return sdktypes.InvalidValue, err
 	}
 
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -51,7 +51,7 @@ func (i integration) removeIssueLabel(ctx context.Context, args []sdktypes.Value
 		return sdktypes.InvalidValue, err
 	}
 
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}

--- a/integrations/github/issues.go
+++ b/integrations/github/issues.go
@@ -29,7 +29,7 @@ func (i integration) createIssue(ctx context.Context, args []sdktypes.Value, kwa
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -58,7 +58,7 @@ func (i integration) getIssue(ctx context.Context, args []sdktypes.Value, kwargs
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -97,7 +97,7 @@ func (i integration) updateIssue(ctx context.Context, args []sdktypes.Value, kwa
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -135,7 +135,7 @@ func (i integration) listRepositoryIssues(ctx context.Context, args []sdktypes.V
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}

--- a/integrations/github/jwt.go
+++ b/integrations/github/jwt.go
@@ -33,7 +33,8 @@ const (
 	enterpriseURLEnvVar = "GITHUB_ENTERPRISE_URL"
 )
 
-func (i integration) NewClient(ctx context.Context, user string) (*github.Client, error) {
+// TODO: Remove "user"
+func (i integration) NewClient(ctx context.Context) (*github.Client, error) {
 	// Extract the connection token from the given context.
 	cid, err := sdkmodule.FunctionConnectionIDFromContext(ctx)
 	if err != nil {
@@ -46,30 +47,30 @@ func (i integration) NewClient(ctx context.Context, user string) (*github.Client
 	if pat := data.Get(vars.PAT); pat.IsValid() {
 		return github.NewTokenClient(ctx, pat.Value()), nil
 	} else {
-		return i.newClientWithInstallJWT(data, user)
+		return i.newClientWithInstallJWT(data)
 	}
 }
 
 // NewClientWithInstallJWT returns a GitHub client that
 // uses a newly-generated GitHub app installation JWT.
-func (i integration) newClientWithInstallJWT(data sdktypes.Vars, user string) (*github.Client, error) {
+func (i integration) newClientWithInstallJWT(data sdktypes.Vars) (*github.Client, error) {
 	// Initialize and return a GitHub client with a JWT.
-	s := data.GetValue(vars.UserAppID(user))
+	s := data.GetValue(vars.AppID)
 	if s == "" {
-		return nil, fmt.Errorf("app ID not found for owner %q", user)
+		return nil, fmt.Errorf("app ID not found")
 	}
 	aid, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("invalid app ID %q for owner %q", s, user)
+		return nil, fmt.Errorf("invalid app ID %q", s)
 	}
 
-	s = data.GetValue(vars.UserInstallID(user))
+	s = data.GetValue(vars.InstallID)
 	if s == "" {
-		return nil, fmt.Errorf("install ID not found for owner %q", user)
+		return nil, fmt.Errorf("install ID not found")
 	}
 	iid, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("invalid nstall ID %q for owner %q", s, user)
+		return nil, fmt.Errorf("invalid install ID %q", s)
 	}
 
 	return i.newClientWithInstallJWTFromGitHubIDs(aid, iid)

--- a/integrations/github/jwt.go
+++ b/integrations/github/jwt.go
@@ -33,7 +33,6 @@ const (
 	enterpriseURLEnvVar = "GITHUB_ENTERPRISE_URL"
 )
 
-// TODO: Remove "user"
 func (i integration) NewClient(ctx context.Context) (*github.Client, error) {
 	// Extract the connection token from the given context.
 	cid, err := sdkmodule.FunctionConnectionIDFromContext(ctx)

--- a/integrations/github/oauth.go
+++ b/integrations/github/oauth.go
@@ -130,8 +130,8 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 	user := string(*i.Account.Login)
 
 	c.Finalize(sdktypes.NewVars().
-		Set(vars.UserAppID(user), appID, false).
-		Set(vars.UserInstallID(user), installID, false).
+		Set(vars.AppID, appID, false).
+		Set(vars.InstallID, installID, false).
 		Set(vars.InstallKey(appID, installID), user, false))
 }
 

--- a/integrations/github/pulls.go
+++ b/integrations/github/pulls.go
@@ -37,7 +37,7 @@ func (i integration) createPullRequest(ctx context.Context, args []sdktypes.Valu
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -79,7 +79,7 @@ func (i integration) getPullRequest(ctx context.Context, args []sdktypes.Value, 
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -118,7 +118,7 @@ func (i integration) listPullRequests(ctx context.Context, args []sdktypes.Value
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -154,7 +154,7 @@ func (i integration) listPullRequestFiles(ctx context.Context, args []sdktypes.V
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -190,7 +190,7 @@ func (i integration) requestReview(ctx context.Context, args []sdktypes.Value, k
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}

--- a/integrations/github/reactions.go
+++ b/integrations/github/reactions.go
@@ -24,7 +24,7 @@ func (i integration) createReactionForCommitComment(ctx context.Context, args []
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -54,7 +54,7 @@ func (i integration) createReactionForIssue(ctx context.Context, args []sdktypes
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -84,7 +84,7 @@ func (i integration) createReactionForIssueComment(ctx context.Context, args []s
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -113,7 +113,7 @@ func (i integration) createReactionForPullRequestReviewComment(ctx context.Conte
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}

--- a/integrations/github/repo.go
+++ b/integrations/github/repo.go
@@ -26,7 +26,7 @@ func (i integration) listCollaborators(ctx context.Context, args []sdktypes.Valu
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}

--- a/integrations/github/repository_content.go
+++ b/integrations/github/repository_content.go
@@ -55,7 +55,7 @@ func (i integration) createOrUpdateFile(ctx context.Context, args []sdktypes.Val
 		opts.SHA = &sha
 	}
 
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -82,7 +82,7 @@ func (i integration) getContents(ctx context.Context, args []sdktypes.Value, kwa
 		return sdktypes.InvalidValue, err
 	}
 
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}

--- a/integrations/github/review_comments.go
+++ b/integrations/github/review_comments.go
@@ -40,7 +40,7 @@ func (i integration) createReviewComment(ctx context.Context, args []sdktypes.Va
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -73,7 +73,7 @@ func (i integration) createReviewCommentReply(ctx context.Context, args []sdktyp
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -104,7 +104,7 @@ func (i integration) deleteReviewComment(ctx context.Context, args []sdktypes.Va
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -135,7 +135,7 @@ func (i integration) getReviewComment(ctx context.Context, args []sdktypes.Value
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -175,7 +175,7 @@ func (i integration) listPullRequestReviewComments(ctx context.Context, args []s
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -229,7 +229,7 @@ func (i integration) updateReviewComment(ctx context.Context, args []sdktypes.Va
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}

--- a/integrations/github/reviews.go
+++ b/integrations/github/reviews.go
@@ -33,7 +33,7 @@ func (i integration) createReview(ctx context.Context, args []sdktypes.Value, kw
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -73,7 +73,7 @@ func (i integration) deletePendingReview(ctx context.Context, args []sdktypes.Va
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -108,7 +108,7 @@ func (i integration) dismissReview(ctx context.Context, args []sdktypes.Value, k
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -145,7 +145,7 @@ func (i integration) getReview(ctx context.Context, args []sdktypes.Value, kwarg
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -181,7 +181,7 @@ func (i integration) listReviews(ctx context.Context, args []sdktypes.Value, kwa
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -227,7 +227,7 @@ func (i integration) listReviewComments(ctx context.Context, args []sdktypes.Val
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -274,7 +274,7 @@ func (i integration) submitReview(ctx context.Context, args []sdktypes.Value, kw
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -312,7 +312,7 @@ func (i integration) updateReview(ctx context.Context, args []sdktypes.Value, kw
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}

--- a/integrations/github/users.go
+++ b/integrations/github/users.go
@@ -26,7 +26,7 @@ func (i integration) getUser(ctx context.Context, args []sdktypes.Value, kwargs 
 		// According to github docs, this endpoint requires no permissions.
 		gh, err = i.newAnonymousClient()
 	} else {
-		gh, err = i.NewClient(ctx, owner)
+		gh, err = i.NewClient(ctx)
 	}
 	if err != nil {
 		return sdktypes.InvalidValue, err
@@ -66,7 +66,7 @@ func (i integration) searchUsers(ctx context.Context, args []sdktypes.Value, kwa
 		// According to github docs, this endpoint requires no permissions.
 		gh, err = i.newAnonymousClient()
 	} else {
-		gh, err = i.NewClient(ctx, owner)
+		gh, err = i.NewClient(ctx)
 	}
 	if err != nil {
 		return sdktypes.InvalidValue, err

--- a/integrations/github/webhooks/webhook.go
+++ b/integrations/github/webhooks/webhook.go
@@ -137,7 +137,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Transform the received GitHub event into an autokitteh event.
+	// Transform the received GitHub event into an AutoKitteh event.
 	data, err := transformEvent(l, w, ghEvent)
 	if err != nil {
 		return

--- a/integrations/github/workflows.go
+++ b/integrations/github/workflows.go
@@ -27,7 +27,7 @@ func (i integration) triggerWorkflow(ctx context.Context, args []sdktypes.Value,
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}
@@ -57,7 +57,7 @@ func (i integration) listWorkflows(ctx context.Context, args []sdktypes.Value, k
 	}
 
 	// Invoke the API method.
-	gh, err := i.NewClient(ctx, owner)
+	gh, err := i.NewClient(ctx)
 	if err != nil {
 		return sdktypes.InvalidValue, err
 	}

--- a/runtimes/pythonrt/py-sdk/autokitteh/github.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/github.py
@@ -39,24 +39,17 @@ def github_client(connection: str, **kwargs) -> Github:
         return Github(Auth.Token(pat), **kwargs)
 
     # GitHub App (JWT)
-    app_name = os.getenv("GITHUB_APP_NAME")
     private_key = os.getenv("GITHUB_PRIVATE_KEY")
-    if app_name and private_key:
-        app_id = os.getenv(f"{connection}__app_id__{app_name}")
-        if not app_id:
-            raise ConnectionInitError(connection)
-
-        install_id = os.getenv(f"{connection}__install_id__{app_name}")
-        if not install_id:
-            raise ConnectionInitError(connection)
-
-        app = GithubIntegration(auth=Auth.AppAuth(int(app_id), private_key), **kwargs)
-        return app.get_github_for_installation(int(install_id))
-
-    # Errors
-    elif app_name:
+    if not private_key:
         raise EnvVarError("GITHUB_PRIVATE_KEY", "missing")
-    elif private_key:
-        raise EnvVarError("GITHUB_APP_NAME", "missing")
-    else:
+
+    app_id = os.getenv(f"{connection}__app_id")
+    if not app_id:
         raise ConnectionInitError(connection)
+
+    install_id = os.getenv(f"{connection}__install_id")
+    if not install_id:
+        raise ConnectionInitError(connection)
+
+    app = GithubIntegration(auth=Auth.AppAuth(int(app_id), private_key), **kwargs)
+    return app.get_github_for_installation(int(install_id))

--- a/runtimes/pythonrt/py-sdk/pyproject.toml
+++ b/runtimes/pythonrt/py-sdk/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = 'autokitteh'
 # If you bump minor or major, update ../requirements.txt as well
-version = '0.2.7'
+version = '0.2.8'
 description = 'AutoKitteh Python SDK'
 readme = 'README.md'
 license = {file = 'LICENSE'}


### PR DESCRIPTION
Remove the GitHub app installation's owner (org/user) from the names of OAuth connection vars.

This change spans both the AK server and the Python SDK - both need to be released and deployed together!

Core files in this PR (the rest are just small adjustments):

- integrations/github
  - internal/vars/vars.go
  - jwt.go
  - oauth.go
- runtimes/pythonrt/py-sdk/autokitteh/github.py

Tested manually with this Python code snippet:

```python
import random

from autokitteh.github import github_client

# https://docs.github.com/en/rest/reactions/reactions#about-reactions
REACTIONS = ["+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"]

def on_github_issue_comment(event):
    github = github_client("github_conn")
    repo = github.get_repo(event.data.repo.id)
    issue = repo.get_issue(event.data.issue.number)
    comment = issue.get_comment(event.data.comment.id)
    reaction = random.choice(REACTIONS)
    comment.create_reaction(reaction)
```

Refs: ENG-1422, ENG-1445

BREAKING CHANGE: OAuth connection vars in existing GitHub connections need to be renamed.