### PR TITLE
feat: acceptance test for basic usability of integrations

### DIFF
--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -1,0 +1,42 @@
+# Acceptance Test Project
+
+This AutoKitteh project is used as a testing tool for:
+
+- Acceptance of new cloud environments
+- Connection auth types, UIs, and flows
+- Python runtime issues involving connections
+
+It is meant to be simpler and quicker than running all the projects in
+[Kittehub](https://github.com/autokitteh/kittehub/):
+
+- Single project deployment
+- Simple but comprehensive triggers
+- Trivial API calls without runtime-dependent input or logic
+
+In other words, running this project successfully is a prerequisite for testing
+all the projects in [Kittehub](https://github.com/autokitteh/kittehub/).
+
+## Expected Connection Types and Names
+
+See the `connections` section in the [autokitteh.yaml](./autokitteh.yaml)
+file.
+
+## Connection Auth Types
+
+For each connection, configure and re-run this project with all available auth
+types.
+
+Reminder: once a connection's auth type is set it can't be changed, so you'll
+have to delete and recreate each connection in order to test all of its auth
+types.
+
+## Supported Trigger Events
+
+See the `triggers` section in the [autokitteh.yaml](./autokitteh.yaml) file.
+
+Note tha all entry-point handler functions print the received event, but they
+don't use the event's data payload.
+
+## API Calls as Manual Runs
+
+See the [api_calls.py](./api_calls.py) file.

--- a/tests/acceptance/api_calls.py
+++ b/tests/acceptance/api_calls.py
@@ -1,0 +1,62 @@
+"""See https://autokitteh.readthedocs.io/en/latest/"""
+
+import os
+
+from autokitteh.github import github_client
+from autokitteh.google import gmail_client
+from autokitteh.google import google_calendar_client
+from autokitteh.google import google_forms_client
+from autokitteh.slack import slack_client
+
+import print
+
+
+def all(event):
+    github_get_repo("GitHub repo", event)
+    gmail_get_profile(event)
+    google_calendar_list(event)
+    google_forms_get(event)
+    slack_auth_test(event)
+
+
+def github_get_repo(_):
+    github = github_client("github_conn")
+    repo = github.get_repo("autokitteh/autokitteh")
+    print("GitHub:", repo)
+
+
+def gmail_get_profile(_):
+    gmail = gmail_client("gmail_conn").users()
+    profile = gmail.getProfile(userId="me").execute()
+    print.pretty_json("Gmail profile", profile)
+
+
+def google_calendar_list(_):
+    calendar_id = os.getenv("calendar_conn__CalendarID")
+    if not calendar_id:
+        print("No Google Calendar is being watched")
+    else:
+        print("Watched Google Calendar ID:", calendar_id)
+
+    gcal = google_calendar_client("calendar_conn")
+    req = gcal.calendarList().list()
+    while req:
+        resp = req.execute()
+        for item in resp["items"]:
+            print.pretty_json("Google Calendar", item)
+        req = gcal.calendarList().list_next(req, resp)
+
+
+def google_forms_get(_):
+    form_id = os.getenv("forms_conn__FormID")
+    if not form_id:
+        print("No Google Form is being watched, can't make API call!")
+    else:
+        forms = google_forms_client("forms_conn").forms()
+        form = forms.get(formId=form_id).execute()
+        print.pretty_json("Google Form", form)
+
+
+def slack_auth_test(_):
+    slack = slack_client("slack_conn")
+    print.pretty_json("Slack auth", slack.auth_test().data)

--- a/tests/acceptance/autokitteh.yaml
+++ b/tests/acceptance/autokitteh.yaml
@@ -1,0 +1,27 @@
+version: v1
+
+project:
+  name: integration_tests
+  connections:
+    - name: github_conn
+      integration: github
+    - name: gmail_conn
+      integration: gmail
+    - name: calendar_conn
+      integration: googlecalendar
+    - name: forms_conn
+      integration: googleforms
+    - name: slack_conn
+      integration: slack
+  triggers:
+    - name: github_issue_comment
+      connection: github_conn
+      event_type: issue_comment
+      call: events.py:on_github_issue_comment
+    - name: http_request
+      type: webhook
+      call: events.py:on_http_request
+    - name: slack_message
+      connection: slack_conn
+      event_type: message
+      call: events.py:on_slack_message

--- a/tests/acceptance/events.py
+++ b/tests/acceptance/events.py
@@ -1,0 +1,27 @@
+"""See https://docs.autokitteh.com/develop/events/types"""
+
+import api_calls
+import print
+
+
+def on_http_request(event):
+    """To trigger this function, run this command:
+    curl -i "http[s]://autokitteh-address/webhooks/trigger-slug"
+    """
+    print.pretty_json("HTTP trigger event", event)
+
+
+def on_github_issue_comment(event):
+    """To trigger this function, add/edit/delete a comment on a GitHub
+    issue in a repository that the AutoKitteh app has been installed in.
+    """
+    print.pretty_json("GitHub issue comment event", event)
+    api_calls.github_get_repo(event)
+
+
+def on_slack_message(event):
+    """To trigger this function, post a message in your Slack DM with the
+    AutoKitteh app, or a private/public channel that it has been added to.
+    """
+    print.pretty_json("Slack message event", event)
+    api_calls.slack_auth_test(event)

--- a/tests/acceptance/print.py
+++ b/tests/acceptance/print.py
@@ -1,0 +1,5 @@
+import json
+
+
+def pretty_json(label, data):
+    print(label + ":\n" + json.dumps(data, indent=2))


### PR DESCRIPTION
This can be used for acceptance tests for new environments and auth types, verification of connection UIs and flows, misc Python bug reproductions, etc.

It is meant to be simpler and quicker than running all the samples one after the other - a single deployment, trivial API calls without runtime parameters, and no extra logic in triggers. In other words, is checks that the rest of the projects are ready to be tested.

It's not meant to offer the same functionality coverage or educational value as other projects in this repo.

FYI, some functionalities are currently broken in the cloud platform, but are working in on-prem servers (e.g. #774 and #779 not deployed in prod, and ENG-1680).