### PR TITLE
fix(github): missing param name when creating PAT connections

### DIFF
--- a/internal/backend/webhookssvc/svc.go
+++ b/internal/backend/webhookssvc/svc.go
@@ -122,17 +122,12 @@ func requestToData(r *http.Request) (map[string]sdktypes.Value, error) {
 			}),
 		),
 		"trailers": sdktypes.NewDictValueFromStringMap(
-			kittehs.TransformMapValues(r.Header, func(vs []string) sdktypes.Value {
+			kittehs.TransformMapValues(r.Trailer, func(vs []string) sdktypes.Value {
 				return sdktypes.NewStringValue(strings.Join(vs, ", "))
 			})),
 		"method":            sdktypes.NewStringValue(r.Method),
-		"raw_url":           sdktypes.NewStringValue(r.URL.String()),
+		"raw_url":           sdktypes.NewStringValue(r.RequestURI),
 		"url":               urlData(r.URL),
-		"request_uri":       sdktypes.NewStringValue(r.RequestURI),
-		"content_length":    sdktypes.NewIntegerValue(r.ContentLength),
-		"transfer_encoding": kittehs.Must1(sdktypes.NewListValue(kittehs.Transform(r.TransferEncoding, sdktypes.NewStringValue))),
-		"host":              sdktypes.NewStringValue(r.Host),
-		"remote_addr":       sdktypes.NewStringValue(r.RemoteAddr),
 	}, nil
 }
 

--- a/internal/backend/webhookssvc/svc.go
+++ b/internal/backend/webhookssvc/svc.go
@@ -125,9 +125,9 @@ func requestToData(r *http.Request) (map[string]sdktypes.Value, error) {
 			kittehs.TransformMapValues(r.Trailer, func(vs []string) sdktypes.Value {
 				return sdktypes.NewStringValue(strings.Join(vs, ", "))
 			})),
-		"method":            sdktypes.NewStringValue(r.Method),
-		"raw_url":           sdktypes.NewStringValue(r.RequestURI),
-		"url":               urlData(r.URL),
+		"method":  sdktypes.NewStringValue(r.Method),
+		"raw_url": sdktypes.NewStringValue(r.RequestURI),
+		"url":     urlData(r.URL),
 	}, nil
 }
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/github.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/github.py
@@ -36,7 +36,7 @@ def github_client(connection: str, **kwargs) -> Github:
     # PAT + webhook
     pat = os.getenv(f"{connection}__pat")
     if pat:
-        return Github(Auth.Token(pat), **kwargs)
+        return Github(auth=Auth.Token(pat), **kwargs)
 
     # GitHub App (JWT)
     app_id = os.getenv(f"{connection}__app_id")

--- a/tests/system/testdata/end2end/http.txtar
+++ b/tests/system/testdata/end2end/http.txtar
@@ -43,7 +43,7 @@ def on_http(data, trigger, event):
     "state": {
         "completed": {
             "prints": [
-                "data(body = {\"form\": None, \"bytes\": None, \"json\": None}, headers = {\"Accept-Encoding\": \"gzip\", \"User-Agent\": \"Go-http-client/1.1\"}, method = \"GET\", raw_url = \"/webhooks/00000000000000000000000004/\", url = {\"fragment\": \"\", \"raw_path\": \"\", \"query\": {}, \"raw_fragment\": \"\", \"raw_query\": \"\", \"path\": \"/webhooks/00000000000000000000000004/\"})",
+                "data(body = {\"form\": None, \"bytes\": None, \"json\": None}, headers = {\"Accept-Encoding\": \"gzip\", \"User-Agent\": \"Go-http-client/1.1\"}, method = \"GET\", raw_url = \"/webhooks/00000000000000000000000004/\", trailers = {}, url = {\"fragment\": \"\", \"raw_path\": \"\", \"query\": {}, \"raw_fragment\": \"\", \"raw_query\": \"\", \"path\": \"/webhooks/00000000000000000000000004/\"})",
                 "get",
                 "trigger(name = \"http\")"
             ],

--- a/tests/system/testdata/end2end/http.txtar
+++ b/tests/system/testdata/end2end/http.txtar
@@ -81,7 +81,7 @@ def on_http(data, trigger, event):
     "state": {
         "completed": {
             "prints": [
-                "data(body = {\"form\": None, \"bytes\": None, \"json\": None}, headers = {\"Accept-Encoding\": \"gzip\", \"User-Agent\": \"Go-http-client/1.1\", \"Content-Length\": \"0\"}, method = \"POST\", raw_url = \"/webhooks/00000000000000000000000004/test/aaa/bbb/ccc\", url = {\"fragment\": \"\", \"raw_path\": \"\", \"query\": {}, \"raw_fragment\": \"\", \"raw_query\": \"\", \"path\": \"/webhooks/00000000000000000000000004/test/aaa/bbb/ccc\"})",
+                "data(body = {\"form\": None, \"bytes\": None, \"json\": None}, headers = {\"Accept-Encoding\": \"gzip\", \"User-Agent\": \"Go-http-client/1.1\", \"Content-Length\": \"0\"}, method = \"POST\", raw_url = \"/webhooks/00000000000000000000000004/test/aaa/bbb/ccc\", trailers = {}, url = {\"fragment\": \"\", \"raw_path\": \"\", \"query\": {}, \"raw_fragment\": \"\", \"raw_query\": \"\", \"path\": \"/webhooks/00000000000000000000000004/test/aaa/bbb/ccc\"})",
                 "post",
                 "trigger(name = \"http\")"
             ],


### PR DESCRIPTION
Also fixing system test breakage from #778 by removing non-deterministic and unnecessary additions to the webhook event

Refs: ENG-1709