### PR TITLE
fix(cli/trigger): disallow empty connection on create

### DIFF
--- a/cmd/ak/cmd/triggers/create.go
+++ b/cmd/ak/cmd/triggers/create.go
@@ -26,7 +26,7 @@ var createCmd = common.StandardCommand(&cobra.Command{
 	Args:  cobra.NoArgs,
 
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		common.UnsetEmptyFlags(cmd, "connection", "schedule")
+		common.UnsetEmptyFlags(cmd, "connection", "schedule", "project", "env")
 		return nil
 	},
 
@@ -42,14 +42,20 @@ var createCmd = common.StandardCommand(&cobra.Command{
 		}
 
 		// Project and/or environment are required.
-		p, _, err := r.ProjectNameOrID(ctx, project)
-		if err = common.AddNotFoundErrIfCond(err, p.IsValid()); err != nil {
-			return common.ToExitCodeErrorNotNilErr(err, "project")
+		if project != "" {
+			p, _, err := r.ProjectNameOrID(ctx, project)
+			if err = common.AddNotFoundErrIfCond(err, p.IsValid()); err != nil {
+				return common.ToExitCodeErrorNotNilErr(err, "project")
+			}
 		}
 
-		e, eid, err := r.EnvNameOrID(ctx, env, project)
-		if err = common.AddNotFoundErrIfCond(err, e.IsValid()); err != nil {
-			return common.ToExitCodeErrorNotNilErr(err, "environment")
+		var eid sdktypes.EnvID
+		if env != "" {
+			e, _, err := r.EnvNameOrID(ctx, env, project)
+			if err = common.AddNotFoundErrIfCond(err, e.IsValid()); err != nil {
+				return common.ToExitCodeErrorNotNilErr(err, "environment")
+			}
+			eid = e.ID()
 		}
 
 		// Mode 1: connection is required, event and/or filter

--- a/cmd/ak/cmd/triggers/create.go
+++ b/cmd/ak/cmd/triggers/create.go
@@ -25,6 +25,11 @@ var createCmd = common.StandardCommand(&cobra.Command{
 	Short: "Create event trigger",
 	Args:  cobra.NoArgs,
 
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		common.UnsetEmptyFlags(cmd, "connection", "schedule")
+		return nil
+	},
+
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := resolver.Resolver{Client: common.Client()}
 		ctx, cancel := common.LimitedContext()

--- a/cmd/ak/common/flags.go
+++ b/cmd/ak/common/flags.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/internal/resolver"
@@ -67,4 +68,20 @@ func ToExitCodeWithSkipNotFoundFlag(cmd *cobra.Command, err error, whats ...stri
 		}
 	}
 	return exitErr
+}
+
+// maybe we could just run this check for all required flags instead of providing explicit ones?
+func UnsetEmptyFlags(cmd *cobra.Command, flags ...string) {
+	flagsMap := make(map[string]struct{}, len(flags))
+	for _, flag := range flags {
+		flagsMap[flag] = struct{}{}
+	}
+
+	cmd.Flags().Visit(func(flag *pflag.Flag) {
+		if _, ok := flagsMap[flag.Name]; ok {
+			if flag.Value.Type() == "string" && flag.Changed && flag.Value.String() == "" {
+				flag.Changed = false
+			}
+		}
+	})
 }

--- a/internal/backend/db/dbgorm/triggers.go
+++ b/internal/backend/db/dbgorm/triggers.go
@@ -82,7 +82,7 @@ func (db *gormdb) triggerToRecord(ctx context.Context, trigger sdktypes.Trigger)
 
 	conn, err := db.GetConnection(ctx, connID)
 	if err != nil {
-		return nil, fmt.Errorf("get trigger connection: %w", err)
+		return nil, fmt.Errorf("connection: %w", err)
 	}
 
 	projID := conn.ProjectID()
@@ -126,7 +126,7 @@ func (db *gormdb) triggerToRecord(ctx context.Context, trigger sdktypes.Trigger)
 }
 
 func (db *gormdb) CreateTrigger(ctx context.Context, trigger sdktypes.Trigger) error {
-	if err := trigger.Strict(); err != nil {
+	if err := trigger.Strict(); err != nil { // name, connection, env but not project
 		return err
 	}
 


### PR DESCRIPTION
- ability to threat empty args as not-provided ones
- report not found types in errors
- disallow empty connection in trigger create