### PR TITLE
fix(db): trace all DB queries only when db.debug = true

### DIFF
--- a/internal/backend/db/dbgorm/dbgorm.go
+++ b/internal/backend/db/dbgorm/dbgorm.go
@@ -69,7 +69,7 @@ func (db *gormdb) GormDB() *gorm.DB { return db.db }
 
 func (db *gormdb) Connect(ctx context.Context) error {
 	var l *zap.Logger
-	if db.cfg.Debug	{
+	if db.cfg.Debug {
 		l = db.z.Named("gorm")
 	}
 	client, err := gormkitteh.OpenZ(l, db.cfg, func(cfg *gorm.Config) {

--- a/internal/backend/db/dbgorm/dbgorm.go
+++ b/internal/backend/db/dbgorm/dbgorm.go
@@ -68,7 +68,11 @@ func New(z *zap.Logger, cfg *Config) (db.DB, error) {
 func (db *gormdb) GormDB() *gorm.DB { return db.db }
 
 func (db *gormdb) Connect(ctx context.Context) error {
-	client, err := gormkitteh.OpenZ(db.z.Named("gorm"), db.cfg, func(cfg *gorm.Config) {
+	var l *zap.Logger
+	if db.cfg.Debug	{
+		l = db.z.Named("gorm")
+	}
+	client, err := gormkitteh.OpenZ(l, db.cfg, func(cfg *gorm.Config) {
 		cfg.SkipDefaultTransaction = true
 	})
 	if err != nil {


### PR DESCRIPTION
It's impossible for me to use debug level with *all* DB queries being logged. But I don't know if this is the right way to disable it.