### PR TITLE
fix(sdk): wrong types in type checks

### DIFF
--- a/sdk/sdktypes/event_destination_id.go
+++ b/sdk/sdktypes/event_destination_id.go
@@ -48,7 +48,7 @@ func (e EventDestinationID) ToTriggerID() TriggerID {
 	return id
 }
 
-func (e EventDestinationID) IsConnectionID() bool { return e.Kind() == envIDKind }
-func (e EventDestinationID) IsTriggerID() bool    { return e.Kind() == connectionIDKind }
+func (e EventDestinationID) IsConnectionID() bool { return e.Kind() == connectionIDKind }
+func (e EventDestinationID) IsTriggerID() bool    { return e.Kind() == triggerIDKind }
 
 func (e EventDestinationID) AsID() ID { return e }

--- a/sdk/sdktypes/event_destination_id_test.go
+++ b/sdk/sdktypes/event_destination_id_test.go
@@ -1,0 +1,44 @@
+package sdktypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventDestinationID(t *testing.T) {
+	tests := []struct {
+		typeID         string
+		wantConnection bool
+		wantTrigger    bool
+	}{
+		{
+			typeID:         "con_01jbw762gzfe4vbv30zvf6f4cj",
+			wantConnection: true,
+		},
+		{
+			typeID:      "trg_01jbw762h5f8mvte837j1qqtfr",
+			wantTrigger: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.typeID, func(t *testing.T) {
+			id, err := ParseEventDestinationID(tt.typeID)
+			assert.NoError(t, err)
+
+			if tt.wantConnection {
+				assert.True(t, id.IsConnectionID())
+			} else {
+				assert.False(t, id.IsConnectionID())
+			}
+
+			if tt.wantTrigger {
+				assert.True(t, id.IsTriggerID())
+			} else {
+				assert.False(t, id.IsTriggerID())
+			}
+
+			assert.Equal(t, tt.typeID, id.String())
+		})
+	}
+}


### PR DESCRIPTION
It looks like the fix is also in #832, but this PR is focused only on the fix, and adds a new unit test too.