### PR TITLE
fix(python): let runner install packages with git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ EOF
 # runtime dependencies for the application.
 FROM python:3.11-slim AS pydeps
 
-RUN apt update -y && apt install git -y
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /runner
 

--- a/runtimes/pythonrt/dockerfilenodeps
+++ b/runtimes/pythonrt/dockerfilenodeps
@@ -1,5 +1,7 @@
 FROM python:3.11-slim AS build
 
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /runner
 COPY pyproject.toml .
 RUN python -m pip install .[all]

--- a/runtimes/pythonrt/dockerfilewithdeps
+++ b/runtimes/pythonrt/dockerfilewithdeps
@@ -1,5 +1,7 @@
 FROM python:3.11-slim AS build
 
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /runner
 COPY pyproject.toml .
 RUN python -m pip install .[all]


### PR DESCRIPTION
AK runner's new Docker containers choked because `pyproject.toml` contains a package which is pinned to a specific git commit (to include our https://github.com/PyGithub/PyGithub/pull/3082):

https://github.com/autokitteh/autokitteh/blob/18c9e3f33432dadf3a96d38184d48e303cbe2ca0/runtimes/pythonrt/runner/pyproject.toml#L27

I added git to both of the runner's Dockerfiles, and also used the same command in the AK repo's main Dockerfile, because `apt-get` is more suited for automation than `apt`.