### PR TITLE
feat: Add home-brew formula configuration for autokitteh

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,21 @@ builds:
       - amd64
       - arm64
 
+brews:
+  - name: autokitteh
+    description: "Durable workflow automation made simple"
+    homepage: "https://autokitteh.com"
+    url_template: "https://github.com/autokitteh/autokitteh/releases/download/{{ .Version }}/{{ .ArtifactName }}"
+    license: "Apache-2.0"
+    install: |
+      bin.install "ak"
+    test: |
+      system "#{bin}/ak --version"
+    repository:
+      owner: autokitteh
+      name: homebrew-tap
+      branch: main
+
 source:
   enabled: false
 


### PR DESCRIPTION
- Configured Homebrew formula in GoReleaser to update automatically with each release.
- Includes formula details, installation script, and test for the ak binary.
- Publishes to autokitteh/homebrew-tap on the main branch.

Refs: ENG-562