### PR TITLE
fix: do not fail temporal workflow on program errors

### DIFF
--- a/internal/backend/sessions/sessionworkflows/metrics.go
+++ b/internal/backend/sessions/sessionworkflows/metrics.go
@@ -7,18 +7,20 @@ import (
 )
 
 var (
-	sessionsCreatedCounter     metric.Int64Counter
-	sessionsCompletedCounter   metric.Int64Counter
-	sessionsErroredCounter     metric.Int64Counter
-	sessionsStoppedCounter     metric.Int64Counter
-	sessionStaleReplaysCounter metric.Int64Counter
-	sessionDurationHistogram   metric.Int64Histogram
+	sessionsCreatedCounter       metric.Int64Counter
+	sessionsCompletedCounter     metric.Int64Counter
+	sessionsErroredCounter       metric.Int64Counter
+	sessionsProgramErrorsCounter metric.Int64Counter
+	sessionsStoppedCounter       metric.Int64Counter
+	sessionStaleReplaysCounter   metric.Int64Counter
+	sessionDurationHistogram     metric.Int64Histogram
 )
 
 func initMetrics(t *telemetry.Telemetry) {
 	sessionsCreatedCounter, _ = t.NewCounter("sessions.created", "Created sessions counter")
 	sessionsCompletedCounter, _ = t.NewCounter("sessions.completed", "Completed sessions counter")
 	sessionsErroredCounter, _ = t.NewCounter("sessions.errored", "Errored sessions counter")
+	sessionsProgramErrorsCounter, _ = t.NewCounter("sessions.program_errors", "Program errors sessions counter")
 	sessionsStoppedCounter, _ = t.NewCounter("sessions.stopped", "Stopped sessions counter")
 	sessionDurationHistogram, _ = t.NewHistogram("sessions.duration", "Session duration histogram")
 	sessionStaleReplaysCounter, _ = t.NewCounter("sessions.stale_replays", "Stale replays sessions counter")

--- a/internal/backend/sessions/sessionworkflows/workflows.go
+++ b/internal/backend/sessions/sessionworkflows/workflows.go
@@ -203,8 +203,12 @@ func (ws *workflows) sessionWorkflow(wctx workflow.Context, params *sessionWorkf
 			ws.errored(dwctx, sid, err, prints)
 
 			if _, ok := sdktypes.FromError(err); ok {
-				// User level error (convertable to ProgramError), no need to indicate the workflow as errored.
+				// User level error (convertable to ProgramError).
 				l.Info("session workflow program error")
+				sessionsProgramErrorsCounter.Add(metricsCtx, 1)
+
+				// No need to indicate the workflow as errored.
+				err = nil
 			} else {
 				l.Sugar().Errorf("session workflow error: %v", err)
 			}


### PR DESCRIPTION
we should fail the workflows only on non user related errors