### PR TITLE
fix(ENG-1773): allow to disable login redir

### DIFF
--- a/internal/backend/auth/authloginhttpsvc/svc.go
+++ b/internal/backend/auth/authloginhttpsvc/svc.go
@@ -229,6 +229,11 @@ func (a *svc) newSuccessLoginHandler(ld *loginData) http.Handler {
 			return
 		}
 
+		if noredir, _ := strconv.ParseBool(r.URL.Query().Get("noredir")); noredir {
+			fmt.Fprint(w, "login successful")
+			return
+		}
+
 		http.Redirect(w, r, getRedirect(r), http.StatusFound)
 	}
 


### PR DESCRIPTION
if requester specifies `?noredir=1`, instead of redirect on successful login, it will just return 200.