### PR TITLE
feat(db): use gormzap logger

### DIFF
--- a/internal/backend/db/dbgorm/dbgorm.go
+++ b/internal/backend/db/dbgorm/dbgorm.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pressly/goose/v3"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 
 	_ "ariga.io/atlas-provider-gorm/gormschema"
 
@@ -71,7 +70,6 @@ func (db *gormdb) GormDB() *gorm.DB { return db.db }
 func (db *gormdb) Connect(ctx context.Context) error {
 	client, err := gormkitteh.OpenZ(db.z.Named("gorm"), db.cfg, func(cfg *gorm.Config) {
 		cfg.SkipDefaultTransaction = true
-		cfg.Logger = logger.Default
 	})
 	if err != nil {
 		return fmt.Errorf("opendb: %w", err)

--- a/internal/backend/gormkitteh/z.go
+++ b/internal/backend/gormkitteh/z.go
@@ -15,7 +15,7 @@ func OpenZ(z *zap.Logger, cfg *Config, f func(*gorm.Config)) (*gorm.DB, error) {
 	return Open(cfg, func(c *gorm.Config) {
 		l := &zapgorm2.Logger{
 			ZapLogger:                 z,
-			LogLevel:                  logger.Info, // ensure minimal level
+			LogLevel:                  logger.Warn,
 			SlowThreshold:             cfg.SlowQueryThreshold,
 			IgnoreRecordNotFoundError: true,
 		}
@@ -24,11 +24,12 @@ func OpenZ(z *zap.Logger, cfg *Config, f func(*gorm.Config)) (*gorm.DB, error) {
 			f(c)
 		}
 		c.Logger = l
-		// TODO: maybe we could clone the core with the same encoder and writer, but with different/lower level?
+		// TODO(ENG-1590): maybe we could clone the core with the same encoder and writer, but with different/lower level?
 		// (we cannon lower level with zap.IncreaseLevel(), unfortunately or extract encoder and writer from the original core)
 		// so, if explicit debug is requested - switch to default gorm logger (which will log to stdout)
 		if cfg.Debug {
 			c.Logger = logger.Default
+			l.LogLevel = logger.Info
 		}
 	})
 }

--- a/internal/backend/gormkitteh/z.go
+++ b/internal/backend/gormkitteh/z.go
@@ -15,19 +15,20 @@ func OpenZ(z *zap.Logger, cfg *Config, f func(*gorm.Config)) (*gorm.DB, error) {
 	return Open(cfg, func(c *gorm.Config) {
 		l := &zapgorm2.Logger{
 			ZapLogger:                 z,
-			LogLevel:                  logger.Warn,
+			LogLevel:                  logger.Info, // ensure minimal level
 			SlowThreshold:             cfg.SlowQueryThreshold,
 			IgnoreRecordNotFoundError: true,
 		}
 
-		if cfg.Debug {
-			l.LogLevel = logger.Info
-		}
-
-		c.Logger = l
-
 		if f != nil {
 			f(c)
+		}
+		c.Logger = l
+		// TODO: maybe we could clone the core with the same encoder and writer, but with different/lower level?
+		// (we cannon lower level with zap.IncreaseLevel(), unfortunately or extract encoder and writer from the original core)
+		// so, if explicit debug is requested - switch to default gorm logger (which will log to stdout)
+		if cfg.Debug {
+			c.Logger = logger.Default
 		}
 	})
 }

--- a/internal/backend/gormkitteh/z.go
+++ b/internal/backend/gormkitteh/z.go
@@ -15,7 +15,7 @@ func OpenZ(z *zap.Logger, cfg *Config, f func(*gorm.Config)) (*gorm.DB, error) {
 	return Open(cfg, func(c *gorm.Config) {
 		l := &zapgorm2.Logger{
 			ZapLogger:                 z,
-			LogLevel:                  logger.Warn,
+			LogLevel:                  logger.Info, // lowest possible. will be checked vs. zap logger level
 			SlowThreshold:             cfg.SlowQueryThreshold,
 			IgnoreRecordNotFoundError: true,
 		}


### PR DESCRIPTION
right our db layer is always using default gorm logger (overriding any other logger), which prevents us to see db logs in datadog
- use zap gorm logger
- switch to default gorm one if debug is requested