### PR TITLE
fix(slack): parse channel_archive events correctly

### DIFF
--- a/integrations/slack/events/channel.go
+++ b/integrations/slack/events/channel.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 
@@ -79,6 +80,9 @@ func ChannelGroupHandler(l *zap.Logger, w http.ResponseWriter, body []byte, cb *
 			return nil
 		}
 	}
+
+	// Workaround for ENG-980: "is_moved: 0" should be "is_moved: false".
+	body = bytes.ReplaceAll(body, []byte(`"is_moved":0`), []byte(`"is_moved":false`))
 
 	// Parse and return the inner event details.
 	j := &channelGroupContainer{}


### PR DESCRIPTION
`is_moved` should be a boolean, but it's sent as a number (0) in `channel_archive` events, thereby breaking Go's JSON unmarshaling.

There's no documentation to say if it's a bug, or if it's specific just to this event, so I chose to continue with the expected behavior rather than the actual one.

Refs: ENG-980