### PR TITLE
ci: build image on every pr

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -91,6 +91,31 @@ jobs:
       - name: Session tests
         run: make bin/ak test-sessions
 
+  verify-docker-builds:
+    needs:
+      - static-analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.ref != 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup version info
+        run: |
+          # These are consumed in the Dockerfile.
+          echo "${GITHUB_REF#refs/tags/}" > .version
+          echo "${GITHUB_SHA}" > .commit
+      - name: Verify Image Builds
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64
+          tags: autokitteh:latest
+          push: false
+          provenance: false
+
   publish_docker_image:
     needs:
       - test-sessions

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -92,8 +92,6 @@ jobs:
         run: make bin/ak test-sessions
 
   verify-docker-builds:
-    needs:
-      - static-analysis
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: github.ref != 'refs/heads/main'


### PR DESCRIPTION
this makes docker builds an image on every pr
this is to solve the case where we merge to main
and only then we discover that the docker build step is broken

it does not publish the image, only builds