### PR TITLE
refactor(webhooks): update fields in webhook events

### DIFF
--- a/internal/backend/webhookssvc/svc.go
+++ b/internal/backend/webhookssvc/svc.go
@@ -103,7 +103,7 @@ func requestToData(r *http.Request) (map[string]sdktypes.Value, error) {
 	}
 
 	r.Body = io.NopCloser(bytes.NewReader(body))
-	r.ParseForm()
+	_ = r.ParseForm()
 
 	return map[string]sdktypes.Value{
 		"body": bodyData(body, r.PostForm),

--- a/runtimes/pythonrt/ak_runner/__main__.py
+++ b/runtimes/pythonrt/ak_runner/__main__.py
@@ -117,10 +117,10 @@ def run(args):
 
     # Inject HTTP body
     # TODO (ENG-624) change this once we support callbacks to autokitteh
-    body = event.get("data", {}).get("body")
+    body = event.get("data", {}).get("body", {}).get("bytes")
     if isinstance(body, str):
         try:
-            event["data"]["body"] = b64decode(body)
+            event["data"]["body"]["bytes"] = b64decode(body)
         except ValueError:
             pass
 

--- a/tests/system/testdata/deployments/state.txtar
+++ b/tests/system/testdata/deployments/state.txtar
@@ -39,7 +39,7 @@ project:
 
 -- program.star --
 def on_http_get(event):
-    if event.data.url.path.endswith('short'):
+    if event.data.raw_url.endswith('short'):
       print(ak.is_deployment_active())
       return
 

--- a/tests/system/testdata/end2end/http.txtar
+++ b/tests/system/testdata/end2end/http.txtar
@@ -43,7 +43,7 @@ def on_http(data, trigger, event):
     "state": {
         "completed": {
             "prints": [
-                "data(body = body(bytes = \u003cbuilt-in function .bytes\u003e, form = \u003cbuilt-in function .form\u003e, json = \u003cbuilt-in function .json\u003e, text = \u003cbuilt-in function .text\u003e), headers = {\"Accept-Encoding\": \"gzip\", \"User-Agent\": \"Go-http-client/1.1\"}, method = \"GET\", url = url(fragment = \"\", host = \"\", opaque = \"\", path = \"/webhooks/00000000000000000000000004/\", query = {}, raw = \"\", raw_fragment = \"\", raw_query = \"\", scheme = \"\"))",
+                "data(body = {\"form\": None, \"bytes\": None, \"json\": None}, headers = {\"Accept-Encoding\": \"gzip\", \"User-Agent\": \"Go-http-client/1.1\"}, method = \"GET\", raw_url = \"/webhooks/00000000000000000000000004/\", url = {\"fragment\": \"\", \"raw_path\": \"\", \"query\": {}, \"raw_fragment\": \"\", \"raw_query\": \"\", \"path\": \"/webhooks/00000000000000000000000004/\"})",
                 "get",
                 "trigger(name = \"http\")"
             ],
@@ -81,7 +81,7 @@ def on_http(data, trigger, event):
     "state": {
         "completed": {
             "prints": [
-                "data(body = body(bytes = \u003cbuilt-in function .bytes\u003e, form = \u003cbuilt-in function .form\u003e, json = \u003cbuilt-in function .json\u003e, text = \u003cbuilt-in function .text\u003e), headers = {\"Accept-Encoding\": \"gzip\", \"User-Agent\": \"Go-http-client/1.1\", \"Content-Length\": \"0\"}, method = \"POST\", url = url(fragment = \"\", host = \"\", opaque = \"\", path = \"/webhooks/00000000000000000000000004/test/aaa/bbb/ccc\", query = {}, raw = \"\", raw_fragment = \"\", raw_query = \"\", scheme = \"\"))",
+                "data(body = {\"form\": None, \"bytes\": None, \"json\": None}, headers = {\"Accept-Encoding\": \"gzip\", \"User-Agent\": \"Go-http-client/1.1\", \"Content-Length\": \"0\"}, method = \"POST\", raw_url = \"/webhooks/00000000000000000000000004/test/aaa/bbb/ccc\", url = {\"fragment\": \"\", \"raw_path\": \"\", \"query\": {}, \"raw_fragment\": \"\", \"raw_query\": \"\", \"path\": \"/webhooks/00000000000000000000000004/test/aaa/bbb/ccc\"})",
                 "post",
                 "trigger(name = \"http\")"
             ],

--- a/tests/system/testdata/sessions/events.txtar
+++ b/tests/system/testdata/sessions/events.txtar
@@ -54,9 +54,9 @@ project:
 def on_http_start():
   s1 = subscribe("http2")
   s2 = subscribe("http1")
-  print(1, next_event(s2)['body'].text())
-  print(2, next_event(s1)['body'].text())
+  print(1, next_event(s2)['body']['bytes'])
+  print(2, next_event(s1)['body']['bytes'])
   print(3, next_event(s2, timeout=1))
-  print(4, next_event(s1, s2, timeout=2)['body'].text())
-  print(5, next_event(s1, s2, timeout=2)['body'].text())
+  print(4, next_event(s1, s2, timeout=2)['body']['bytes'])
+  print(5, next_event(s1, s2, timeout=2)['body']['bytes'])
   print("done")


### PR DESCRIPTION
- Add `raw_url` alongside `url`
- Replace `body` functions with data (`bytes`, `form`, `json` - `None` if missing)
- Remove always-empty fields from `url`: leave only `path`, `query`, `fragment` (i.e. remove `scheme`, `opaque`, `host`)

Refs: ENG-1517, ENG-1518