### PR TITLE
fix(google): search for connections using the right integration ID

### DIFF
--- a/integrations/google/client.go
+++ b/integrations/google/client.go
@@ -11,10 +11,14 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-var integrationID = sdktypes.NewIntegrationIDFromName("google")
+var (
+	gmailIntegrationID = sdktypes.NewIntegrationIDFromName("gmail")
+	formsIntegrationID = sdktypes.NewIntegrationIDFromName("googleforms")
+	googleIntegrationID = sdktypes.NewIntegrationIDFromName("google")
+)
 
 var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: integrationID.String(),
+	IntegrationId: googleIntegrationID.String(),
 	UniqueName:    "google",
 	DisplayName:   "Google (All APIs)",
 	Description:   "Aggregation of all available Google APIs.",

--- a/integrations/google/client.go
+++ b/integrations/google/client.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	gmailIntegrationID = sdktypes.NewIntegrationIDFromName("gmail")
-	formsIntegrationID = sdktypes.NewIntegrationIDFromName("googleforms")
+	gmailIntegrationID  = sdktypes.NewIntegrationIDFromName("gmail")
+	formsIntegrationID  = sdktypes.NewIntegrationIDFromName("googleforms")
 	googleIntegrationID = sdktypes.NewIntegrationIDFromName("google")
 )
 

--- a/integrations/google/client.go
+++ b/integrations/google/client.go
@@ -11,14 +11,10 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-var (
-	gmailIntegrationID  = sdktypes.NewIntegrationIDFromName("gmail")
-	formsIntegrationID  = sdktypes.NewIntegrationIDFromName("googleforms")
-	googleIntegrationID = sdktypes.NewIntegrationIDFromName("google")
-)
+var integrationID = sdktypes.NewIntegrationIDFromName("google")
 
 var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: googleIntegrationID.String(),
+	IntegrationId: integrationID.String(),
 	UniqueName:    "google",
 	DisplayName:   "Google (All APIs)",
 	Description:   "Aggregation of all available Google APIs.",

--- a/integrations/google/forms/client.go
+++ b/integrations/google/forms/client.go
@@ -25,10 +25,10 @@ type api struct {
 	cid  sdktypes.ConnectionID
 }
 
-var integrationID = sdktypes.NewIntegrationIDFromName("googleforms")
+var IntegrationID = sdktypes.NewIntegrationIDFromName("googleforms")
 
 var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: integrationID.String(),
+	IntegrationId: IntegrationID.String(),
 	UniqueName:    "googleforms",
 	DisplayName:   "Google Forms",
 	Description:   "Google Forms is a survey administration software that part of the Google Workspace office suite.",

--- a/integrations/google/gmail/client.go
+++ b/integrations/google/gmail/client.go
@@ -29,10 +29,10 @@ type api struct {
 	cid  sdktypes.ConnectionID
 }
 
-var integrationID = sdktypes.NewIntegrationIDFromName("gmail")
+var IntegrationID = sdktypes.NewIntegrationIDFromName("gmail")
 
 var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: integrationID.String(),
+	IntegrationId: IntegrationID.String(),
 	UniqueName:    "gmail",
 	DisplayName:   "Gmail",
 	Description:   "Gmail is an email service provided by Google.",

--- a/integrations/google/notifs.go
+++ b/integrations/google/notifs.go
@@ -40,7 +40,7 @@ func (h handler) handleFormsNotification(w http.ResponseWriter, r *http.Request)
 
 	// Find all the connection IDs associated with the watch ID.
 	ctx := extrazap.AttachLoggerToContext(l, r.Context())
-	cids, err := h.vars.FindConnectionIDs(ctx, formsIntegrationID, name, watchID)
+	cids, err := h.vars.FindConnectionIDs(ctx, forms.IntegrationID, name, watchID)
 	if err != nil {
 		l.Error("Failed to find connection IDs", zap.Error(err))
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -107,7 +107,7 @@ func (h handler) handleGmailNotification(w http.ResponseWriter, r *http.Request)
 
 	// Find all the connection IDs associated with the email address.
 	ctx := extrazap.AttachLoggerToContext(l, r.Context())
-	cids, err := h.vars.FindConnectionIDs(ctx, gmailIntegrationID, vars.UserEmail, notif.EmailAddress)
+	cids, err := h.vars.FindConnectionIDs(ctx, gmail.IntegrationID, vars.UserEmail, notif.EmailAddress)
 	if err != nil {
 		l.Error("Failed to find connection IDs", zap.Error(err))
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/integrations/google/notifs.go
+++ b/integrations/google/notifs.go
@@ -40,7 +40,7 @@ func (h handler) handleFormsNotification(w http.ResponseWriter, r *http.Request)
 
 	// Find all the connection IDs associated with the watch ID.
 	ctx := extrazap.AttachLoggerToContext(l, r.Context())
-	cids, err := h.vars.FindConnectionIDs(ctx, integrationID, name, watchID)
+	cids, err := h.vars.FindConnectionIDs(ctx, formsIntegrationID, name, watchID)
 	if err != nil {
 		l.Error("Failed to find connection IDs", zap.Error(err))
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -107,7 +107,7 @@ func (h handler) handleGmailNotification(w http.ResponseWriter, r *http.Request)
 
 	// Find all the connection IDs associated with the email address.
 	ctx := extrazap.AttachLoggerToContext(l, r.Context())
-	cids, err := h.vars.FindConnectionIDs(ctx, integrationID, vars.UserEmail, notif.EmailAddress)
+	cids, err := h.vars.FindConnectionIDs(ctx, gmailIntegrationID, vars.UserEmail, notif.EmailAddress)
 	if err != nil {
 		l.Error("Failed to find connection IDs", zap.Error(err))
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)


### PR DESCRIPTION
The Gmail and Google Forms integrations support events.

When looking for connection IDs that match these incoming events, use the correct (i.e. specific) integration ID, instead of the generic "google" integration.