### PR TITLE
feat(cmd): add verify filter command

### DIFF
--- a/cmd/ak/cmd/events/event.go
+++ b/cmd/ak/cmd/events/event.go
@@ -38,6 +38,7 @@ func init() {
 	eventCmd.AddCommand(listCmd)
 	eventCmd.AddCommand(redispatchCmd)
 	eventCmd.AddCommand(saveCmd)
+	eventCmd.AddCommand(verifyCmd)
 }
 
 func events() sdkservices.Events {

--- a/cmd/ak/cmd/events/verify.go
+++ b/cmd/ak/cmd/events/verify.go
@@ -1,0 +1,24 @@
+package events
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.autokitteh.dev/autokitteh/cmd/ak/common"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+var verifyCmd = common.StandardCommand(&cobra.Command{
+	Use:     "verify-filter <filter_expression>",
+	Short:   "Verify if a CEL filter expression is valid",
+	Args:    cobra.ExactArgs(1),
+	Aliases: []string{"vf"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		filter := args[0]
+		if err := sdktypes.VerifyEventFilter(filter); err != nil {
+			return fmt.Errorf("verify filter: %w", err)
+		}
+		common.RenderKV("result", "filter expression is valid")
+		return nil
+	},
+})


### PR DESCRIPTION
There have been times when I’ve been unsure whether a filter I’m using is correct, and this command provides a quick and reliable way to verify it, especially since the logic was already in place.