### PR TITLE
fix(google): allow GET to start OAuth flow instead of POST

### DIFF
--- a/integrations/google/creds.go
+++ b/integrations/google/creds.go
@@ -32,7 +32,7 @@ func (h handler) handleCreds(w http.ResponseWriter, r *http.Request) {
 
 	// Check "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
-	if !strings.HasPrefix(contentType, contentTypeForm) {
+	if r.Method == http.MethodPost && !strings.HasPrefix(contentType, contentTypeForm) {
 		c.AbortBadRequest("unexpected content type")
 		return
 	}
@@ -66,7 +66,7 @@ func (h handler) handleCreds(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	switch r.PostFormValue("auth_type") {
+	switch r.FormValue("auth_type") {
 	// GCP service-account JSON-key connection? Save the JSON key.
 	case "", "json":
 		ctx := extrazap.AttachLoggerToContext(l, r.Context())
@@ -75,12 +75,12 @@ func (h handler) handleCreds(w http.ResponseWriter, r *http.Request) {
 
 	// User OAuth connect? Redirect to AutoKitteh's OAuth starting point.
 	case "oauth":
-		http.Redirect(w, r, oauthURL(r.PostForm, c), http.StatusFound)
+		http.Redirect(w, r, oauthURL(r.Form, c), http.StatusFound)
 
 	// Unknown mode.
 	default:
-		l.Error("Unexpected auth type", zap.String("auth_type", r.PostFormValue("auth_type")))
-		c.AbortServerError(fmt.Sprintf("unexpected auth type %q", r.PostFormValue("auth_type")))
+		l.Error("Unexpected auth type", zap.String("auth_type", r.FormValue("auth_type")))
+		c.AbortServerError(fmt.Sprintf("unexpected auth type %q", r.FormValue("auth_type")))
 	}
 }
 

--- a/integrations/google/server.go
+++ b/integrations/google/server.go
@@ -56,7 +56,8 @@ func Start(l *zap.Logger, noAuth *http.ServeMux, auth *http.ServeMux, v sdkservi
 	// through AutoKitteh's auth middleware to extract the user ID from a cookie.
 	h := NewHTTPHandler(l, o, v, d)
 	auth.HandleFunc("GET "+oauthPath, h.handleOAuth)
-	auth.HandleFunc(savePath, h.handleCreds) // GET for JSON keys, POST for OAuth.
+	auth.HandleFunc("GET "+savePath, h.handleCreds)  // Passthrough for OAuth.
+	auth.HandleFunc("POST "+savePath, h.handleCreds) // Save JSON key.
 
 	// Event webhooks (unauthenticated by definition).
 	noAuth.HandleFunc("POST "+formsWebhookPath, h.handleFormsNotification)

--- a/integrations/google/server.go
+++ b/integrations/google/server.go
@@ -56,7 +56,7 @@ func Start(l *zap.Logger, noAuth *http.ServeMux, auth *http.ServeMux, v sdkservi
 	// through AutoKitteh's auth middleware to extract the user ID from a cookie.
 	h := NewHTTPHandler(l, o, v, d)
 	auth.HandleFunc("GET "+oauthPath, h.handleOAuth)
-	auth.HandleFunc("POST "+savePath, h.handleCreds)
+	auth.HandleFunc(savePath, h.handleCreds) // GET for JSON keys, POST for OAuth.
 
 	// Event webhooks (unauthenticated by definition).
 	noAuth.HandleFunc("POST "+formsWebhookPath, h.handleFormsNotification)


### PR DESCRIPTION
Context: OAuth flows need to happen interactively. In the SaaS web UI they involve opening a browser tab/window from the existing web UI, i.e. it needs to start with an HTTP GET request instead of HTTP POST, to avoid CORS issues.