### PR TITLE
fix(google): repeat #539 for JSON

### DIFF
--- a/integrations/google/creds.go
+++ b/integrations/google/creds.go
@@ -123,11 +123,6 @@ func (h handler) finalize(ctx context.Context, c sdkintegrations.ConnectionInit,
 		return
 	}
 
-	// Reset the list of vars because "h.vars.Set()" modifies the values of secret vars.
-	vsl = kittehs.TransformMapToList(vs.ToMap(), func(_ sdktypes.Symbol, v sdktypes.Var) sdktypes.Var {
-		return v.WithScopeID(sdktypes.NewVarScopeID(cid))
-	})
-
 	if err := forms.UpdateWatches(ctx, h.vars, cid); err != nil {
 		l.Error("Google Forms watches creation error", zap.Error(err))
 		c.AbortServerError("form watches creation error")
@@ -141,7 +136,7 @@ func (h handler) finalize(ctx context.Context, c sdkintegrations.ConnectionInit,
 	}
 
 	// Redirect to the post-init handler to finish the connection setup.
-	c.Finalize(vsl)
+	c.Finalize(vs)
 }
 
 func oauthURL(form url.Values, c sdkintegrations.ConnectionInit) string {

--- a/integrations/google/creds.go
+++ b/integrations/google/creds.go
@@ -123,6 +123,11 @@ func (h handler) finalize(ctx context.Context, c sdkintegrations.ConnectionInit,
 		return
 	}
 
+	// Reset the list of vars because "h.vars.Set()" modifies the values of secret vars.
+	vsl = kittehs.TransformMapToList(vs.ToMap(), func(_ sdktypes.Symbol, v sdktypes.Var) sdktypes.Var {
+		return v.WithScopeID(sdktypes.NewVarScopeID(cid))
+	})
+
 	if err := forms.UpdateWatches(ctx, h.vars, cid); err != nil {
 		l.Error("Google Forms watches creation error", zap.Error(err))
 		c.AbortServerError("form watches creation error")

--- a/integrations/google/server.go
+++ b/integrations/google/server.go
@@ -55,7 +55,7 @@ func Start(l *zap.Logger, muxNoAuth *http.ServeMux, muxAuth *http.ServeMux, v sd
 
 	h := NewHTTPHandler(l, o, v, d)
 	muxAuth.HandleFunc("GET "+oauthPath, h.handleOAuth)
-	muxNoAuth.HandleFunc("POST "+credsPath, h.handleCreds)
+	muxAuth.HandleFunc("POST "+credsPath, h.handleCreds)
 
 	// Event webhooks.
 	muxNoAuth.HandleFunc("POST "+formsWebhookPath, h.handleFormsNotification)

--- a/internal/backend/vars/vars.go
+++ b/internal/backend/vars/vars.go
@@ -31,6 +31,10 @@ func varSecretKey(secret sdktypes.Var) string {
 
 func (v *Vars) SetConnections(conns sdkservices.Connections) { v.conns = conns }
 
+// Set sets the given variables in the database. If any of the variables are
+// secrets, it stores them in the secret store. Note that this function modifies
+// the values of secret variables to be the secret key in the secret store.
+// Do not change this behavior - it's useful, even though it's unexpected.
 func (v *Vars) Set(ctx context.Context, vs ...sdktypes.Var) error {
 	for i, va := range vs {
 		if va.IsSecret() {


### PR DESCRIPTION
Saving Google JSON keys requires an authenticated user identity, like OAuth.

~Also, because we save secret vars twice, make sure their values are not changed after the first save.~

False alarm about that 2nd part: `postInit()` already adds scope IDs to the vars, so we can `Finalize(vs)` instead of `Finalize(vsl)` (which was modified by `h.vars.Set`).

Refs: ENG-1470