### PR TITLE
fix(integrations): require "custom oauth" for each connection due to Auth0 domain restrictions

### DIFF
--- a/integrations/auth0/client.go
+++ b/integrations/auth0/client.go
@@ -14,11 +14,11 @@ import (
 type integration struct{ vars sdkservices.Vars }
 
 var (
-	authType      = sdktypes.NewSymbol("auth_type")
-	clientIDName  = sdktypes.NewSymbol("client_id")
+	authType         = sdktypes.NewSymbol("auth_type")
+	clientIDName     = sdktypes.NewSymbol("client_id")
 	clientSecretName = sdktypes.NewSymbol("client_secret")
-	domainName        = sdktypes.NewSymbol("auth0_domain")
-	integrationID = sdktypes.NewIntegrationIDFromName("auth0")
+	domainName       = sdktypes.NewSymbol("auth0_domain")
+	integrationID    = sdktypes.NewIntegrationIDFromName("auth0")
 )
 
 var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{

--- a/integrations/auth0/client.go
+++ b/integrations/auth0/client.go
@@ -14,7 +14,7 @@ import (
 type integration struct{ vars sdkservices.Vars }
 
 var (
-	integrationID    = sdktypes.NewIntegrationIDFromName("auth0")
+	integrationID = sdktypes.NewIntegrationIDFromName("auth0")
 
 	authType         = sdktypes.NewSymbol("auth_type")
 	clientIDName     = sdktypes.NewSymbol("client_id")

--- a/integrations/auth0/client.go
+++ b/integrations/auth0/client.go
@@ -15,7 +15,9 @@ type integration struct{ vars sdkservices.Vars }
 
 var (
 	authType      = sdktypes.NewSymbol("auth_type")
-	domain        = sdktypes.NewSymbol("domain")
+	clientIDName  = sdktypes.NewSymbol("client_id")
+	clientSecretName = sdktypes.NewSymbol("client_secret")
+	domainName        = sdktypes.NewSymbol("auth0_domain")
 	integrationID = sdktypes.NewIntegrationIDFromName("auth0")
 )
 

--- a/integrations/auth0/client.go
+++ b/integrations/auth0/client.go
@@ -14,11 +14,12 @@ import (
 type integration struct{ vars sdkservices.Vars }
 
 var (
+	integrationID    = sdktypes.NewIntegrationIDFromName("auth0")
+
 	authType         = sdktypes.NewSymbol("auth_type")
 	clientIDName     = sdktypes.NewSymbol("client_id")
 	clientSecretName = sdktypes.NewSymbol("client_secret")
 	domainName       = sdktypes.NewSymbol("auth0_domain")
-	integrationID    = sdktypes.NewIntegrationIDFromName("auth0")
 )
 
 var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{

--- a/integrations/auth0/oauth.go
+++ b/integrations/auth0/oauth.go
@@ -9,20 +9,22 @@ import (
 
 	"go.autokitteh.dev/autokitteh/integrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
+	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 	"go.uber.org/zap"
 )
 
 type handler struct {
 	logger *zap.Logger
+	vars   sdkservices.Vars
 }
 
 const (
 	domainEnvVarName = "AUTH0_DOMAIN"
 )
 
-func NewHandler(l *zap.Logger) http.Handler {
-	return handler{logger: l}
+func NewHandler(l *zap.Logger, vars sdkservices.Vars) http.Handler {
+	return handler{logger: l, vars: vars}
 }
 
 func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -93,6 +95,6 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	c.Finalize(sdktypes.NewVars(data.ToVars()...).
-		Append(sdktypes.NewVar(domain).SetValue(d)).
+		Append(sdktypes.NewVar(domainName).SetValue(d)).
 		Append(sdktypes.NewVar(authType).SetValue(integrations.OAuth)))
 }

--- a/integrations/auth0/save.go
+++ b/integrations/auth0/save.go
@@ -1,0 +1,79 @@
+package auth0
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+	"go.uber.org/zap"
+)
+
+const (
+	headerContentType = "Content-Type"
+	contentTypeForm   = "application/x-www-form-urlencoded"
+)
+
+func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
+	c, l := sdkintegrations.NewConnectionInit(h.logger, w, r, desc)
+
+	// Check "Content-Type" header.
+	contentType := r.Header.Get(headerContentType)
+	if r.Method == http.MethodPost && !strings.HasPrefix(contentType, contentTypeForm) {
+		c.AbortBadRequest("unexpected content type")
+		return
+	}
+
+	// Read and parse POST request body.
+	if err := r.ParseForm(); err != nil {
+		l.Error("Failed to parse incoming HTTP request", zap.Error(err))
+		c.AbortServerError("form parsing error")
+		return
+	}
+
+	clientID := r.FormValue("client_id")
+	clientSecret := r.FormValue("client_secret")
+	auth0Domain := r.FormValue("auth0_domain")
+
+	if clientID == "" || clientSecret == "" || auth0Domain == "" {
+		c.AbortBadRequest("missing required fields")
+		return
+	}
+
+	vs := sdktypes.NewVars().
+		Set(clientIDName, clientID, false).
+		Set(clientSecretName, clientSecret, true).
+		Set(domainName, auth0Domain, false)
+
+	if err := h.saveAuthCredentials(r.Context(), c, vs); err != nil {
+		l.Error("Failed to save Auth0 credentials", zap.Error(err))
+		c.AbortServerError("failed to save credentials")
+		return
+	}
+
+	// Redirect to AutoKitteh's OAuth starting point.
+	http.Redirect(w, r, oauthURL(c), http.StatusFound)
+}
+
+func oauthURL(c sdkintegrations.ConnectionInit) string {
+	return fmt.Sprintf("/oauth/start/auth0?cid=%s&origin=%s", c.ConnectionID, c.Origin)
+}
+
+func (h handler) saveAuthCredentials(ctx context.Context, c sdkintegrations.ConnectionInit, vs sdktypes.Vars) error {
+	cid, err := sdktypes.StrictParseConnectionID(c.ConnectionID)
+	if err != nil {
+		return fmt.Errorf("invalid connection ID: %w", err)
+	}
+
+	vsl := make([]sdktypes.Var, 0, len(vs))
+	for _, v := range vs {
+		vsl = append(vsl, v.WithScopeID(sdktypes.NewVarScopeID(cid)))
+	}
+
+	if err := h.vars.Set(ctx, vsl...); err != nil {
+		return fmt.Errorf("failed to save credentials: %w", err)
+	}
+	return nil
+}

--- a/integrations/auth0/server.go
+++ b/integrations/auth0/server.go
@@ -31,6 +31,7 @@ func Start(l *zap.Logger, muxes *muxes.Muxes, vars sdkservices.Vars) {
 	// to have an authenticated user context, so the DB layer won't reject them.
 	// For this purpose, init webhooks are managed by the "auth" mux, which passes
 	// through AutoKitteh's auth middleware to extract the user ID from a cookie.
-	muxes.Auth.Handle("GET "+oauthPath, NewHandler(l, vars))
-	muxes.Auth.Handle("GET "+savePath, NewHandler(l, vars))
+	h := NewHTTPHandler(l, vars)
+	muxes.Auth.HandleFunc("GET "+oauthPath, h.handleOAuth)
+	muxes.Auth.HandleFunc("POST "+savePath, h.handleSave)
 }

--- a/integrations/auth0/server.go
+++ b/integrations/auth0/server.go
@@ -6,16 +6,23 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
+	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/web/static"
 )
 
-// oauthPath is the URL path for our handler to save
-// new OAuth-based connections.
-const oauthPath = "/auth0/oauth"
+const (
+	// oauthPath is the URL path for our handler to save
+	// new OAuth-based connections.
+	oauthPath = "/auth0/oauth"
+
+	// savePath is the URL path for our handler to save authentication credentials.
+	// It acts as a passthrough for the OAuth flow.
+	savePath = "/auth0/save"
+)
 
 // Start initializes all the HTTP handlers of the Auth0 integration.
 // This includes connection UIs, initialization webhooks, and event webhooks.
-func Start(l *zap.Logger, muxes *muxes.Muxes) {
+func Start(l *zap.Logger, muxes *muxes.Muxes, vars sdkservices.Vars) {
 	// Connection UI.
 	uiPath := "GET " + desc.ConnectionURL().Path + "/"
 	muxes.NoAuth.Handle(uiPath, http.FileServer(http.FS(static.Auth0WebContent)))
@@ -24,5 +31,6 @@ func Start(l *zap.Logger, muxes *muxes.Muxes) {
 	// to have an authenticated user context, so the DB layer won't reject them.
 	// For this purpose, init webhooks are managed by the "auth" mux, which passes
 	// through AutoKitteh's auth middleware to extract the user ID from a cookie.
-	muxes.Auth.Handle("GET "+oauthPath, NewHandler(l))
+	muxes.Auth.Handle("GET "+oauthPath, NewHandler(l, vars))
+	muxes.Auth.Handle("GET "+savePath, NewHandler(l, vars))
 }

--- a/internal/backend/oauth/oauth.go
+++ b/internal/backend/oauth/oauth.go
@@ -476,6 +476,7 @@ func (o *oauth) getConfigWithConnection(ctx context.Context, intg string, cid sd
 	cfgCopy.ClientSecret = vs.GetValueByString("client_secret")
 
 	// Special case: Auth0 uses a dynamic domain stored in vars.
+	// TODO(INT-129): Add dynamic domain handling to all OAuth integrations.
 	if intg == "auth0" {
 		cfgCopy.Endpoint.AuthURL = strings.Replace(cfgCopy.Endpoint.AuthURL, "{{AUTH0_DOMAIN}}", vs.GetValueByString("auth0_domain"), 1)
 		cfgCopy.Endpoint.TokenURL = strings.Replace(cfgCopy.Endpoint.TokenURL, "{{AUTH0_DOMAIN}}", vs.GetValueByString("auth0_domain"), 1)

--- a/internal/backend/oauth/oauth.go
+++ b/internal/backend/oauth/oauth.go
@@ -475,7 +475,7 @@ func (o *oauth) getConfigWithConnection(ctx context.Context, intg string, cid sd
 	cfgCopy.ClientID = vs.GetValueByString("client_id")
 	cfgCopy.ClientSecret = vs.GetValueByString("client_secret")
 
-	// Special case: Auth0 uses a dynamic domain stored in vars. 
+	// Special case: Auth0 uses a dynamic domain stored in vars.
 	if intg == "auth0" {
 		cfgCopy.Endpoint.AuthURL = strings.Replace(cfgCopy.Endpoint.AuthURL, "{{AUTH0_DOMAIN}}", vs.GetValueByString("auth0_domain"), 1)
 		cfgCopy.Endpoint.TokenURL = strings.Replace(cfgCopy.Endpoint.TokenURL, "{{AUTH0_DOMAIN}}", vs.GetValueByString("auth0_domain"), 1)

--- a/internal/backend/svc/integrations.go
+++ b/internal/backend/svc/integrations.go
@@ -76,7 +76,7 @@ func integrationsFXOption() fx.Option {
 		fx.Invoke(func(lc fx.Lifecycle, l *zap.Logger, muxes *muxes.Muxes, svcs sdkservices.Services) {
 			HookOnStart(lc, func(ctx context.Context) error {
 				asana.Start(l, muxes)
-				auth0.Start(l, muxes)
+				auth0.Start(l, muxes, svcs.Vars())
 				aws.Start(l, muxes)
 				chatgpt.Start(l, muxes)
 				confluence.Start(l, muxes, svcs.Vars(), svcs.OAuth(), svcs.Dispatcher())

--- a/runtimes/pythonrt/py-sdk/autokitteh/auth0.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/auth0.py
@@ -29,4 +29,4 @@ def auth0_client(connection: str, **kwargs) -> Auth0:
     if not token or not domain:
         raise ConnectionInitError(connection)
 
-    return Auth0(domain, token)
+    return Auth0(domain, token, **kwargs)

--- a/runtimes/pythonrt/py-sdk/autokitteh/auth0.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/auth0.py
@@ -25,7 +25,7 @@ def auth0_client(connection: str, **kwargs) -> Auth0:
     check_connection_name(connection)
 
     token = os.getenv(connection + "__oauth_AccessToken")
-    domain = os.getenv(connection + "__domain")
+    domain = os.getenv(connection + "__auth0_domain")
     if not token or not domain:
         raise ConnectionInitError(connection)
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/hubspot.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/hubspot.py
@@ -26,11 +26,11 @@ def hubspot_client(connection: str, **kwargs) -> HubSpot:
 
     refresh_token = os.getenv(connection + "__oauth_RefreshToken")
     if not refresh_token:
-        raise ConnectionInitError("OAuth refresh token is missing")
+        raise ConnectionInitError(connection)
 
     try:
         access_token, _ = refresh_oauth("hubspot", connection)
     except Exception as e:
         raise OAuthRefreshError(connection, str(e)) from e
 
-    return HubSpot(access_token=access_token)
+    return HubSpot(access_token=access_token, **kwargs)

--- a/web/static/auth0/connect/index.html
+++ b/web/static/auth0/connect/index.html
@@ -35,23 +35,75 @@
         <h1>Auth0 - Create a New Connection</h1>
       </td>
     </table>
-    <!-- TODO() -->
 
-    <p class="info">
-      Click the button below to install and authorize<br />
-      the <b>AutoKitteh</b> app in your Auth0 tenant
-    </p>
-    <!-- TODO(ENG-799): remove ID once its unused -->
-    <a id="oauth-link" href="/oauth/start/auth0" class="clickable"
-      >Start OAuth Flow</a
-    >
+    <p class="info">Information:</p>
+    <ul class="links">
+      <li>
+        <a
+          href="https://docs.autokitteh.com/integrations/auth0/config"
+          target="_blank"
+          class="info"
+        >
+          AutoKitteh guide: configuring Auth0 integration
+        </a>
+      </li>
+    </ul>
 
-    <!-- TODO(ENG-799) -->
+    <form id="save-form" method="post" action="/auth0/save">
+      <input type="hidden" name="auth_type" value="oauth" />
+
+      <div class="form-group">
+        <label for="client_id">Client ID</label>
+        <input
+          type="text"
+          id="clientId"
+          name="client_id"
+          autocomplete="off"
+          spellcheck="false"
+          required
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="client_secret">Client Secret</label>
+        <input
+          type="text"
+          id="clientSecret" 
+          name="client_secret"
+          autocomplete="off"
+          spellcheck="false"
+          required
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="auth0_domain">Auth0 Domain</label>
+        <input
+          type="text"
+          id="auth0Domain"
+          name="auth0_domain"
+          autocomplete="off"
+          spellcheck="false"
+          required
+        />
+      </div>
+
+      <div class="form-group">
+        <p class="info">
+          Click the button below to install and authorize<br />
+          the <strong>AutoKitteh</strong> app in your Auth0 tenant
+        </p>
+      </div>
+
+      <button type="submit" class="submit-btn">Start OAuth Flow</button>
+    </form>
+
+
     <script>
       const queryString = window.location.search;
       document
-        .getElementById("oauth-link")
-        .setAttribute("href", "/oauth/start/auth0" + queryString);
+        .getElementById("save-form")
+        .setAttribute("action", "/auth0/save" + queryString);
     </script>
   </body>
 </html>

--- a/web/static/auth0/connect/index.html
+++ b/web/static/auth0/connect/index.html
@@ -44,7 +44,7 @@
           target="_blank"
           class="info"
         >
-          AutoKitteh guide: configuring Auth0 integration
+          AutoKitteh guide: configuring Auth0 connections
         </a>
       </li>
     </ul>


### PR DESCRIPTION
### Key Changes

1. **Dynamic Credential Handling**
   - Added `client_id`, `client_secret`, and `auth0_domain` as configurable variables managed via the `vars` service.

2. **OAuth Flow Enhancements**
   - Refactored the OAuth flow to support connection-specific credentials and dynamically replace placeholders (e.g., `{{AUTH0_DOMAIN}}`) for auth0.
   - Introduced a `/auth0/save` endpoint to store credentials before starting the OAuth flow.