### PR TITLE
refactor(slack): improve slash-command acks

### DIFF
--- a/integrations/slack/webhooks/slash_command.go
+++ b/integrations/slack/webhooks/slash_command.go
@@ -126,9 +126,7 @@ func (h handler) HandleSlashCommand(w http.ResponseWriter, r *http.Request) {
 	// https://api.slack.com/interactivity/slash-commands#responding_to_commands
 	// https://api.slack.com/interactivity/slash-commands#responding_response_url
 	// https://api.slack.com/interactivity/slash-commands#enabling-interactivity-with-slash-commands__best-practices
-	if len(cmd.Text) == 0 {
-		return
-	}
 	w.Header().Add(api.HeaderContentType, api.ContentTypeJSONCharsetUTF8)
-	fmt.Fprintf(w, "{\"response_type\": \"ephemeral\", \"text\": \"Your command: `%s`\"}", cmd.Text)
+	resp := "{\"response_type\": \"ephemeral\", \"text\": \"Your command: `%s %s`\"}"
+	fmt.Fprintf(w, resp, cmd.Command, cmd.Text)
 }

--- a/integrations/slack/websockets/slash_command.go
+++ b/integrations/slack/websockets/slash_command.go
@@ -56,20 +56,15 @@ func (h handler) handleSlashCommand(e *socketmode.Event, c *socketmode.Client) {
 	// Dispatch the event to all of them, for asynchronous handling.
 	h.dispatchAsyncEventsToConnections(cids, akEvent)
 
-	// https://api.slack.com/apis/connections/socket#acknowledge
-	if len(cmd.Text) == 0 {
-		c.Ack(*e.Request)
-		return
-	}
-
 	// https://api.slack.com/apis/connections/socket#command
+	// https://api.slack.com/apis/connections/socket#acknowledge
 	c.Ack(*e.Request, map[string][]map[string]any{
 		"blocks": {
 			{
 				"type": "section",
 				"text": map[string]string{
 					"type": "mrkdwn",
-					"text": fmt.Sprintf("Your command: `%s`", cmd.Text),
+					"text": fmt.Sprintf("Your command: `%s %s`", cmd.Command, cmd.Text),
 				},
 			},
 		},


### PR DESCRIPTION
1. Acknowledge (i.e. send an ephemeral response message about) a slash command even if it doesn't have any text
2. Mention the command itself in the acknowledgement, not just the text
