### PR TITLE
chore(db): don't log user ID when it's missing

### DIFF
--- a/internal/backend/db/dbgorm/ownership.go
+++ b/internal/backend/db/dbgorm/ownership.go
@@ -241,7 +241,9 @@ func (c *UsersOwnershipChecker) EnsureUserAccessToEntities(ctx context.Context, 
 }
 
 func (c *UsersOwnershipChecker) JoinUserEntity(ctx context.Context, db *gorm.DB, entity string, uid string) *gorm.DB {
-	c.z.Debug("withUser", zap.String("origin", akCtx.RequestOrginator(ctx).String()), zap.String("entity", entity), zap.Any("uid", uid))
+	if uid != "" {
+		c.z.Debug("withUser", zap.String("origin", akCtx.RequestOrginator(ctx).String()), zap.String("entity", entity), zap.Any("uid", uid))
+	}
 	if akCtx.RequestOrginator(ctx) == akCtx.User {
 		return joinUserEntity(db, entity, uid)
 	}

--- a/internal/backend/db/dbgorm/ownership_resolver_test.go
+++ b/internal/backend/db/dbgorm/ownership_resolver_test.go
@@ -43,7 +43,7 @@ type dbs struct {
 	varSvc sdkservices.Vars
 }
 
-func newIntegrationsSvc(t *testing.T, f *dbFixture) sdkservices.Integrations {
+func newIntegrationsSvc() sdkservices.Integrations {
 	desc := kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
 		IntegrationId: sdktypes.NewIDFromUUID[sdktypes.IntegrationID](&testIntegrationID).String(),
 		UniqueName:    "test",
@@ -71,7 +71,7 @@ func newDBServices(t *testing.T) (sdkservices.DBServices, *dbFixture) {
 	z := zaptest.NewLogger(t) // FIXME: or gormdb.z?
 	telemetry := kittehs.Must1(telemetry.New(z, &telemetry.Config{Enabled: false}))
 
-	intSvc := newIntegrationsSvc(t, f)
+	intSvc := newIntegrationsSvc()
 	bldSvc := builds.New(builds.Builds{Z: z, DB: gdb}, telemetry)
 	prjSvc := projects.New(projects.Projects{Z: z, DB: gdb}, telemetry)
 	depSvc := deployments.New(z, gdb, telemetry)


### PR DESCRIPTION
There's no point in logging DB ownership where there is no user ID.

This is particularly redundant when receiving HTTP callbacks from third parties: we see this debug log entry for each HTTP request which is anonymous by definition. We're not losing any information after this PR - the lack of this log message means exactly the same as the log message without a UID.

On the way, fix a small lint warning nearby (remove unused func parameters in test code).