### PR TITLE
feat(connections): determine auth mode based on explicit var

### DIFF
--- a/integrations/atlassian/confluence/client.go
+++ b/integrations/atlassian/confluence/client.go
@@ -43,10 +43,9 @@ func New(cvars sdkservices.Vars) sdkservices.Integration {
 	)
 }
 
-// connStatus is an optional connection status check provided by the
-// integration to AutoKitteh. The possible results are "init required"
-// (the connection is not usable yet) and "using X" (where "X" is the
-// authentication method: OAuth 2.0, Cloud API token, or on-prem PAT).
+// connStatus is an optional connection status check provided by
+// the integration to AutoKitteh. The possible results are "init
+// required" (the connection is not usable yet) and "using X".
 func connStatus(i *integration) sdkintegrations.OptFn {
 	return sdkintegrations.WithConnectionStatus(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
 		if !cid.IsValid() {
@@ -58,16 +57,22 @@ func connStatus(i *integration) sdkintegrations.OptFn {
 			return sdktypes.InvalidStatus, err
 		}
 
-		if vs.Has(oauthAccessToken) {
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using OAuth 2.0"), nil
-		}
-		if vs.Has(email) {
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using API token"), nil
-		}
-		if vs.Has(token) {
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using PAT"), nil
+		at := vs.Get(authType)
+		if !at.IsValid() || at.Value() == "" {
+			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "init required"), nil
 		}
 
-		return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "unrecognized auth"), nil
+		// Align with:
+		// https://github.com/autokitteh/web-platform/blob/main/src/enums/connections/connectionTypes.enum.ts
+		switch at.Value() {
+		case "apiToken":
+			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using cloud API token"), nil
+		case "oauth":
+			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using OAuth 2.0"), nil
+		case "pat":
+			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using on-prem PAT"), nil
+		default:
+			return sdktypes.NewStatus(sdktypes.StatusCodeError, "bad auth type"), nil
+		}
 	})
 }

--- a/integrations/atlassian/confluence/save.go
+++ b/integrations/atlassian/confluence/save.go
@@ -63,7 +63,9 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 
 	initData := sdktypes.NewVars().Set(baseURL, b, false).Set(token, t, true)
 	if e != "" {
-		initData = initData.Set(email, e, true)
+		initData = initData.Set(email, e, true).Set(authType, "apiToken", false)
+	} else {
+		initData = initData.Set(authType, "pat", false)
 	}
 
 	for _, category := range eventCategories {

--- a/integrations/atlassian/confluence/vars.go
+++ b/integrations/atlassian/confluence/vars.go
@@ -5,6 +5,8 @@ import (
 )
 
 var (
+	authType = sdktypes.NewSymbol("authType")
+
 	baseURL = sdktypes.NewSymbol("BaseURL")
 	token   = sdktypes.NewSymbol("Token")
 	email   = sdktypes.NewSymbol("Email")

--- a/integrations/atlassian/confluence/vars.go
+++ b/integrations/atlassian/confluence/vars.go
@@ -11,12 +11,11 @@ var (
 	token   = sdktypes.NewSymbol("Token")
 	email   = sdktypes.NewSymbol("Email")
 
-	oauthAccessToken = sdktypes.NewSymbol("oauth_AccessToken")
-	accessID         = sdktypes.NewSymbol("AccessID")
-	accessURL        = sdktypes.NewSymbol("AccessURL")
-	accessName       = sdktypes.NewSymbol("AccessName")
-	accessScope      = sdktypes.NewSymbol("AccessScope")
-	accessAvatarURL  = sdktypes.NewSymbol("AccessAvatarURL")
+	accessID        = sdktypes.NewSymbol("AccessID")
+	accessURL       = sdktypes.NewSymbol("AccessURL")
+	accessName      = sdktypes.NewSymbol("AccessName")
+	accessScope     = sdktypes.NewSymbol("AccessScope")
+	accessAvatarURL = sdktypes.NewSymbol("AccessAvatarURL")
 )
 
 func webhookID(category string) sdktypes.Symbol {

--- a/integrations/atlassian/jira/save.go
+++ b/integrations/atlassian/jira/save.go
@@ -50,7 +50,9 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 
 	initData := sdktypes.NewVars().Set(baseURL, b, false).Set(token, t, true)
 	if e != "" {
-		initData = initData.Set(email, e, true)
+		initData = initData.Set(email, e, true).Set(authType, "apiToken", false)
+	} else {
+		initData = initData.Set(authType, "pat", false)
 	}
 
 	c.Finalize(initData)

--- a/integrations/atlassian/jira/vars.go
+++ b/integrations/atlassian/jira/vars.go
@@ -5,6 +5,8 @@ import (
 )
 
 var (
+	authType = sdktypes.NewSymbol("authType")
+
 	baseURL = sdktypes.NewSymbol("BaseURL")
 	token   = sdktypes.NewSymbol("Token")
 	email   = sdktypes.NewSymbol("Email")

--- a/integrations/atlassian/jira/vars.go
+++ b/integrations/atlassian/jira/vars.go
@@ -11,12 +11,11 @@ var (
 	token   = sdktypes.NewSymbol("Token")
 	email   = sdktypes.NewSymbol("Email")
 
-	oauthAccessToken = sdktypes.NewSymbol("oauth_AccessToken")
-	accessID         = sdktypes.NewSymbol("AccessID")
-	accessURL        = sdktypes.NewSymbol("AccessURL")
-	accessName       = sdktypes.NewSymbol("AccessName")
-	accessScope      = sdktypes.NewSymbol("AccessScope")
-	accessAvatarURL  = sdktypes.NewSymbol("AccessAvatarURL")
+	accessID        = sdktypes.NewSymbol("AccessID")
+	accessURL       = sdktypes.NewSymbol("AccessURL")
+	accessName      = sdktypes.NewSymbol("AccessName")
+	accessScope     = sdktypes.NewSymbol("AccessScope")
+	accessAvatarURL = sdktypes.NewSymbol("AccessAvatarURL")
 
 	webhookID         = sdktypes.NewSymbol("WebhookID")
 	webhookExpiration = sdktypes.NewSymbol("WebhookExpiration")

--- a/integrations/github/client.go
+++ b/integrations/github/client.go
@@ -52,10 +52,9 @@ func connTest(*integration) sdkintegrations.OptFn {
 	})
 }
 
-// connStatus is an optional connection status check provided by the
-// integration to AutoKitteh. The possible results are "init required"
-// (the connection is not usable yet) and "using X" (where "X" is the
-// authentication method: a GitHub app, or a user's PAT + webhook).
+// connStatus is an optional connection status check provided by
+// the integration to AutoKitteh. The possible results are "init
+// required" (the connection is not usable yet) and "using X".
 func connStatus(i *integration) sdkintegrations.OptFn {
 	return sdkintegrations.WithConnectionStatus(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
 		if !cid.IsValid() {
@@ -67,10 +66,21 @@ func connStatus(i *integration) sdkintegrations.OptFn {
 			return sdktypes.InvalidStatus, err
 		}
 
-		if vs.Has(vars.PAT) {
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using PAT + webhook"), nil
+		at := vs.Get(vars.AuthType)
+		if !at.IsValid() || at.Value() == "" {
+			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "init required"), nil
 		}
-		return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using GitHub app"), nil
+
+		// Align with:
+		// https://github.com/autokitteh/web-platform/blob/main/src/enums/connections/connectionTypes.enum.ts
+		switch at.Value() {
+		case "oauth":
+			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using GitHub app"), nil
+		case "pat":
+			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using PAT + webhook"), nil
+		default:
+			return sdktypes.NewStatus(sdktypes.StatusCodeError, "bad auth type"), nil
+		}
 	})
 }
 

--- a/integrations/github/internal/vars/vars.go
+++ b/integrations/github/internal/vars/vars.go
@@ -7,6 +7,8 @@ import (
 )
 
 var (
+	AuthType = sdktypes.NewSymbol("authType")
+
 	// GitHub app (OAuth)
 	AppID     = sdktypes.NewSymbol("app_id")
 	InstallID = sdktypes.NewSymbol("install_id")

--- a/integrations/github/oauth.go
+++ b/integrations/github/oauth.go
@@ -130,6 +130,7 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 	user := string(*i.Account.Login)
 
 	c.Finalize(sdktypes.NewVars().
+		Set(vars.AuthType, "oauth", false).
 		Set(vars.AppID, appID, false).
 		Set(vars.InstallID, installID, false).
 		Set(vars.InstallKey(appID, installID), user, false))

--- a/integrations/github/pat.go
+++ b/integrations/github/pat.go
@@ -67,6 +67,7 @@ func (h handler) handlePAT(w http.ResponseWriter, r *http.Request) {
 	}
 
 	c.Finalize(sdktypes.NewVars().
+		Set(vars.AuthType, "pat", false).
 		Set(vars.PAT, pat, true).
 		Set(vars.PATKey, patKey, false).
 		Set(vars.PATSecret, secret, true).

--- a/integrations/google/connections/conn_status.go
+++ b/integrations/google/connections/conn_status.go
@@ -9,10 +9,9 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-// connStatus is an optional connection status check provided by the
-// integration to AutoKitteh. The possible results are "init required"
-// (the connection is not usable yet) and "using X" (where "X" is the
-// authentication method: OAuth 2.0 (user), or JSON key (service account).
+// connStatus is an optional connection status check provided by
+// the integration to AutoKitteh. The possible results are "init
+// required" (the connection is not usable yet) and "using X".
 func ConnStatus(cvars sdkservices.Vars) sdkintegrations.OptFn {
 	return sdkintegrations.WithConnectionStatus(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
 		if !cid.IsValid() {
@@ -24,13 +23,20 @@ func ConnStatus(cvars sdkservices.Vars) sdkintegrations.OptFn {
 			return sdktypes.InvalidStatus, err
 		}
 
-		if vs.Has(vars.OAuthData) {
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using OAuth 2.0"), nil
-		}
-		if vs.Has(vars.JSON) {
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using JSON key"), nil
+		at := vs.Get(vars.AuthType)
+		if !at.IsValid() || at.Value() == "" {
+			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "init required"), nil
 		}
 
-		return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "unrecognized auth"), nil
+		// Align with:
+		// https://github.com/autokitteh/web-platform/blob/main/src/enums/connections/connectionTypes.enum.ts
+		switch at.Value() {
+		case "jsonKey":
+			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using JSON key"), nil
+		case "oauth":
+			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "using OAuth 2.0"), nil
+		default:
+			return sdktypes.NewStatus(sdktypes.StatusCodeError, "bad auth type"), nil
+		}
 	})
 }

--- a/integrations/google/creds.go
+++ b/integrations/google/creds.go
@@ -71,7 +71,7 @@ func (h handler) handleCreds(w http.ResponseWriter, r *http.Request) {
 	case "", "json":
 		ctx := extrazap.AttachLoggerToContext(l, r.Context())
 		vs := sdktypes.EncodeVars(&vars.Vars{JSON: r.PostFormValue("json"), FormID: formID})
-		h.finalize(ctx, c, vs)
+		h.finalize(ctx, c, vs.Set(vars.AuthType, "jsonKey", false))
 
 	// User OAuth connect? Redirect to AutoKitteh's OAuth starting point.
 	case "oauth":

--- a/integrations/google/internal/vars/vars.go
+++ b/integrations/google/internal/vars/vars.go
@@ -14,6 +14,8 @@ type Vars struct {
 }
 
 var (
+	AuthType = sdktypes.NewSymbol("authType")
+
 	OAuthData = sdktypes.NewSymbol("OAuthData")
 	JSON      = sdktypes.NewSymbol("JSON")
 

--- a/integrations/slack/internal/vars/vars.go
+++ b/integrations/slack/internal/vars/vars.go
@@ -13,6 +13,8 @@ type Vars struct {
 }
 
 var (
+	AuthType = sdktypes.NewSymbol("authType")
+
 	// Socket Mode
 	AppTokenName = sdktypes.NewSymbol("AppToken")
 	BotTokenName = sdktypes.NewSymbol("BotToken")

--- a/integrations/slack/websockets/form.go
+++ b/integrations/slack/websockets/form.go
@@ -73,5 +73,6 @@ func (h handler) HandleForm(w http.ResponseWriter, r *http.Request) {
 		TeamID:       authTest.TeamID,
 	}).
 		Set(vars.AppTokenName, appToken, true).
-		Set(vars.BotTokenName, botToken, true))
+		Set(vars.BotTokenName, botToken, true).
+		Set(vars.AuthType, "socketMode", false))
 }

--- a/sdk/sdkintegrations/oauth.go
+++ b/sdk/sdkintegrations/oauth.go
@@ -29,7 +29,8 @@ func (d OAuthData) ToVars() sdktypes.Vars {
 		Expiry:       d.Token.Expiry.String(),
 	}
 
-	return sdktypes.EncodeVars(data).WithPrefix("oauth_")
+	return sdktypes.EncodeVars(data).WithPrefix("oauth_").
+		Set(sdktypes.NewSymbol("authType"), "oauth", false)
 }
 
 func DecodeOAuthData(raw string) (data *OAuthData, err error) {


### PR DESCRIPTION
Changes in this PR:

- `connStatus` functions for several integrations (Atlassian, GitHub, Google, Slack)
- Saving auth type as `"oauth"` for most OAuth connections in `sdk/sdkintegrations/oauth.go` (except GitHub which doesn't save OAuth data - see `integrations/github/oauth.go`)
- Saving integration-specific non-OAuth auth types (`apiToken`, `pat`, `jsonKey`, `socketMode`)

The 2nd part of implementing this will (for the rest of the integrations) be done separately by Pasha.

Refs: ENG-1408