### PR TITLE
fix: unwrap functions for grpc json session log

### DIFF
--- a/sdk/sdktypes/session_log_record_describe.go
+++ b/sdk/sdktypes/session_log_record_describe.go
@@ -248,20 +248,9 @@ func describeFunctionValue(opts *SessionLogRecordDescribeOptions, w io.Writer, v
 	}
 }
 
-var sessionLogDescUnwrapper = ValueWrapper{
-	SafeForJSON: true,
-	Preunwrap: func(v Value) (Value, error) {
-		if v.IsFunction() {
-			return NewStringValuef("|function: %v|", v.GetFunction().Name()), nil
-		}
-
-		return v, nil
-	},
-}
-
 func describeValue(opts *SessionLogRecordDescribeOptions, w io.Writer, v Value) {
 	if opts.UnwrapValues {
-		x, err := sessionLogDescUnwrapper.Unwrap(v)
+		x, err := valueStringUnwrapper.Unwrap(v)
 		if err != nil {
 			fmt.Fprintf(w, "unwrap: %v\n", err)
 			return

--- a/sdk/sdktypes/value.go
+++ b/sdk/sdktypes/value.go
@@ -165,6 +165,18 @@ func (v Value) ToStringValuesMap() (map[string]Value, error) {
 func (v Value) Unwrap() (any, error)     { return UnwrapValue(v) }
 func (v Value) UnwrapInto(dst any) error { return UnwrapValueInto(dst, v) }
 
+// An unwrapper that is alway safe to serialize to string afterwards.
+var valueStringUnwrapper = ValueWrapper{
+	SafeForJSON: true,
+	Preunwrap: func(v Value) (Value, error) {
+		if v.IsFunction() {
+			return NewStringValuef("|function: %v|", v.GetFunction().Name()), nil
+		}
+
+		return v, nil
+	},
+}
+
 func ValueProtoToJSONStringValue(pb *ValuePB) (*ValuePB, error) {
 	if pb == nil {
 		return nil, nil
@@ -175,9 +187,7 @@ func ValueProtoToJSONStringValue(pb *ValuePB) (*ValuePB, error) {
 		return nil, fmt.Errorf("decode: %w", err)
 	}
 
-	uw := ValueWrapper{SafeForJSON: true}
-
-	u, err := uw.Unwrap(v)
+	u, err := valueStringUnwrapper.Unwrap(v)
 	if err != nil {
 		return nil, fmt.Errorf("unwrap: %w", err)
 	}


### PR DESCRIPTION
when session log is unwrapped, wrapped functions cause it to fail. this will just print the function name instead of the function "content".
