### PR TITLE
fix: properly classify activity errors

### DIFF
--- a/internal/backend/dispatcher/activities.go
+++ b/internal/backend/dispatcher/activities.go
@@ -11,6 +11,7 @@ import (
 	"go.temporal.io/sdk/worker"
 
 	akCtx "go.autokitteh.dev/autokitteh/internal/backend/context"
+	"go.autokitteh.dev/autokitteh/internal/backend/temporalclient"
 	"go.autokitteh.dev/autokitteh/internal/backend/types"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
@@ -27,22 +28,22 @@ const (
 
 func (d *Dispatcher) registerActivities(w worker.Worker) {
 	w.RegisterActivityWithOptions(
-		d.getEventSessionData,
+		d.getEventSessionDataActivity,
 		activity.RegisterOptions{Name: getEventSessionDataActivityName},
 	)
 
 	w.RegisterActivityWithOptions(
-		d.startSession,
+		d.startSessionActivity,
 		activity.RegisterOptions{Name: startSessionActivityName},
 	)
 
 	w.RegisterActivityWithOptions(
-		d.listWaitingSignals,
+		d.listWaitingSignalsActivity,
 		activity.RegisterOptions{Name: listWaitingSignalsActivityName},
 	)
 
 	w.RegisterActivityWithOptions(
-		d.signalWorkflow,
+		d.signalWorkflowActivity,
 		activity.RegisterOptions{Name: signalWorkflowActivityName},
 	)
 }
@@ -54,18 +55,20 @@ type sessionData struct {
 	Connection   sdktypes.Connection
 }
 
-func (d *Dispatcher) listWaitingSignals(ctx context.Context, dstid sdktypes.EventDestinationID) ([]*types.Signal, error) {
-	return d.svcs.DB.ListWaitingSignals(ctx, dstid)
+func (d *Dispatcher) listWaitingSignalsActivity(ctx context.Context, dstid sdktypes.EventDestinationID) ([]*types.Signal, error) {
+	sigs, err := d.svcs.DB.ListWaitingSignals(ctx, dstid)
+	return sigs, temporalclient.TranslateError(err, "list waiting signals for %v", dstid)
 }
 
-func (d *Dispatcher) startSession(ctx context.Context, session sdktypes.Session) (sdktypes.SessionID, error) {
+func (d *Dispatcher) startSessionActivity(ctx context.Context, session sdktypes.Session) (sdktypes.SessionID, error) {
 	ctx = akCtx.WithRequestOrginator(ctx, akCtx.Dispatcher)
 	ctx = akCtx.WithOwnershipOf(ctx, d.svcs.DB.GetOwnership, session.EnvID().UUIDValue())
 
-	return d.svcs.Sessions.Start(ctx, session)
+	sid, err := d.svcs.Sessions.Start(ctx, session)
+	return sid, temporalclient.TranslateError(err, "start session %v", session.ID())
 }
 
-func (d *Dispatcher) getEventSessionData(ctx context.Context, event sdktypes.Event, opts *sdkservices.DispatchOptions) ([]sessionData, error) {
+func (d *Dispatcher) getEventSessionDataActivity(ctx context.Context, event sdktypes.Event, opts *sdkservices.DispatchOptions) ([]sessionData, error) {
 	ctx = akCtx.WithRequestOrginator(ctx, akCtx.EventWorkflow)
 	ctx = akCtx.WithOwnershipOf(ctx, d.svcs.DB.GetOwnership, event.DestinationID().UUIDValue())
 
@@ -102,14 +105,14 @@ func (d *Dispatcher) getEventSessionData(ctx context.Context, event sdktypes.Eve
 
 	if cid := dstid.ToConnectionID(); cid.IsValid() {
 		if ts, err = d.svcs.Triggers.List(ctx, sdkservices.ListTriggersFilter{ConnectionID: cid}); err != nil {
-			return nil, fmt.Errorf("list triggers: %w", err)
+			return nil, temporalclient.TranslateError(err, "list triggers for %v", cid)
 		}
 
 		sl.Infof("found %d triggers for connection %v", len(ts), cid)
 	} else if tid := dstid.ToTriggerID(); tid.IsValid() {
 		t, err := d.svcs.Triggers.Get(ctx, tid)
 		if err != nil {
-			return nil, fmt.Errorf("get trigger: %w", err)
+			return nil, temporalclient.TranslateError(err, "get trigger %v", tid)
 		}
 
 		ts = append(ts, t)
@@ -159,7 +162,7 @@ func (d *Dispatcher) getEventSessionData(ctx context.Context, event sdktypes.Eve
 		if !found {
 			activeDeployments, err := d.svcs.Deployments.List(ctx, sdkservices.ListDeploymentsFilter{State: sdktypes.DeploymentStateActive, EnvID: envID})
 			if err != nil {
-				sl.With("err", err).Errorf("could not fetch active deployments: %v", err)
+				return nil, temporalclient.TranslateError(err, "list active deployments for %v", envID)
 			}
 
 			var testingDeployments []sdktypes.Deployment
@@ -167,7 +170,7 @@ func (d *Dispatcher) getEventSessionData(ctx context.Context, event sdktypes.Eve
 			if optsEnvID.IsValid() || opts.DeploymentID.IsValid() {
 				testingDeployments, err = d.svcs.Deployments.List(ctx, sdkservices.ListDeploymentsFilter{State: sdktypes.DeploymentStateTesting, EnvID: envID})
 				if err != nil {
-					sl.With("err", err).Errorf("could not fetch testing deployments: %v", err)
+					return nil, temporalclient.TranslateError(err, "list testing deployments for %v", envID)
 				}
 			}
 
@@ -210,7 +213,7 @@ func (d *Dispatcher) getEventSessionData(ctx context.Context, event sdktypes.Eve
 	return sds, nil
 }
 
-func (d *Dispatcher) signalWorkflow(ctx context.Context, wid string, sigid uuid.UUID, eid sdktypes.EventID) error {
+func (d *Dispatcher) signalWorkflowActivity(ctx context.Context, wid string, sigid uuid.UUID, eid sdktypes.EventID) error {
 	sl := d.sl.With("workflow_id", wid, "signal_id", sigid, "event_id", eid)
 
 	if err := d.svcs.LazyTemporalClient().SignalWorkflow(ctx, wid, "", sigid.String(), eid); err != nil {
@@ -220,7 +223,7 @@ func (d *Dispatcher) signalWorkflow(ctx context.Context, wid string, sigid uuid.
 
 			if err := d.svcs.DB.RemoveSignal(ctx, sigid); err != nil {
 				sl.With("err", err).Error("db remove signal %v: %w", sigid, err)
-				return err
+				return temporalclient.TranslateError(err, "remove signal %v", sigid)
 			}
 
 			// might be some race condition after workflow was done, not really an error.
@@ -229,7 +232,7 @@ func (d *Dispatcher) signalWorkflow(ctx context.Context, wid string, sigid uuid.
 
 		sl.With("err", err).Errorf("signal workflow %v for %v: %v", wid, sigid, err)
 
-		return err
+		return temporalclient.TranslateError(err, "signal workflow %v for %v", wid, sigid)
 	}
 
 	return nil

--- a/internal/backend/scheduler/scheduler.go
+++ b/internal/backend/scheduler/scheduler.go
@@ -133,7 +133,7 @@ func (sch *Scheduler) activity(ctx context.Context, tid sdktypes.TriggerID) erro
 	t, err := sch.triggers.Get(ctx, tid)
 	if err != nil {
 		if !errors.Is(err, sdkerrors.ErrNotFound) {
-			return fmt.Errorf("get trigger: %w", err)
+			return temporalclient.TranslateError(err, "get trigger %v", tid)
 		}
 	}
 
@@ -141,7 +141,7 @@ func (sch *Scheduler) activity(ctx context.Context, tid sdktypes.TriggerID) erro
 		sl.Warnf("trigger %v not found, removing schedule", tid)
 
 		if err := sch.Delete(ctx, tid); err != nil {
-			return fmt.Errorf("delete schedule: %w", err)
+			return temporalclient.TranslateError(err, "delete schedule for %v", tid)
 		}
 
 		return nil
@@ -149,7 +149,7 @@ func (sch *Scheduler) activity(ctx context.Context, tid sdktypes.TriggerID) erro
 
 	eid, err := sch.dispatcher.Dispatch(ctx, sdktypes.NewEvent(tid).WithType("tick"), nil)
 	if err != nil {
-		return fmt.Errorf("dispatch event: %w", err)
+		return temporalclient.TranslateError(err, "dispatch event for %v", tid)
 	}
 
 	sl.With("event_id", eid).Infof("schedule event workflow for %v dispatched as %v", tid, eid)

--- a/internal/backend/sessions/sessionworkflows/modules/testtools/testtools.go
+++ b/internal/backend/sessions/sessionworkflows/modules/testtools/testtools.go
@@ -11,6 +11,7 @@ import (
 
 	"go.autokitteh.dev/autokitteh/internal/backend/fixtures"
 	"go.autokitteh.dev/autokitteh/internal/backend/sessions/sessioncontext"
+	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdkexecutor"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
@@ -23,7 +24,7 @@ var (
 	errTestSoft = errors.New("soft test error")
 
 	// A hard eror is intended to be a simulated infrastructure error to trigger a retry.
-	ErrTestHard = errors.New("hard test error")
+	ErrTestHard = sdkerrors.NewRetryableErrorf("hard test error")
 )
 
 func New() sdkexecutor.Executor {

--- a/internal/backend/temporalclient/errors.go
+++ b/internal/backend/temporalclient/errors.go
@@ -1,0 +1,24 @@
+package temporalclient
+
+import (
+	"fmt"
+
+	"go.temporal.io/sdk/temporal"
+
+	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
+)
+
+func TranslateError(err error, f string, args ...any) error {
+	if err == nil {
+		return nil
+	}
+
+	return temporal.NewApplicationErrorWithOptions(
+		fmt.Sprintf(f, args...),
+		sdkerrors.ErrorType(err),
+		temporal.ApplicationErrorOptions{
+			NonRetryable: !sdkerrors.IsRetryableError(err),
+			Cause:        err,
+		},
+	)
+}

--- a/runtimes/pythonrt/pythonrt.go
+++ b/runtimes/pythonrt/pythonrt.go
@@ -463,7 +463,7 @@ func (py *pySvc) initialCall(ctx context.Context, funcName string, args []sdktyp
 		select {
 		case healthErr := <-runnerHealthChan:
 			if healthErr != nil {
-				return sdktypes.InvalidValue, sdkerrors.NewRetryableError("runner health: %w", healthErr)
+				return sdktypes.InvalidValue, sdkerrors.NewRetryableErrorf("runner health: %w", healthErr)
 			}
 		case r := <-py.channels.log:
 			py.log.Log(pyLevelToZap(r.level), r.message)

--- a/sdk/internal/rpcerrors/errors.go
+++ b/sdk/internal/rpcerrors/errors.go
@@ -45,7 +45,7 @@ func ToSDKError(err error) error {
 	case connect.CodeUnknown: // returned as connect.Error, but unrelated to RPC, just unwrap underlying error
 		return connectErr.Unwrap()
 	default:
-		sdkErr = sdkerrors.ErrRPC
+		sdkErr = fmt.Errorf("unknown connect error: %w", connectErr)
 	}
 
 	// err is a connect error (checked in connect.CodeOf), so we can safely cast it

--- a/sdk/sdkclients/internal/validate.go
+++ b/sdk/sdkclients/internal/validate.go
@@ -1,8 +1,6 @@
 package internal
 
 import (
-	"fmt"
-
 	"google.golang.org/protobuf/proto"
 
 	akproto "go.autokitteh.dev/autokitteh/proto"
@@ -12,7 +10,7 @@ import (
 
 func Validate(pb proto.Message) error {
 	if err := akproto.Validate(pb); err != nil {
-		return fmt.Errorf("%w: invalid rpc response: %v", sdkerrors.ErrRPC, err)
+		return sdkerrors.NewInvalidArgumentError("invalid proto message: %v", err)
 	}
 
 	return nil

--- a/sdk/sdkerrors/errors_test.go
+++ b/sdk/sdkerrors/errors_test.go
@@ -1,6 +1,7 @@
 package sdkerrors
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,5 +16,23 @@ func TestIgnoreNotFoundErr(t *testing.T) {
 	x, err = IgnoreNotFoundErr[int](1, ErrConflict)
 	if assert.Equal(t, err, ErrConflict) {
 		assert.Zero(t, x)
+	}
+}
+
+func TestErrorType(t *testing.T) {
+	tests := []struct {
+		err error
+		typ string
+	}{
+		{ErrNotFound, "not_found"},
+		{NewRetryableError(ErrNotFound), "retryable_not_found"},
+		{NewInvalidArgumentError("meow"), "invalid_argument"},
+		{errors.New("woof"), "unknown"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.typ, func(t *testing.T) {
+			assert.Equal(t, ErrorType(test.err), test.typ)
+		})
 	}
 }

--- a/sdk/sdktypes/program_error.go
+++ b/sdk/sdktypes/program_error.go
@@ -7,6 +7,7 @@ import (
 
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	programv1 "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/program/v1"
+	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdklogger"
 )
 
@@ -94,6 +95,11 @@ func WrapError(err error) ProgramError {
 }
 
 type programError ProgramError
+
+var _ error = programError{}
+
+// This allows `errors.Is(err, sdkerrors.ErrProgram)“ to work.
+func (e programError) Unwrap() error { return sdkerrors.ErrProgram }
 
 func (e programError) Error() string {
 	if !e.IsValid() {

--- a/sdk/sdktypes/program_error_test.go
+++ b/sdk/sdktypes/program_error_test.go
@@ -1,0 +1,21 @@
+package sdktypes
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
+)
+
+func TestIsProgramError(t *testing.T) {
+	var p programError
+
+	if !errors.Is(p, sdkerrors.ErrProgram) {
+		t.Errorf("expected true, got false")
+	}
+
+	if !errors.Is(fmt.Errorf("meow %w", p), sdkerrors.ErrProgram) {
+		t.Errorf("expected true, got false")
+	}
+}


### PR DESCRIPTION
this enables as to discern between retryable and not retryable activity errors. it is probable that not all our methods return proper errors, so we'll have to treat these when we bump into them.

this also makes the error display in temporal more understandable.