### PR TITLE
fix(python): deal with errors gracefully

### DIFF
--- a/runtimes/pythonrt/pythonrt.go
+++ b/runtimes/pythonrt/pythonrt.go
@@ -74,6 +74,8 @@ type pySvc struct {
 	runnerID string
 
 	firstCall bool // first call is the trigger, other calls are activities
+	accPrints []*logMessage
+	accLogs   []*logMessage
 
 	channels comChannels
 
@@ -350,42 +352,42 @@ func pyLevelToZap(level string) zapcore.Level {
 }
 
 func (py *pySvc) call(ctx context.Context, val sdktypes.Value, args []sdktypes.Value, kw map[string]sdktypes.Value) {
-	req := pb.ActivityReplyRequest{}
+	fn := val.GetFunction()
 
-	// We want to send reply in any case
-	defer func() {
+	reply := func(req *pb.ActivityReplyRequest) {
+		if req.Error != "" {
+			py.log.Error("activity reply error", zap.String("error", req.Error))
+		}
+
+		req.Data = fn.Data()
+
 		ctx, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
-		reply, err := py.runner.ActivityReply(ctx, &req)
+
+		reply, err := py.runner.ActivityReply(ctx, req)
 		switch {
 		case err != nil:
 			py.log.Error("activity reply error", zap.Error(err))
 		case reply.Error != "":
 			py.log.Error("activity reply error", zap.String("error", reply.Error))
 		}
-	}()
+	}
 
 	if !val.IsFunction() {
-		py.log.Error("bad function", zap.Any("val", val))
-		req.Error = fmt.Sprintf("%#v is not a function", val)
+		reply(&pb.ActivityReplyRequest{Error: fmt.Sprintf("%#v is not a function", val)})
 		return
 	}
 
-	fn := val.GetFunction()
-	req.Data = fn.Data()
 	out, err := py.cbs.Call(py.ctx, py.runID, val, args, kw)
-
-	switch {
-	case err != nil:
-		req.Error = fmt.Sprintf("%s - %s", fn.Name().String(), err)
-		py.log.Error("activity reply error", zap.Error(err))
-	case !out.IsBytes():
-		req.Error = fmt.Sprintf("call output not bytes: %#v", out)
-		py.log.Error("activity reply error", zap.String("error", req.Error))
-	default:
-		data := out.GetBytes().Value()
-		req.Result = data
+	if err == nil && !out.IsBytes() {
+		err = fmt.Errorf("call output not bytes: %#v", out)
 	}
+	if err != nil {
+		reply(&pb.ActivityReplyRequest{Error: err.Error()})
+		return
+	}
+
+	reply(&pb.ActivityReplyRequest{Result: out.GetBytes().Value()})
 }
 
 // initialCall handles initial call from autokitteh, it does the message loop with Python.
@@ -460,18 +462,17 @@ func (py *pySvc) initialCall(ctx context.Context, funcName string, args []sdktyp
 	// Wait for client Done message
 	var done *pb.DoneRequest
 	for {
+		py.emitPrintsAndLogs(ctx)
+
 		select {
 		case healthErr := <-runnerHealthChan:
 			if healthErr != nil {
 				return sdktypes.InvalidValue, sdkerrors.NewRetryableError("runner health: %w", healthErr)
 			}
 		case r := <-py.channels.log:
-			level := pyLevelToZap(r.level)
-			py.log.Log(level, r.message)
-			close(r.doneChannel)
+			py.accLogs = append(py.accLogs, r)
 		case r := <-py.channels.print:
-			py.cbs.Print(ctx, py.runID, r.message)
-			close(r.doneChannel)
+			py.accPrints = append(py.accPrints, r)
 		case r := <-py.channels.request:
 			var (
 				fnName = "pyFunc"
@@ -520,12 +521,34 @@ func (py *pySvc) initialCall(ctx context.Context, funcName string, args []sdktyp
 	}
 }
 
+func (py *pySvc) emitPrintsAndLogs(ctx context.Context) {
+	for ; len(py.accPrints) > 0; py.accPrints = py.accPrints[1:] {
+		p := py.accPrints[0]
+		py.cbs.Print(ctx, py.runID, p.message)
+
+		if p.doneChannel != nil {
+			close(p.doneChannel)
+		}
+	}
+
+	for ; len(py.accLogs) > 0; py.accLogs = py.accLogs[1:] {
+		p := py.accLogs[0]
+		py.log.Log(pyLevelToZap(p.level), p.message)
+
+		if p.doneChannel != nil {
+			close(p.doneChannel)
+		}
+	}
+}
+
 // drainPrints drains the print channel at the end of a run.
 func (py *pySvc) drainPrints(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case r := <-py.channels.log:
+			py.log.Log(pyLevelToZap(r.level), r.message)
 		case r := <-py.channels.print:
 			py.cbs.Print(ctx, py.runID, r.message)
 		}
@@ -581,6 +604,8 @@ func (py *pySvc) Call(ctx context.Context, v sdktypes.Value, args []sdktypes.Val
 	case resp.Error != "":
 		return sdktypes.InvalidValue, fmt.Errorf("%s", resp.Error)
 	}
+
+	py.emitPrintsAndLogs(ctx)
 
 	return sdktypes.NewBytesValue(resp.Result), nil
 }

--- a/runtimes/pythonrt/pythonrt.go
+++ b/runtimes/pythonrt/pythonrt.go
@@ -543,6 +543,10 @@ func (py *pySvc) emitPrintsAndLogs(ctx context.Context) {
 
 // drainPrints drains the print channel at the end of a run.
 func (py *pySvc) drainPrints(ctx context.Context) {
+	// emit already accumulated prints and logs.
+	py.emitPrintsAndLogs(ctx)
+
+	// flush the rest of the prints and logs.
 	for {
 		select {
 		case <-ctx.Done():

--- a/runtimes/pythonrt/runner/main.py
+++ b/runtimes/pythonrt/runner/main.py
@@ -10,7 +10,7 @@ import pickle
 import sys
 from threading import Lock, Thread
 from time import sleep
-from traceback import TracebackException, print_exception
+from traceback import TracebackException, format_exception
 
 import grpc
 from grpc_reflection.v1alpha import reflection
@@ -62,9 +62,11 @@ def exc_traceback(err):
 def display_err(fn, err):
     func_name = full_func_name(fn)
     log.exception("calling %s: %s", func_name, err)
+
+    exc = "".join(format_exception(err))
+
     # Print the error to stderr so it'll show in session logs
-    print(f"error: {err}", file=sys.stderr)
-    print_exception(err, file=sys.stderr)
+    print(f"error: {err}\n\n{exc}", file=sys.stderr)
 
 
 # Go passes HTTP event.data.body.bytes as base64 encode string
@@ -196,7 +198,9 @@ class Runner(rpc.RunnerServicer):
         try:
             result = fn(*args, **kw)
         except Exception as e:
-            display_err(fn, e)
+            # NOPE: display_err(fn, e)
+            # This emits wierd additional data that the users will not want
+            # to see and confuse them.
             err = e
 
         resp = pb.ExecuteResponse(
@@ -207,9 +211,6 @@ class Runner(rpc.RunnerServicer):
             resp.error = str(err)
             tb = exc_traceback(err)
             resp.traceback.extend(tb)
-
-            context.set_code(grpc.StatusCode.ABORTED)
-            context.set_details(resp.error)
 
         return resp
 
@@ -224,6 +225,13 @@ class Runner(rpc.RunnerServicer):
             log.error("call_id %r not found", call_id)
             context.abort(
                 grpc.StatusCode.INVALID_ARGUMENT, "call_id {call_id!r} not found"
+            )
+
+        if request.error:
+            fut.set_exception(ActivityError(request.error))
+            context.abort(
+                grpc.StatusCode.ABORTED,
+                f"call_id {call_id!r}: activity error: {request.error}",
             )
 
         try:

--- a/runtimes/pythonrt/worker_grpc_handler.go
+++ b/runtimes/pythonrt/worker_grpc_handler.go
@@ -104,6 +104,9 @@ func (s *workerGRPCHandler) Log(ctx context.Context, req *pb.LogRequest) (*pb.Lo
 	m := &logMessage{level: req.Level, message: req.Message}
 
 	if !runner.firstCall {
+		// If we're not in the first call, the prints channel is not listened on since
+		// the select loop is stuck on the initialCall function.
+		// Cccumulate the prints which will be reported when the call is done.
 		runner.accLogs = append(runner.accLogs, m)
 		return &pb.LogResponse{}, nil
 	}
@@ -133,6 +136,9 @@ func (s *workerGRPCHandler) Print(ctx context.Context, req *pb.PrintRequest) (*p
 	m := &logMessage{level: "info", message: req.Message}
 
 	if !runner.firstCall {
+		// If we're not in the first call, the prints channel is not listened on since
+		// the select loop is stuck on the initialCall function.
+		// Cccumulate the prints which will be reported when the call is done.
 		runner.accPrints = append(runner.accPrints, m)
 		return &pb.PrintResponse{}, nil
 	}

--- a/runtimes/pythonrt/worker_grpc_handler.go
+++ b/runtimes/pythonrt/worker_grpc_handler.go
@@ -106,7 +106,7 @@ func (s *workerGRPCHandler) Log(ctx context.Context, req *pb.LogRequest) (*pb.Lo
 	if !runner.firstCall {
 		// If we're not in the first call, the prints channel is not listened on since
 		// the select loop is stuck on the initialCall function.
-		// Cccumulate the prints which will be reported when the call is done.
+		// Accumulate the prints which will be reported when the call is done.
 		runner.accLogs = append(runner.accLogs, m)
 		return &pb.LogResponse{}, nil
 	}
@@ -138,7 +138,7 @@ func (s *workerGRPCHandler) Print(ctx context.Context, req *pb.PrintRequest) (*p
 	if !runner.firstCall {
 		// If we're not in the first call, the prints channel is not listened on since
 		// the select loop is stuck on the initialCall function.
-		// Cccumulate the prints which will be reported when the call is done.
+		// Accumulate the prints which will be reported when the call is done.
 		runner.accPrints = append(runner.accPrints, m)
 		return &pb.PrintResponse{}, nil
 	}


### PR DESCRIPTION
- currently when there is an error inside an activity, python attempts to make a print. when this happens there is a deadlock since `initialCall` blocks the select. the fix is to accumulate the prints and logs and emit them all together when this is done.
- traces are not emitted in a single print, which should make @daabr a happier person.
- errors look much cleaner now, no non-user related gibrish.

Refs: ENG-1700