### PR TITLE
feat(python): Add "timeout" parameter to "next_event" in Python sdk.

### DIFF
--- a/runtimes/pythonrt/ak_runner/call.py
+++ b/runtimes/pythonrt/ak_runner/call.py
@@ -1,5 +1,6 @@
 import inspect
 from collections import namedtuple
+from datetime import timedelta
 from pathlib import Path
 from time import sleep
 
@@ -75,14 +76,22 @@ class AKCall:
                 return func(*args, **kw)
 
             log.info("ak function call: %s(%r, %r)", func.__name__, args, kw)
+
+            if func is autokitteh.next_event:
+                timeout = kw.get("timeout")
+                if isinstance(timeout, timedelta):
+                    kw["timeout"] = timeout.total_seconds()
+
             self.comm.send_call(func.__name__, args, kw)
             msg = self.comm.recv(MessageType.call_return)
             value = msg["payload"]["value"]
+
             if func is autokitteh.next_event:
                 value = {} if value is None else value  # None means timeout
                 if not isinstance(value, dict):
                     raise TypeError(f"next_event returned {value!r}, expected dict")
                 value = autokitteh.AttrDict(value)
+
             return value
 
         if not self.should_run_as_activity(func):

--- a/runtimes/pythonrt/py-sdk/autokitteh/events.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/events.py
@@ -1,5 +1,6 @@
 """Un/subscribe and consume AutoKitteh connection events."""
 
+from datetime import timedelta
 from uuid import uuid4
 
 from .attr_dict import AttrDict
@@ -17,7 +18,7 @@ def unsubscribe(subscription_id: str) -> None:
     pass
 
 
-def next_event(subscription_id: str) -> AttrDict:
+def next_event(subscription_id: str, *, timeout: timedelta = None) -> AttrDict:
     """Get the next event from the subscription."""
     # Dummy implementation for local development.
     return AttrDict()


### PR DESCRIPTION
Also converts timeout from timedelta to seconds when sending to Go.