### PR TITLE
chore: kill poller and faker

### DIFF
--- a/internal/backend/sessions/sessioncalls/activity.go
+++ b/internal/backend/sessions/sessioncalls/activity.go
@@ -10,7 +10,6 @@ type callActivityInputs struct {
 	SessionID sdktypes.SessionID
 	Seq       uint32
 	Debug     bool
-	Poller    sdktypes.Value
 }
 
 type callActivityOutputs struct {
@@ -37,7 +36,7 @@ func (cs *calls) sessionCallActivity(ctx context.Context, params *callActivityIn
 		err error
 	)
 
-	ret.Debug, ret.Attempt, err = cs.executeCall(ctx, params.SessionID, params.Seq, params.Poller, executors)
+	ret.Debug, ret.Attempt, err = cs.executeCall(ctx, params.SessionID, params.Seq, executors)
 
 	if !params.Debug {
 		// don't let temporal know about the debug data.

--- a/internal/backend/sessions/sessioncalls/call.go
+++ b/internal/backend/sessions/sessioncalls/call.go
@@ -17,38 +17,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-func (cs *calls) checkPollPolicy(ctx context.Context, pollfn, result sdktypes.Value, executors *sdkexecutor.Executors) (retry bool, interval time.Duration, err error) {
-	var res sdktypes.SessionCallAttemptResult
-	if res, err = cs.invoke(ctx, pollfn, []sdktypes.Value{result}, nil, executors, 0); err != nil {
-		err = fmt.Errorf("poll function invoke: %w", err)
-		return
-	} else if err = res.GetError(); err != nil {
-		err = fmt.Errorf("poll function error: %w", err)
-		return
-	}
-
-	pollRet := res.GetValue()
-
-	if pollRet.IsNothing() {
-		// Nothing: no retry.
-		return
-	}
-
-	if isBool := pollRet.IsBoolean(); isBool {
-		// True: no retry. False: immediate retry.
-		return !pollRet.GetBoolean().Value(), 0, nil
-	}
-
-	// Duration: retry with specified interval.
-	if interval, err = pollRet.ToDuration(); err != nil {
-		err = fmt.Errorf("poller return value must be either a boolean or convertible to duration: %w", err)
-		return
-	}
-
-	retry = true
-	return
-}
-
 func (cs *calls) invoke(ctx context.Context, callv sdktypes.Value, args []sdktypes.Value, kwargs map[string]sdktypes.Value, executors *sdkexecutor.Executors, timeout time.Duration) (sdktypes.SessionCallAttemptResult, error) {
 	xid := callv.GetFunction().ExecutorID()
 
@@ -120,7 +88,7 @@ func (cs *calls) invoke(ctx context.Context, callv sdktypes.Value, args []sdktyp
 }
 
 // This is executed either in an activity (for regular calls) or directly in a workflow (for internal calls).
-func (cs *calls) executeCall(ctx context.Context, sessionID sdktypes.SessionID, seq uint32, poller sdktypes.Value, executors *sdkexecutor.Executors) (debug any, attempt uint32, _ error) {
+func (cs *calls) executeCall(ctx context.Context, sessionID sdktypes.SessionID, seq uint32, executors *sdkexecutor.Executors) (debug any, attempt uint32, _ error) {
 	z := cs.z.With(zap.Uint32("seq", seq))
 
 	call, err := cs.svcs.DB.GetSessionCallSpec(ctx, sessionID, seq)
@@ -133,87 +101,46 @@ func (cs *calls) executeCall(ctx context.Context, sessionID sdktypes.SessionID, 
 		return nil, 0, err
 	}
 
-	var (
-		interval time.Duration
-		last     bool
-	)
-
 	z = z.With(zap.Any("function", callv))
 
-	if poller.IsValid() && callv.GetFunction().HasFlag(sdktypes.DisablePollingFunctionFlag) {
-		z.Debug("poller exists, but function is not pollable")
-		poller = sdktypes.InvalidValue
+	if attempt, err = cs.svcs.DB.StartSessionCallAttempt(ctx, sessionID, seq); err != nil {
+		return nil, 0, err
 	}
 
-	for !last {
-		z := z.With(zap.Uint32("attempt", attempt))
+	z.Debug("calling")
 
-		attempt, err = cs.svcs.DB.StartSessionCallAttempt(ctx, sessionID, seq)
-		if err != nil {
-			return nil, attempt, err
-		}
+	var result sdktypes.SessionCallAttemptResult
 
-		if interval != 0 {
-			z.Debug("waiting", zap.Duration("interval", interval))
-			select {
-			case <-time.After(interval):
-				// nop
-			case <-ctx.Done():
-				return nil, attempt, ctx.Err()
-			}
-		}
-
-		z.Debug("calling")
-
-		var result sdktypes.SessionCallAttemptResult
-
-		func() {
-			defer func() {
-				if reason := recover(); reason != nil {
-					result = sdktypes.NewSessionCallAttemptResult(sdktypes.InvalidValue, fmt.Errorf("panic: %v", reason))
-					return
-				}
-			}()
-
-			if result, err = cs.invoke(ctx, callv, args, kwargs, executors, opts.Timeout); err != nil {
-				z.Panic("call integration", zap.Error(err))
+	func() {
+		defer func() {
+			if reason := recover(); reason != nil {
+				result = sdktypes.NewSessionCallAttemptResult(sdktypes.InvalidValue, fmt.Errorf("panic: %v", reason))
+				return
 			}
 		}()
 
-		if err := result.GetError(); err != nil {
-			last = true
-			z.Debug("call returned an error", zap.Error(err))
-		} else {
-			z.Debug("call returned a value")
-
-			if !poller.IsValid() {
-				last = true
-			} else {
-				var retry bool
-
-				if retry, interval, err = cs.checkPollPolicy(ctx, poller, result.GetValue(), executors); err != nil {
-					result = sdktypes.NewSessionCallAttemptResult(sdktypes.InvalidValue, fmt.Errorf("poll function: %w", err))
-					last = true
-				} else {
-					last = !retry
-				}
-
-				z.Debug("poll results", zap.Bool("last", last), zap.Duration("t", interval))
-			}
+		if result, err = cs.invoke(ctx, callv, args, kwargs, executors, opts.Timeout); err != nil {
+			z.Panic("call integration", zap.Error(err))
 		}
+	}()
 
-		if opts.Catch {
-			result = sdktypes.NewSessionCallAttemptResult(result.ToValueTuple(), nil)
-		}
+	if err := result.GetError(); err != nil {
+		z.Debug("call returned an error", zap.Error(err))
+	} else {
+		z.Debug("call returned a value")
+	}
 
-		// TODO: this is an error in db access inside the activity. If this fails we might be in a troubling state.
-		//       need to at least manually retry this.
-		if err := cs.svcs.DB.CompleteSessionCallAttempt(
-			ctx, sessionID, seq, attempt,
-			sdktypes.NewSessionCallAttemptComplete(last, interval, result),
-		); err != nil {
-			return nil, attempt, err
-		}
+	if opts.Catch {
+		result = sdktypes.NewSessionCallAttemptResult(result.ToValueTuple(), nil)
+	}
+
+	// TODO: this is an error in db access inside the activity. If this fails we might be in a troubling state.
+	//       need to at least manually retry this.
+	if err := cs.svcs.DB.CompleteSessionCallAttempt(
+		ctx, sessionID, seq, attempt,
+		sdktypes.NewSessionCallAttemptComplete(true, 0, result),
+	); err != nil {
+		return nil, 0, err
 	}
 
 	return call, attempt, nil

--- a/internal/backend/sessions/sessionworkflows/module.go
+++ b/internal/backend/sessions/sessionworkflows/module.go
@@ -12,17 +12,14 @@ import (
 
 func (w *sessionWorkflow) newModule() sdkexecutor.Executor {
 	flags := sdkmodule.WithFlags(
-		sdktypes.PureFunctionFlag,           // no need to run in an activity, we must have it in the workflow.
-		sdktypes.PrivilidgedFunctionFlag,    // provide workflow context.
-		sdktypes.DisablePollingFunctionFlag, // no polling.
+		sdktypes.PureFunctionFlag,        // no need to run in an activity, we must have it in the workflow.
+		sdktypes.PrivilidgedFunctionFlag, // provide workflow context.
 	)
 
 	return fixtures.NewBuiltinExecutor(
 		fixtures.ModuleExecutorID,
 		sdkmodule.ExportValue("timeout_error", sdkmodule.WithValue(fixtures.TimeoutError)),
 		sdkmodule.ExportFunction("syscall", w.syscall, flags),
-		sdkmodule.ExportFunction("poll", w.setPoller, flags),
-		sdkmodule.ExportFunction("fake", w.fake, flags),
 		sdkmodule.ExportFunction("sleep", w.sleep, flags),
 		sdkmodule.ExportFunction("start", w.start, flags),
 		sdkmodule.ExportFunction("subscribe", w.subscribe, flags),

--- a/runtimes/starlarkrt/internal/bootstrap/bootstrap.star
+++ b/runtimes/starlarkrt/internal/bootstrap/bootstrap.star
@@ -24,17 +24,6 @@
 def nop():
     pass
 
-# EXPORT: poll
-def poll(fn, pollerfn):
-    orig = ak.poll(pollerfn)
-    r = fn()
-    ak.poll(orig)
-    return r
-
-# EXPORT: fake
-def fake(*args, **kwargs):
-    return ak.fake(*args, **kwargs)
-
 # EXPORT: sleep
 def sleep(*args, **kwargs):
     return ak.sleep(*args, **kwargs)

--- a/sdk/sdktypes/value_function.go
+++ b/sdk/sdktypes/value_function.go
@@ -74,10 +74,9 @@ func init() {
 type FunctionFlag string
 
 const (
-	PrivilidgedFunctionFlag    FunctionFlag = "privilidged" // pass workflow context.
-	PureFunctionFlag           FunctionFlag = "pure"        // do not run in an activity.
-	DisablePollingFunctionFlag FunctionFlag = "no-poll"     // do not poll.
-	ConstFunctionFlag          FunctionFlag = "const"       // result is serialized in data.
+	PrivilidgedFunctionFlag FunctionFlag = "privilidged" // pass workflow context.
+	PureFunctionFlag        FunctionFlag = "pure"        // do not run in an activity.
+	ConstFunctionFlag       FunctionFlag = "const"       // result is serialized in data.
 )
 
 func (ff FunctionFlag) String() string { return string(ff) }
@@ -87,8 +86,7 @@ func validateFunctionFlags(fs []string) error {
 
 	for _, f := range fs {
 		switch f {
-		case PrivilidgedFunctionFlag.String(), PureFunctionFlag.String(),
-			DisablePollingFunctionFlag.String(), ConstFunctionFlag.String():
+		case PrivilidgedFunctionFlag.String(), PureFunctionFlag.String(), ConstFunctionFlag.String():
 			return nil
 		default:
 			errs = append(errs, fmt.Errorf("invalid function flag %q", f))


### PR DESCRIPTION
kill polling and faking capabilities in session. these were once considered for starlark, but now we don't need them anymore.

note i left the attempt recording capability, since we might use it soon enough when we do retries.