### PR TITLE
feat: allow enabling/disabling sessions workers

### DIFF
--- a/internal/backend/sessions/config.go
+++ b/internal/backend/sessions/config.go
@@ -9,12 +9,14 @@ import (
 )
 
 type Config struct {
-	Workflows sessionworkflows.Config `koanf:"workflows"`
-	Calls     sessioncalls.Config     `koanf:"calls"`
-	Debug     bool                    `koanf:"debug"`
+	Workflows    sessionworkflows.Config `koanf:"workflows"`
+	Calls        sessioncalls.Config     `koanf:"calls"`
+	Debug        bool                    `koanf:"debug"`
+	EnableWorker bool                    `koanf:"enable_worker"`
 }
 
 var defaultConfig = Config{
+	EnableWorker: true,
 	Workflows: sessionworkflows.Config{
 		Temporal: sessionworkflows.TemporalConfig{
 			WorkflowTaskTimeout:         time.Hour,

--- a/internal/backend/sessions/sessions.go
+++ b/internal/backend/sessions/sessions.go
@@ -44,8 +44,15 @@ func New(z *zap.Logger, config *Config, db db.DB, svcs sessionsvcs.Svcs, telemet
 }
 
 func (s *sessions) StartWorkers(ctx context.Context) error {
+
 	s.calls = sessioncalls.New(s.z.Named("sessionworkflows"), s.config.Calls, s.svcs)
 	s.workflows = sessionworkflows.New(s.z.Named("sessionworkflows"), s.config.Workflows, s, s.svcs, s.calls, s.telemetry)
+
+	if !s.config.EnableWorker {
+		s.z.Info("Session worker: disabled")
+		return nil
+	}
+	s.z.Info("Session worker: enabled")
 
 	if err := s.workflows.StartWorkers(ctx); err != nil {
 		return fmt.Errorf("workflow workflows: %w", err)


### PR DESCRIPTION
this is to support running API only mode and worker mode so we can run the workers on a remote machine
and make sure all workflows are executed correctly