### PR TITLE
DRAFT: refactor: use explicit callbacks in python instead of call by value to syscalls

### DIFF
--- a/internal/backend/sessions/sessionworkflows/module.go
+++ b/internal/backend/sessions/sessionworkflows/module.go
@@ -19,14 +19,15 @@ func (w *sessionWorkflow) newModule() sdkexecutor.Executor {
 	return fixtures.NewBuiltinExecutor(
 		fixtures.ModuleExecutorID,
 		sdkmodule.ExportValue("timeout_error", sdkmodule.WithValue(fixtures.TimeoutError)),
-		sdkmodule.ExportFunction("syscall", w.syscall, flags),
+		sdkmodule.ExportFunction("callopts", callopts, flags),
+		sdkmodule.ExportFunction("is_deployment_active", w.isDeploymentActive),
+
+		// syscalls
 		sdkmodule.ExportFunction("sleep", w.sleep, flags),
 		sdkmodule.ExportFunction("start", w.start, flags),
 		sdkmodule.ExportFunction("subscribe", w.subscribe, flags),
 		sdkmodule.ExportFunction("unsubscribe", w.unsubscribe, flags),
 		sdkmodule.ExportFunction("next_event", w.nextEvent, flags),
-		sdkmodule.ExportFunction("callopts", callopts, flags),
-		sdkmodule.ExportFunction("is_deployment_active", w.isDeploymentActive),
 	)
 }
 

--- a/sdk/sdktypes/run_id.go
+++ b/sdk/sdktypes/run_id.go
@@ -10,3 +10,5 @@ func (runIDTraits) Prefix() string { return runIDKind }
 
 func NewRunID() RunID                    { return newID[RunID]() }
 func ParseRunID(s string) (RunID, error) { return ParseID[RunID](s) }
+
+var InvalidRunID RunID


### PR DESCRIPTION
- add syscalls to callbacks instead of inferring them from ak module in globals
- currently it still routes to the module, but at the session level. this is to keep the trace in autokitteh showing them.

easiest to review this if you begin with `sdk/sdkservices/runtimes.go`.

i bet there is more code to remove due to this, but just wanted to show the approach for now.

this is something I've been talking with @tebeka for a while. not sure if worth it. lmk.

another route could be just putting the function values themselves in the callbacks or someplace else so you wouldn't need to figure them out.