### PR TITLE
feat(google): refresh OAuth tokens in Go, not Python

### DIFF
--- a/internal/backend/sessions/sessionworkflows/module.go
+++ b/internal/backend/sessions/sessionworkflows/module.go
@@ -27,6 +27,7 @@ func (w *sessionWorkflow) newModule() sdkexecutor.Executor {
 		sdkmodule.ExportFunction("next_event", w.nextEvent, flags),
 		sdkmodule.ExportFunction("callopts", callopts, flags),
 		sdkmodule.ExportFunction("is_deployment_active", w.isDeploymentActive),
+		sdkmodule.ExportFunction("google_refresh_handler", w.refreshGoogleOAuth, flags),
 	)
 }
 

--- a/internal/backend/sessions/sessionworkflows/oauth.go
+++ b/internal/backend/sessions/sessionworkflows/oauth.go
@@ -1,0 +1,16 @@
+package sessionworkflows
+
+import (
+	"context"
+	"errors"
+
+	"go.uber.org/zap"
+
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+func (w *sessionWorkflow) refreshGoogleOAuth(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
+	w.l.Warn("Google OAuth refresh", zap.Any("unwrap", args), zap.Any("unwrap", kwargs))
+
+	return sdktypes.InvalidValue, errors.New("not implemented")
+}

--- a/internal/backend/sessions/sessionworkflows/syscalls.go
+++ b/internal/backend/sessions/sessionworkflows/syscalls.go
@@ -21,6 +21,8 @@ const (
 	subscribeOp   = "subscribe"
 	nextEventOp   = "next_event"
 	unsubscribeOp = "unsubscribe"
+
+	refreshGoogleOAuthOp = "google_refresh_handler"
 )
 
 func (w *sessionWorkflow) syscall(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
@@ -47,6 +49,8 @@ func (w *sessionWorkflow) syscall(ctx context.Context, args []sdktypes.Value, kw
 		return w.nextEvent(ctx, args, kwargs)
 	case unsubscribeOp:
 		return w.unsubscribe(ctx, args, kwargs)
+	case refreshGoogleOAuthOp:
+		return w.refreshGoogleOAuth(ctx, args, kwargs)
 	default:
 		return sdktypes.InvalidValue, fmt.Errorf("unknown op %q", op)
 	}

--- a/runtimes/pythonrt/ak_runner/call.py
+++ b/runtimes/pythonrt/ak_runner/call.py
@@ -6,6 +6,7 @@ from time import sleep
 
 import autokitteh
 from autokitteh import decorators
+from autokitteh import google
 
 from . import log
 from .comm import Comm, MessageType
@@ -16,6 +17,7 @@ AK_FUNCS = {
     autokitteh.next_event,
     autokitteh.subscribe,
     autokitteh.unsubscribe,
+    google.google_refresh_handler,
     sleep,
 }
 

--- a/runtimes/pythonrt/ak_runner/loader.py
+++ b/runtimes/pythonrt/ak_runner/loader.py
@@ -28,6 +28,8 @@ class Transformer(ast.NodeTransformer):
         self.generic_visit(node)
 
         name = name_of(node.func, self.code_lines)
+        print(str(node))
+        print(str(name))
 
         if not name or name in BUILTIN:
             return node

--- a/runtimes/pythonrt/ak_runner/loader.py
+++ b/runtimes/pythonrt/ak_runner/loader.py
@@ -25,22 +25,48 @@ class Transformer(ast.NodeTransformer):
 
     def visit_Call(self, node):
         # Recurse, see https://docs.python.org/3/library/ast.html#ast.NodeVisitor.generic_visit
+        # and https://docs.python.org/3/library/ast.html#ast.NodeTransformer
         self.generic_visit(node)
 
         name = name_of(node.func, self.code_lines)
-        print(str(node))
-        print(str(name))
+        print(f"CALL LINE: {self.code_lines[node.lineno - 1]}")
+        print(f"CALL NAME: {name}")
 
         if not name or name in BUILTIN:
             return node
 
         log.info("%s:%d: patching %s with action", self.file_name, node.lineno, name)
+        print(f"PATCHING CALL IN {self.file_name}:{node.lineno}: {name}")
         call = ast.Call(
             func=ast.Name(id=ACTION_NAME, ctx=ast.Load()),
             args=[node.func] + node.args,
             keywords=node.keywords,
         )
         return call
+
+    def visit_Import(self, node: ast.Import):
+        # Recurse, see https://docs.python.org/3/library/ast.html#ast.NodeVisitor.generic_visit
+        # and https://docs.python.org/3/library/ast.html#ast.NodeTransformer
+        self.generic_visit(node)
+
+        for alias in node.names:
+            print(f"IMPORT: ALIAS NAME {alias.name}")
+            # self._parse_module(module_name)
+
+        return node
+
+    def visit_ImportFrom(self, node: ast.ImportFrom):
+        # Recurse, see https://docs.python.org/3/library/ast.html#ast.NodeVisitor.generic_visit
+        # and https://docs.python.org/3/library/ast.html#ast.NodeTransformer
+        self.generic_visit(node)
+
+        print(f"IMPORT FROM: MODULE {node.module}")
+        for alias in node.names:
+            print(f"IMPORT FROM: ALIAS NAME {alias.name}")
+            # self._parse_module(module_name)
+
+        # self._parse_module(module_name)
+        return node
 
 
 def load_code(root_path, action_fn, module_name):

--- a/runtimes/pythonrt/py-sdk/autokitteh/google.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/google.py
@@ -241,8 +241,8 @@ def __google_creds_oauth2(connection: str, scopes: list[str]):
             }
         )
 
-    if creds.expired:
-        creds.refresh(Request())
+    # TODO: if creds.expired:
+    creds.refresh(Request())
 
     return creds
 
@@ -264,7 +264,7 @@ def google_refresh_handler(request, scopes: list[str]) -> tuple[str, datetime]:
     Returns:
         New access token and its expiry date.
     """
-    print("NOT OVERRIDDEN!!!")
+    print("NOT OVERRIDDEN!!!")  # TODO: Remove this line
     return "DUMMY TOKEN", datetime.now(UTC).replace(tzinfo=None)
 
 


### PR DESCRIPTION
This PR is based on the `main` branch before PR #660 

AK's AST parsing is currently limited to the user's code, so we can't intercept and replace calls to our dummy handler function in other modules without a deep change in `loader.py`.

Two options that I can think of:

1. Parse AK's Python SDK module too, and wrap the _**definition**_ of the refresh handler function - is that possible?
2. Parse AK's Python SDK and `google-auth-library-python`, and wrap all the _**calls**_ to the refresh handler function

   - https://github.com/autokitteh/autokitteh/blob/777966b55fc5f61a0ab76af75fb25e14bdd08286/runtimes/pythonrt/py-sdk/autokitteh/google.py#L251
   - https://github.com/googleapis/google-auth-library-python/blob/63f657174c603c077af3bbf7580b75b5f3b4943e/google/oauth2/credentials.py#L372

Either way, this is not applicable for GitHub and Slack.