### PR TITLE
feat: Add Gemini connStatus function 

### DIFF
--- a/integrations/auth.go
+++ b/integrations/auth.go
@@ -10,5 +10,4 @@ const (
 	OAuth      = "oauth"
 	PAT        = "pat"
 	SocketMode = "socketMode" // Slack integration only
-	BotToken   = "botToken"   // Gemini integration only
 )

--- a/integrations/auth.go
+++ b/integrations/auth.go
@@ -10,4 +10,5 @@ const (
 	OAuth      = "oauth"
 	PAT        = "pat"
 	SocketMode = "socketMode" // Slack integration only
+	BotToken   = "botToken"   // Gemini integration only
 )

--- a/integrations/google/gemini/client.go
+++ b/integrations/google/gemini/client.go
@@ -67,7 +67,7 @@ func connStatus(i *integration) sdkintegrations.OptFn {
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		}
 
-		if at.Value() == integrations.BotToken {
+		if at.Value() == integrations.APIKey {
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Initialized"), nil
 		}
 		return sdktypes.NewStatus(sdktypes.StatusCodeError, "Bad auth type"), nil

--- a/integrations/google/internal/vars/vars.go
+++ b/integrations/google/internal/vars/vars.go
@@ -16,7 +16,7 @@ type Vars struct {
 }
 
 var (
-	AuthType = sdktypes.NewSymbol("authType")
+	AuthType = sdktypes.NewSymbol("auth_type")
 
 	OAuthData = sdktypes.NewSymbol("OAuthData")
 	JSON      = sdktypes.NewSymbol("JSON")


### PR DESCRIPTION
Added connStatus to Gemini, and return appropriate connection statuses like “Initialized” or “Init required.”
Also fixed AuthType symbol bug in vars.go 

refs: INT-82