### PR TITLE
fix: pass context to data converter without workflow deadlock detector

### DIFF
--- a/internal/backend/sessions/sessionworkflows/workflow.go
+++ b/internal/backend/sessions/sessionworkflows/workflow.go
@@ -514,6 +514,7 @@ func (w *sessionWorkflow) run(wctx workflow.Context, l *zap.Logger) (prints []st
 	ctx := temporalclient.NewWorkflowContextAsGOContext(wctx)
 
 	temporalclient.WithoutDeadlockDetection(
+		wctx,
 		func() {
 			run, err = sdkruntimes.Run(
 				ctx,

--- a/internal/backend/temporalclient/withoutdeadlockdetection.go
+++ b/internal/backend/temporalclient/withoutdeadlockdetection.go
@@ -29,6 +29,12 @@ func (f abuser) ToStrings(*commonpb.Payloads) []string {
 //
 // See also https://github.com/temporalio/temporal/issues/6546.
 // Blame Maxim, not me.
-func WithoutDeadlockDetection(f func()) {
-	_ = workflow.DataConverterWithoutDeadlockDetection(abuser(f)).ToStrings(nil)
+func WithoutDeadlockDetection(wctx workflow.Context, f func()) {
+	cvt := workflow.DataConverterWithoutDeadlockDetection(abuser(f))
+
+	// The data converter without deadlock detection is ContextAware,
+	// and it must have the workflow context in order to work.
+	cvt = cvt.(workflow.ContextAware).WithWorkflowContext(wctx)
+
+	_ = cvt.ToStrings(nil)
 }


### PR DESCRIPTION
Without the context, its `pause` method does nothing. This explicitly passes the workflow context to the convertor to make it effective.

tested in debugger with `time.Sleep(30)` before and after change.