### PR TITLE
fix(ENG-1914): fix exception handling

### DIFF
--- a/cmd/ak/cmd/sessions/test.go
+++ b/cmd/ak/cmd/sessions/test.go
@@ -21,12 +21,10 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-var trimPythonExceptionPath bool
-
 var trimRe = regexp.MustCompile(`\/.*\/ak-(user|runner)-.*?\/`)
 
 var testCmd = common.StandardCommand(&cobra.Command{
-	Use:   "test <txtar-file> [--build-id=...] [--env=...] [--deployment-id=...] [--entrypoint=...] [--quiet] [--timeout DURATION] [--poll-interval DURATION] [--no-timestamps] [--trim-exception-path]",
+	Use:   "test <txtar-file> [--build-id=...] [--env=...] [--deployment-id=...] [--entrypoint=...] [--quiet] [--timeout DURATION] [--poll-interval DURATION] [--no-timestamps]",
 	Short: "Test a session run",
 	Args:  cobra.ExactArgs(1),
 
@@ -112,9 +110,7 @@ var testCmd = common.StandardCommand(&cobra.Command{
 		var prints strings.Builder
 		for _, r := range rs {
 			if p, ok := r.GetPrint(); ok {
-				if trimPythonExceptionPath {
-					p = trimRe.ReplaceAllString(p, "")
-				}
+				p = trimRe.ReplaceAllString(p, "")
 
 				prints.WriteString(p)
 				prints.WriteRune('\n')
@@ -137,5 +133,4 @@ func init() {
 	testCmd.Flags().DurationVarP(&watchTimeout, "timeout", "t", 0, "watch timeout duration")
 	testCmd.Flags().BoolVar(&noTimestamps, "no-timestamps", false, "omit timestamps from watch output")
 	testCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "don't print anything, just wait to finish")
-	testCmd.Flags().BoolVarP(&trimPythonExceptionPath, "trim-exception-path", "k", false, "trim python exception path temporary directory prefix")
 }

--- a/runtimes/pythonrt/pythonrt.go
+++ b/runtimes/pythonrt/pythonrt.go
@@ -547,6 +547,10 @@ func (py *pySvc) initialCall(ctx context.Context, funcName string, args []sdktyp
 				return sdktypes.InvalidValue, perr.ToError()
 			}
 
+			if done.Result == nil {
+				return sdktypes.InvalidValue, errors.New("done result is nil")
+			}
+
 			done.Result.Custom.ExecutorId = py.xid.String()
 			return sdktypes.ValueFromProto(done.Result)
 		case <-ctx.Done():

--- a/runtimes/pythonrt/runner/main.py
+++ b/runtimes/pythonrt/runner/main.py
@@ -331,7 +331,9 @@ class Runner(pb.runner_rpc.RunnerService):
         )
 
         if err:
-            req.error = str(err)
+            # req.error must not be empty, otherwise the server would not know
+            # that there was an error.
+            req.error = str(err) or "exception"
             tb = exc_traceback(err)
             req.traceback.extend(tb)
         else:

--- a/tests/sessions/python_exception.txtar
+++ b/tests/sessions/python_exception.txtar
@@ -1,0 +1,14 @@
+error: 
+
+Traceback (most recent call last):
+  File "runner/main.py", line 323, in on_event
+    result = fn(event)
+  File "main.py", line 4, in main
+    raise X()
+main.X
+
+-- main.py:main --
+class X(Exception): pass
+
+def main(event):
+    raise X()

--- a/tests/sessions/python_exception.txtar
+++ b/tests/sessions/python_exception.txtar
@@ -3,6 +3,7 @@ error:
 Traceback (most recent call last):
   File "runner/main.py", line 323, in on_event
     result = fn(event)
+             ^^^^^^^^^
   File "main.py", line 4, in main
     raise X()
 main.X

--- a/tests/sessions/run.sh
+++ b/tests/sessions/run.sh
@@ -92,7 +92,7 @@ for f in tests/sessions/${TESTS}; do
 
     AK="${PWD}/${ak_filename} -C http.service_url=http://$(cat ${addr_filename})"
 
-    ${AK} session test -k "${f}"
+    ${AK} session test "${f}"
 
     down 
 done

--- a/tests/sessions/run.sh
+++ b/tests/sessions/run.sh
@@ -92,7 +92,7 @@ for f in tests/sessions/${TESTS}; do
 
     AK="${PWD}/${ak_filename} -C http.service_url=http://$(cat ${addr_filename})"
 
-    ${AK} session test "${f}"
+    ${AK} session test -k "${f}"
 
     down 
 done


### PR DESCRIPTION
when an exception that its `str(ex)` is empty is propagated from python the runtime does not know that it happened.
this fixes it by always having a non empty error string in the done message.

this pr also adds a capability for session tests to trim non deterministic paths from exception printing so they can be compared against.