### PR TITLE
fix: allow initial run in session to take a while

### DIFF
--- a/internal/backend/sessions/sessionworkflows/workflow.go
+++ b/internal/backend/sessions/sessionworkflows/workflow.go
@@ -468,6 +468,7 @@ func (w *sessionWorkflow) run(wctx workflow.Context) (prints []string, err error
 	// some other thing that calls the Call callback from within an activity. The latter is not supported.
 	ctx = context.WithValue(ctx, workflowContextKey, wctx)
 
+	// TODO: replace with activity.IsActivity
 	isFromActivity := func(ctx context.Context) bool { return ctx.Value(workflowContextKey) == nil }
 
 	newRunID := func() (runID sdktypes.RunID) {
@@ -479,10 +480,16 @@ func (w *sessionWorkflow) run(wctx workflow.Context) (prints []string, err error
 		return
 	}
 
+	var run sdkservices.Run
+
 	cbs := sdkservices.RunCallbacks{
 		NewRunID: newRunID,
 		Load:     w.load,
 		Call: func(callCtx context.Context, runID sdktypes.RunID, v sdktypes.Value, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
+			if run == nil {
+				return sdktypes.InvalidValue, fmt.Errorf("cannot call before the run is initialized")
+			}
+
 			if xid := v.GetFunction().ExecutorID(); xid.ToRunID() == runID && w.executors.GetCaller(xid) == nil {
 				// This happens only during initial evaluation (the first run because invoking the entrypoint function),
 				// and the runtime tries to call itself in order to start an activity with its own functions.
@@ -500,7 +507,7 @@ func (w *sessionWorkflow) run(wctx workflow.Context) (prints []string, err error
 
 			prints = append(prints, text)
 
-			if isFromActivity(printCtx) {
+			if isFromActivity(printCtx) || run == nil {
 				// TODO: We do this since we're already in an activity. We need to either
 				//       manually retry this (maybe even using the heartbeat to know if it's
 				//       already been processed), or we need to aggregate the prints
@@ -532,8 +539,6 @@ func (w *sessionWorkflow) run(wctx workflow.Context) (prints []string, err error
 	runDone := make(chan runOrErr)
 
 	go func() {
-		time.Sleep(20 * time.Second)
-
 		// This can take a while to complete since it might provision resources et al,
 		// but since it might call back into the workflow via the callbacks, it must
 		// still run a in a workflow context rather than an activity.
@@ -553,11 +558,9 @@ func (w *sessionWorkflow) run(wctx workflow.Context) (prints []string, err error
 		runDone <- runOrErr{run, err}
 	}()
 
-	var run sdkservices.Run
-
 	for run == nil {
 		select {
-		case <-time.After(time.Second): // TODO: adjust according to deadlock timeout.
+		case <-time.After(workflowDeadlockTimeout / 2):
 			if err := workflow.Sleep(wctx, time.Millisecond); err != nil {
 				return prints, err
 			}

--- a/internal/backend/sessions/sessionworkflows/workflows.go
+++ b/internal/backend/sessions/sessionworkflows/workflows.go
@@ -24,6 +24,8 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
+const workflowDeadlockTimeout = time.Second * 10
+
 type Workflows interface {
 	StartWorkers(context.Context) error
 	StartWorkflow(ctx context.Context, session sdktypes.Session, debug bool) error
@@ -66,7 +68,7 @@ func (ws *workflows) StartWorkers(ctx context.Context) error {
 	opts := ws.cfg.Temporal.Worker
 	opts.DisableRegistrationAliasing = true
 	opts.OnFatalError = func(err error) { ws.z.Error("temporal worker error", zap.Error(err)) }
-	opts.DeadlockDetectionTimeout = time.Second * 10
+	opts.DeadlockDetectionTimeout = workflowDeadlockTimeout
 
 	ws.worker = worker.New(ws.svcs.TemporalClient(), taskQueueName, opts)
 

--- a/tests/sessions/activity_global.txtar
+++ b/tests/sessions/activity_global.txtar
@@ -1,4 +1,4 @@
-(None, "cannot call self during initial evaluation")
+(None, "cannot call before the run is initialized")
 
 -- main.star --
 print(catch(activity(len).run, "george"))

--- a/tests/sessions/os.txtar
+++ b/tests/sessions/os.txtar
@@ -8,13 +8,14 @@ exec(exitcode = 0, files = {"woof.txt": b"woof\n"}, output = "")
 [None, "write key must not contain '..'"]
 [None, "write key must be a relative path"]
 
--- main.star --
-print(os.command('/bin/sh', '-c', 'echo meow'))
-print(os.command('/bin/sh', '-c', 'echo hiss; exit 1'))
-print(os.shell('echo woof'))
-print(os.shell('cat meow.txt', write={'meow.txt': 'meow, world!'}))
-print(os.shell('echo woof > woof.txt', read=['woof.txt']))
-print(os.shell('echo meow; sleep 50', ak_timeout=2, ak_catch=True))
-print(os.shell('echo meow', ak_timeout=2, ak_catch=True))
-print(os.shell('cat meow.txt', write={'../meow.txt': 'meow, world!'}, ak_catch=True))
-print(os.shell('cat meow.txt', write={'/meow.txt': 'meow, world!'}, ak_catch=True))
+-- main.star:main --
+def main():
+    print(os.command('/bin/sh', '-c', 'echo meow'))
+    print(os.command('/bin/sh', '-c', 'echo hiss; exit 1'))
+    print(os.shell('echo woof'))
+    print(os.shell('cat meow.txt', write={'meow.txt': 'meow, world!'}))
+    print(os.shell('echo woof > woof.txt', read=['woof.txt']))
+    print(os.shell('echo meow; sleep 50', ak_timeout=2, ak_catch=True))
+    print(os.shell('echo meow', ak_timeout=2, ak_catch=True))
+    print(os.shell('cat meow.txt', write={'../meow.txt': 'meow, world!'}, ak_catch=True))
+    print(os.shell('cat meow.txt', write={'/meow.txt': 'meow, world!'}, ak_catch=True))


### PR DESCRIPTION
need to finess this, but this is so @efiShtain can try the approach out.
note that calling activities during initial run might not work all the time, depends on timing with the `workflow.Sleep`. We'll work it out if needed.