### PR TITLE
fix: race condition in python rt print

### DIFF
--- a/runtimes/pythonrt/pythonrt_test.go
+++ b/runtimes/pythonrt/pythonrt_test.go
@@ -203,6 +203,7 @@ func Test_pySvc_Run(t *testing.T) {
 
 	ctx, cancel := testCtx(t)
 	defer cancel()
+
 	runID := sdktypes.NewRunID()
 	mainPath := "simple.py"
 	compiled := map[string][]byte{


### PR DESCRIPTION
simplified mechanism, no need for additional accumulator for print and logs. just using a larger buffered channel without checking the done channel.

couldn't test it yet, ran into some trouble. @efiShtain if you can test it out that'll be great. if not I'll do it tomorrow.