### PR TITLE
fix(ENG-1456): events flaky test to not be flaky

### DIFF
--- a/tests/system/testdata/sessions/events.txtar
+++ b/tests/system/testdata/sessions/events.txtar
@@ -6,7 +6,7 @@ return code == 0
 http get /http/myproject/start
 resp code == 200
 
-ak session watch ses_00000000000000000000000008 --end-state RUNNING
+ak session watch ses_00000000000000000000000008 --end-state RUNNING --wait-created
 return code == 0
 
 http post /http/myproject/woof a
@@ -58,7 +58,7 @@ project:
 def on_http_start():
   s1 = subscribe("myhttp", "data.url.path == '/meow'")
   s2 = subscribe("myhttp", "data.url.path == '/woof'")
-  print(1, next_event(s1, s2)['body'].text())
+  print(1, next_event(s2)['body'].text())
   print(2, next_event(s1)['body'].text())
   print(3, next_event(s2, timeout=1))
   print(4, next_event(s1, s2, timeout=2)['body'].text())


### PR DESCRIPTION
two fixes:
- test condition was indeterministic - didn't know which subscription would catch first.
- another indeterminism was that ingest of event was slower than running the ak watch, so now it can wait for session to be created.