### PR TITLE
feat: add webui to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,12 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 # Leverage a bind mount to the current directory to avoid having to copy the
 # source code into the container.
 RUN --mount=type=cache,target=/go/pkg/mod/ \
-    --mount=type=bind,target=. \
+    --mount=type=bind,target=.,rw \
     <<EOF
     export VERSION_PKG_PATH="go.autokitteh.dev/autokitteh/internal/version"
     export TIMESTAMP="$(date -u "+%Y-%m-%dT%H:%MZ")"
     export LDFLAGS="-X "${VERSION_PKG_PATH}.Version=$(cat .version || echo)" -X "${VERSION_PKG_PATH}.Time=${TIMESTAMP}" -X "${VERSION_PKG_PATH}.Commit=$(cat .commit || echo)""
+    make webplatform
     CGO_ENABLED=0 go build -o /bin/ak -ldflags="${LDFLAGS}" ./cmd/ak
 EOF
 

--- a/internal/backend/webplatform/webplatform.go
+++ b/internal/backend/webplatform/webplatform.go
@@ -65,7 +65,7 @@ func (w *Svc) Start(context.Context) error {
 	fsrv := http.FileServer(http.FS(webfs))
 
 	srv := &http.Server{
-		Addr: fmt.Sprintf("localhost:%d", w.Config.Port),
+		Addr: fmt.Sprintf("0.0.0.0:%d", w.Config.Port),
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// If path actually exists in fs, serve it.
 			if f, _ := webfs.Open(strings.TrimPrefix(r.URL.Path, "/")); f != nil {


### PR DESCRIPTION
Although I don't like adding more stuff to the main image, it is currently the simplest way to expose the UI in containers

future version would remove web ui and python and include go based code only as part of isolation and moving to build farm and remote runners