### PR TITLE
refactor(fx): log only errors

### DIFF
--- a/internal/backend/svc/fx.go
+++ b/internal/backend/svc/fx.go
@@ -48,6 +48,11 @@ func Component[T any](name string, set configset.Set[T], opts ...fx.Option) fx.O
 
 func fxLogger(z *zap.Logger) fxevent.Logger {
 	l := &fxevent.ZapLogger{Logger: z.Named("fx")}
+	// When Zap writes a log message, it checks that the message's logging level
+	// is >= AK's (configurable) logging threshold. "Debug" (-1) is the lowest
+	// (i.e. noisiest) possible logging level, so setting FX's info logging to
+	// "Debug - 1" means that it will never be >= AK's logging threshold,
+	// which means that FX will never log info messages, only errors.
 	l.UseLogLevel(zapcore.DebugLevel - 1)
 	l.UseErrorLevel(zapcore.ErrorLevel)
 	return l

--- a/internal/backend/svc/fx.go
+++ b/internal/backend/svc/fx.go
@@ -48,7 +48,7 @@ func Component[T any](name string, set configset.Set[T], opts ...fx.Option) fx.O
 
 func fxLogger(z *zap.Logger) fxevent.Logger {
 	l := &fxevent.ZapLogger{Logger: z.Named("fx")}
-	l.UseLogLevel(zapcore.DebugLevel)
+	l.UseLogLevel(zapcore.DebugLevel - 1)
 	l.UseErrorLevel(zapcore.ErrorLevel)
 	return l
 }


### PR DESCRIPTION
For FX, log only errors, discard the countless and useless start-time messages about successfully providing, decorating, running, and invoking.

This makes the debug level MUCH more user-friendly without losing any info.