### PR TITLE
refactor: IsRetryableError

### DIFF
--- a/internal/backend/sessions/sessionworkflows/workflows.go
+++ b/internal/backend/sessions/sessionworkflows/workflows.go
@@ -240,7 +240,7 @@ func (ws *workflows) sessionWorkflow(wctx workflow.Context, params *sessionWorkf
 				err = nil
 			} else {
 				l.Sugar().Errorf("session workflow error: %v", err)
-				if errors.As(err, &sdkerrors.RetryableErrorType) {
+				if sdkerrors.IsRetryableError(err) {
 					sessionsRetryErrorsCounter.Add(metricsCtx, 1)
 					l.Panic("panic session to retry")
 				}

--- a/sdk/sdkerrors/errors.go
+++ b/sdk/sdkerrors/errors.go
@@ -44,12 +44,15 @@ type RetryableError struct {
 	Err     error
 }
 
-var RetryableErrorType *RetryableError
-
 func (e *RetryableError) Error() string { return fmt.Sprintf("%s: %v", e.Message, e.Err) }
 func (e *RetryableError) Unwrap() error { return e.Err }
 func NewRetryableError(f string, vs ...any) error {
 	return &RetryableError{Err: fmt.Errorf(f, vs...)}
+}
+
+func IsRetryableError(err error) bool {
+	var r *RetryableError
+	return errors.As(err, &r)
 }
 
 type ErrInvalidArgument struct {


### PR DESCRIPTION
simple fix to not reuse a global var. in prep for https://linear.app/autokitteh/issue/ENG-1721/review-activities-and-use-temporalnewnonretryableapplicationerror