### PR TITLE
fix(security): increase unit-test key size to avoid security alerts

### DIFF
--- a/integrations/github/jwt.go
+++ b/integrations/github/jwt.go
@@ -131,7 +131,7 @@ func getPrivateKey() []byte {
 	}
 	// This is solely for unit tests. It's safe dead code in production because
 	// in production we check that the environment variable exists.
-	k, err := rsa.GenerateKey(rand.Reader, 1024)
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
https://github.com/autokitteh/autokitteh/security/code-scanning/29

Even though the generated key is clearly marked as usable only in unit tests, it's still good to eliminate this warning rather than marking it as false.