### PR TITLE
fix(logging): misc logging fixes and improvements

### DIFF
--- a/runtimes/pythonrt/pythonrt.go
+++ b/runtimes/pythonrt/pythonrt.go
@@ -356,7 +356,7 @@ func (py *pySvc) call(ctx context.Context, val sdktypes.Value, args []sdktypes.V
 
 	reply := func(req *pb.ActivityReplyRequest) {
 		if req.Error != "" {
-			py.log.Error("activity reply error", zap.String("error", req.Error))
+			py.log.Warn("activity reply error", zap.String("error", req.Error))
 		}
 
 		req.Data = fn.Data()
@@ -367,9 +367,9 @@ func (py *pySvc) call(ctx context.Context, val sdktypes.Value, args []sdktypes.V
 		reply, err := py.runner.ActivityReply(ctx, req)
 		switch {
 		case err != nil:
-			py.log.Error("activity reply error", zap.Error(err))
+			py.log.Warn("activity reply error", zap.Error(err))
 		case reply.Error != "":
-			py.log.Error("activity reply error", zap.String("error", reply.Error))
+			py.log.Warn("activity reply error", zap.String("reply error", reply.Error))
 		}
 	}
 


### PR DESCRIPTION
(Stacked over #775)

1. Change logs about activity errors to warnings: the cause is usually errors in the user code, so the error level is inappropriate, and its stack trace is irrelevant
2. Do not log results / return values of successful activities - this is private user data that doesn't belong in our logs
3. Fix sugared logger mistakes like:
   - `sl.Level("msg", zap.ValueType("key", value))` - sugared logger attributes are expected to be string+any pairs, not `zap.ValueType` calls
   - `sl.Info("... %v", value)` - `Infof` instead of `Info`
   - `sl.With(err)` - should be `sl.With("err", err)` or `l.With(zap.Error(err))`
4. Prefer regular logger over sugared logger until the latter is actually needed