### PR TITLE
fix(python): improve type error message

### DIFF
--- a/runtimes/pythonrt/runner/syscalls.py
+++ b/runtimes/pythonrt/runner/syscalls.py
@@ -119,7 +119,7 @@ class SysCalls:
                 req.timeout_ms = int(timeout.total_seconds() * 1000)
             else:
                 raise TypeError(
-                    f"invalid timeout {timeout!r}, expecting timedelta or number of seconds"
+                    f"timeout {timeout!r} should be a timedelta or number of seconds"
                 )
 
         resp = call_grpc("next_event", self.worker.NextEvent, req)

--- a/runtimes/pythonrt/runner/syscalls.py
+++ b/runtimes/pythonrt/runner/syscalls.py
@@ -113,12 +113,14 @@ class SysCalls:
 
         req = pb.NextEventRequest(runner_id=self.runner_id, signal_ids=ids)
         if timeout:
-            if isinstance(timeout, float) or isinstance(timeout, int):
+            if isinstance(timeout, int, float):
                 req.timeout_ms = int(timeout * 1000)
             elif isinstance(timeout, timedelta):
                 req.timeout_ms = int(timeout.total_seconds() * 1000)
             else:
-                raise TypeError(f"timeout should be timedelta or int, got {timeout!r}")
+                raise TypeError(
+                    f"invalid timeout {timeout!r}, expecting timedelta or number of seconds"
+                )
 
         resp = call_grpc("next_event", self.worker.NextEvent, req)
 


### PR DESCRIPTION
We allow timeouts to be floats too, since #815.
Also, simplify `isinstance` check.