### PR TITLE
fix: switch ownerships to UUID userid

### DIFF
--- a/internal/backend/db/dbgorm/ownership.go
+++ b/internal/backend/db/dbgorm/ownership.go
@@ -23,6 +23,7 @@ func (gdb *gormdb) GetOwnership(ctx context.Context, entityID sdktypes.UUID) (sd
 
 	uid, err := sdktypes.NewIDFromUUIDString[sdktypes.UserID](o.UserID)
 	if err != nil {
+		// TODO: remove this second parse once we upgrade all users to new format
 		uid, err = sdktypes.ParseUserID(o.UserID)
 		if err != nil {
 			return sdktypes.InvalidUser, err

--- a/internal/backend/db/dbgorm/values.go
+++ b/internal/backend/db/dbgorm/values.go
@@ -25,7 +25,7 @@ func (db *gormdb) SetValue(ctx context.Context, pid sdktypes.ProjectID, key stri
 		return sdkerrors.NewInvalidArgumentError("value too large > %d bytes", maxValueSize)
 	}
 
-	uid := authcontext.GetAuthnUser(ctx).ID().String()
+	uid := authcontext.GetAuthnUser(ctx).ID().UUIDValue().String()
 
 	return translateError(db.transaction(ctx, func(tx *tx) error {
 		db := tx.db

--- a/internal/backend/db/dbgorm/vars.go
+++ b/internal/backend/db/dbgorm/vars.go
@@ -22,7 +22,7 @@ func (gdb *gormdb) withUserVars(ctx context.Context) *gorm.DB {
 func (gdb *gormdb) setVar(ctx context.Context, vr *scheme.Var) error {
 	vr.VarID = vr.ScopeID // just ensure
 
-	uid := authcontext.GetAuthnUser(ctx).ID().String()
+	uid := authcontext.GetAuthnUser(ctx).ID().UUIDValue().String()
 
 	return gdb.transaction(ctx, func(tx *tx) error {
 		db := tx.db

--- a/sdk/sdktypes/id.go
+++ b/sdk/sdktypes/id.go
@@ -111,6 +111,14 @@ func NewIDFromUUID[ID id[T], T idTraits](uuid *UUID) ID {
 	return ID(id[T]{tid: typeid.Must(typeid.FromUUIDBytes[typeid.TypeID[T]](uuid[:]))})
 }
 
+func NewIDFromUUIDString[ID id[T], T idTraits](str string) (ID, error) {
+	uuidUUID, err := uuid.Parse(str)
+	if err != nil {
+		return ID{}, err
+	}
+	return NewIDFromUUID[ID](&uuidUUID), nil
+}
+
 func ParseID[ID id[T], T idTraits](s string) (ID, error) {
 	var zero ID
 


### PR DESCRIPTION
this change will set uuid user id in ownerships table so we can join on it 
it is backward compatible until we update the ownerships table itself 
once updated we should remove the extra check 