### PR TITLE
chore: tweak log messages that don't work well in Datadog

### DIFF
--- a/internal/backend/dispatcher/dispatcher.go
+++ b/internal/backend/dispatcher/dispatcher.go
@@ -91,7 +91,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, event sdktypes.Event, opts *s
 		return sdktypes.InvalidEventID, fmt.Errorf("failed starting workflow: %w", err)
 	}
 
-	sl.Desugar().Info("started dispatcher workflow",
+	sl.Desugar().Info("started dispatcher workflow for event: "+eid.String(),
 		zap.Any("workflow_id", r.GetID()),
 		zap.Any("run_id", r.GetRunID()))
 

--- a/internal/backend/dispatcher/dispatcher.go
+++ b/internal/backend/dispatcher/dispatcher.go
@@ -65,7 +65,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, event sdktypes.Event, opts *s
 
 	sl := d.sl.With("event_id", eid)
 
-	sl.Infof("event %v saved", eid)
+	sl.Infof("event saved: %v", eid)
 
 	memo := map[string]string{
 		"event_id":         eid.String(),
@@ -91,7 +91,9 @@ func (d *Dispatcher) Dispatch(ctx context.Context, event sdktypes.Event, opts *s
 		return sdktypes.InvalidEventID, fmt.Errorf("failed starting workflow: %w", err)
 	}
 
-	sl.With("run", r).Infof("started dispatcher workflow %v for %v", r, eid)
+	sl.Desugar().Info("started dispatcher workflow",
+		zap.Any("workflow_id", r.GetID()),
+		zap.Any("run_id", r.GetRunID()))
 
 	return eid, nil
 }


### PR DESCRIPTION
Before (useless memory addresses):
```
started dispatcher workflow &{event evt_01jf7nqv1kfqxsfp7zaq77s6st 5cb3c7ce-24a0-4187-ad8b-af6951f4abcb 0xc001ca5200 0x3469aa0 0xc0027c90b0 0xc000bcbc80 0xc0011a63c0} for evt_01jf7nqv1kfqxsfp7zaq77s6st
```
After (cleaner message, workflow details are log attributes):
```
started dispatcher workflow for event: evt_01jf7nqv1kfqxsfp7zaq77s6st
```