### PR TITLE
fix(ENG-1910): change web-ui url display on start

### DIFF
--- a/internal/backend/webplatform/webplatform.go
+++ b/internal/backend/webplatform/webplatform.go
@@ -65,7 +65,7 @@ func (w *Svc) Start(context.Context) error {
 	fsrv := http.FileServer(http.FS(webfs))
 
 	srv := &http.Server{
-		Addr: fmt.Sprintf("0.0.0.0:%d", w.Config.Port),
+		Addr: fmt.Sprintf("http://localhost:%d", w.Config.Port),
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// If path actually exists in fs, serve it.
 			if f, _ := webfs.Open(strings.TrimPrefix(r.URL.Path, "/")); f != nil {

--- a/internal/backend/webplatform/webplatform.go
+++ b/internal/backend/webplatform/webplatform.go
@@ -65,7 +65,7 @@ func (w *Svc) Start(context.Context) error {
 	fsrv := http.FileServer(http.FS(webfs))
 
 	srv := &http.Server{
-		Addr: fmt.Sprintf("http://localhost:%d", w.Config.Port),
+		Addr: fmt.Sprintf("localhost:%d", w.Config.Port),
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// If path actually exists in fs, serve it.
 			if f, _ := webfs.Open(strings.TrimPrefix(r.URL.Path, "/")); f != nil {


### PR DESCRIPTION
"Locally-delivered resources such as those with http://127.0.0.1 URLs, http://localhost and http://*.localhost URLs (e.g. http://dev.whatever.localhost/), and file:// URLs are also considered to have been delivered securely."
(reference: https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts)

Since we display and run it on HTTP://0.0.0.0 it's not considered secured and we are loosing some functionalities.