### PR TITLE
fix: move config from backend to internal + support list env variables

### DIFF
--- a/backend/svc/configset.go
+++ b/backend/svc/configset.go
@@ -2,7 +2,7 @@ package svc
 
 import (
 	"go.autokitteh.dev/autokitteh/internal/backend/configset"
-	"go.autokitteh.dev/autokitteh/internal/backend/svc"
+	"go.autokitteh.dev/autokitteh/internal/config"
 )
 
 const (
@@ -13,4 +13,4 @@ const (
 
 var ParseMode = configset.ParseMode
 
-const ConfigDelim = svc.Delim
+const ConfigDelim = config.Delim

--- a/backend/svc/svc.go
+++ b/backend/svc/svc.go
@@ -7,15 +7,16 @@ import (
 
 	"go.autokitteh.dev/autokitteh/internal/backend/httpsvc"
 	"go.autokitteh.dev/autokitteh/internal/backend/svc"
+	"go.autokitteh.dev/autokitteh/internal/config"
 )
 
 type (
 	RunOptions = svc.RunOptions
-	Config     = svc.Config
+	Config     = config.Config
 )
 
 var (
-	LoadConfig = svc.LoadConfig
+	LoadConfig = config.LoadConfig
 	StartDB    = svc.StartDB
 )
 

--- a/cmd/ak/cmd/server/db.go
+++ b/cmd/ak/cmd/server/db.go
@@ -5,6 +5,7 @@ import (
 
 	"go.autokitteh.dev/autokitteh/internal/backend/configset"
 	"go.autokitteh.dev/autokitteh/internal/backend/svc"
+	"go.autokitteh.dev/autokitteh/internal/config"
 )
 
 type db interface {
@@ -12,6 +13,6 @@ type db interface {
 	Migrate(context.Context) error
 }
 
-func InitDB(cfg *svc.Config, mode configset.Mode) (db, error) {
+func InitDB(cfg *config.Config, mode configset.Mode) (db, error) {
 	return svc.StartDB(context.Background(), cfg, svc.RunOptions{Mode: mode})
 }

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,6 @@ github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSC
 github.com/ProtonMail/go-crypto v1.0.0 h1:LRuvITjQWX+WIfr930YHG2HNfjR1uOfyf5vE0kC2U78=
 github.com/ProtonMail/go-crypto v1.0.0/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
-github.com/PuerkitoBio/goquery v1.9.2 h1:4/wZksC3KgkQw7SQgkKotmKljk0M6V8TUvA8Wb4yPeE=
-github.com/PuerkitoBio/goquery v1.9.2/go.mod h1:GHPCaP0ODyyxqcNoFGYlAprUFH81NuRPd0GX3Zu2Mvk=
 github.com/PuerkitoBio/goquery v1.10.0 h1:6fiXdLuUvYs2OJSvNRqlNPoBm6YABE226xrbavY5Wv4=
 github.com/PuerkitoBio/goquery v1.10.0/go.mod h1:TjZZl68Q3eGHNBA8CWaxAN7rOU1EbDz3CWuolcO5Yu4=
 github.com/adrg/xdg v0.5.0 h1:dDaZvhMXatArP1NPHhnfaQUqWBLBsmx1h1HXQdMoFCY=

--- a/internal/backend/gormkitteh/config.go
+++ b/internal/backend/gormkitteh/config.go
@@ -15,10 +15,10 @@ type Config struct {
 	// with an empty DSN, which will make sqlite use a temporary database
 	// (see https://www.sqlite.org/inmemorydb.html).
 	// If `Type` is "require" (RequireExplicitDSNType), `DSN` must be specified.
-	Type  string `koanf:"type"`
-	DSN   string `koanf:"dsn"`
-	Debug bool   `koanf:"debug"`
-
+	Type               string        `koanf:"type"`
+	DSN                string        `koanf:"dsn"`
+	Debug              bool          `koanf:"debug"`
+	ListOfStuff        []string      `koanf:"list"`
 	SlowQueryThreshold time.Duration `koanf:"slow_query_threshold"`
 
 	// If true, DB migrations will run automatically.

--- a/internal/backend/gormkitteh/config.go
+++ b/internal/backend/gormkitteh/config.go
@@ -18,7 +18,6 @@ type Config struct {
 	Type               string        `koanf:"type"`
 	DSN                string        `koanf:"dsn"`
 	Debug              bool          `koanf:"debug"`
-	ListOfStuff        []string      `koanf:"list"`
 	SlowQueryThreshold time.Duration `koanf:"slow_query_threshold"`
 
 	// If true, DB migrations will run automatically.

--- a/internal/backend/svc/svc.go
+++ b/internal/backend/svc/svc.go
@@ -65,6 +65,7 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/backend/varsgrpcsvc"
 	"go.autokitteh.dev/autokitteh/internal/backend/webhookssvc"
 	"go.autokitteh.dev/autokitteh/internal/backend/webtools"
+	"go.autokitteh.dev/autokitteh/internal/config"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/internal/version"
 	"go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/auth/v1/authv1connect"
@@ -129,7 +130,7 @@ var pprofConfigs = configset.Set[pprofConfig]{
 
 type HTTPServerAddr string
 
-func makeFxOpts(cfg *Config, opts RunOptions) []fx.Option {
+func makeFxOpts(cfg *config.Config, opts RunOptions) []fx.Option {
 	return []fx.Option{
 		fx.Supply(cfg),
 		LoggerFxOpt(),
@@ -413,7 +414,7 @@ type RunOptions struct {
 	TemporalClient client.Client // use this instead of creating a new temporal client.
 }
 
-func NewOpts(cfg *Config, ropts RunOptions) []fx.Option {
+func NewOpts(cfg *config.Config, ropts RunOptions) []fx.Option {
 	setFXRunOpts(ropts)
 
 	opts := makeFxOpts(cfg, ropts)
@@ -437,7 +438,7 @@ func NewOpts(cfg *Config, ropts RunOptions) []fx.Option {
 	return append(opts, fx.Populate(svcs))
 }
 
-func StartDB(ctx context.Context, cfg *Config, ropt RunOptions) (db.DB, error) {
+func StartDB(ctx context.Context, cfg *config.Config, ropt RunOptions) (db.DB, error) {
 	setFXRunOpts(ropt)
 
 	var db db.DB

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-package svc
+package config
 
 import (
 	"errors"
@@ -66,8 +66,12 @@ func LoadConfig(envVarPrefix string, confmapvs map[string]any, yamlPath string) 
 		// Env variables should have the following convention to support hierarchical keys:
 		// PREFIX_PARENT1__CHILD1__REQUIRED_KEY_NAME
 		// meaning heirarchy is separated by `__` and the name it self use one `_``.
-		if err := k.Load(env.Provider(envVarPrefix, "__", func(s string) string {
-			return strings.ToLower(strings.TrimPrefix(s, envVarPrefix))
+		if err := k.Load(env.ProviderWithValue(envVarPrefix, "__", func(key, value string) (string, interface{}) {
+			key = strings.ToLower(strings.TrimPrefix(key, envVarPrefix))
+			if strings.Contains(value, ",") {
+				return key, strings.Split(value, ",")
+			}
+			return key, value
 		}), nil); err != nil {
 			return nil, fmt.Errorf("load env: %w", err)
 		}


### PR DESCRIPTION
- Move config from backend to internal, this is something we wanted to do before, this is a preparation for the CLI to use the same config capabilities
- Support passing env variable that parsed as list of strings
```bash
MYVAR: a,b,c 
```

```go
type Cfg struct {
  ListData []string `koanf:"myvar"`
}
```