### PR TITLE
fix(python): disable I/O check due to conflict with HubSpot client

### DIFF
--- a/runtimes/pythonrt/runner/main.py
+++ b/runtimes/pythonrt/runner/main.py
@@ -192,9 +192,10 @@ class Runner(pb.runner_rpc.RunnerService):
         fix_http_body(event)
         event = AttrDict(event)
 
-        # Warn on I/O outside an activity. Should come after importing the user module
-        hook = make_audit_hook(ak_call, self.code_dir)
-        sys.addaudithook(hook)
+        # TODO(ENG-1893): Disabled temporarily due to issues with HubSpot client - need to investigate.
+        # # Warn on I/O outside an activity. Should come after importing the user module
+        # hook = make_audit_hook(ak_call, self.code_dir)
+        # sys.addaudithook(hook)
 
         self.executor.submit(self.on_event, fn, event)
 

--- a/runtimes/pythonrt/runner/main.py
+++ b/runtimes/pythonrt/runner/main.py
@@ -21,7 +21,8 @@ import loader
 import log
 import pb
 import values
-from audit import make_audit_hook
+
+# from audit import make_audit_hook  # TODO(ENG-1893): uncomment this.
 from autokitteh import AttrDict, connections
 from call import AKCall, full_func_name
 from syscalls import SysCalls


### PR DESCRIPTION
Commenting-out the usage of #870 due to an apparent conflict with the HubSpot client - getting a lot of warnings for calls that don't use files in any obvious way.

Need to investigate, resolve, and then uncomment.

Workflow snippet for example:

```
from autokitteh.hubspot import hubspot_client

hubspot = hubspot_client("hubspot_conn")

def on_trigger(event):
    print(hubspot.crm.contacts.basic_api.get_page(limit=10))
```

Refs: ENG-1893