### PR TITLE
fix: `ak up -m test` get stuck sometimes

### DIFF
--- a/internal/backend/temporalclient/client.go
+++ b/internal/backend/temporalclient/client.go
@@ -119,15 +119,14 @@ func (c *impl) startDevServer(ctx context.Context) error {
 	c.cfg.DevServer.Stdout = c.logFile
 
 	for i := 0; i < c.cfg.DevServerStartMaxAttempts && c.srv == nil; i++ {
-		c.l.Info("Starting Temporal dev server", zap.Int("attempt", i))
+		c.l.Info("starting temporal dev server", zap.Int("attempt", i))
 
 		if i > 0 {
 			select {
 			case <-time.After(c.cfg.DevServerStartRetryInterval):
 				// nop
 			case <-ctx.Done():
-				err = fmt.Errorf("context done: %w", ctx.Err())
-				break
+				return fmt.Errorf("context done: %w", ctx.Err())
 			}
 		}
 
@@ -141,7 +140,7 @@ func (c *impl) startDevServer(ctx context.Context) error {
 
 		c.srv, err = testsuite.StartDevServer(startCtx, c.cfg.DevServer)
 		if err != nil {
-			c.l.Error("Failed to start Temporal dev server", zap.Error(err), zap.Int("attempt", i))
+			c.l.Error("failed to start temporal dev server", zap.Error(err), zap.Int("attempt", i))
 		}
 	}
 
@@ -149,7 +148,7 @@ func (c *impl) startDevServer(ctx context.Context) error {
 		return fmt.Errorf("start Temporal dev server: %w", err)
 	}
 
-	c.l.Info("Started Temporal dev server", zap.String("address", c.srv.FrontendHostPort()))
+	c.l.Info("started temporal dev server", zap.String("address", c.srv.FrontendHostPort()))
 
 	if c.client != nil {
 		c.client.Close()

--- a/internal/backend/temporalclient/client.go
+++ b/internal/backend/temporalclient/client.go
@@ -127,6 +127,7 @@ func (c *impl) startDevServer(ctx context.Context) error {
 				// nop
 			case <-ctx.Done():
 				err = fmt.Errorf("context done: %w", ctx.Err())
+				break
 			}
 		}
 

--- a/internal/backend/temporalclient/client.go
+++ b/internal/backend/temporalclient/client.go
@@ -118,7 +118,33 @@ func (c *impl) startDevServer(ctx context.Context) error {
 	c.cfg.DevServer.Stderr = c.logFile
 	c.cfg.DevServer.Stdout = c.logFile
 
-	if c.srv, err = testsuite.StartDevServer(ctx, c.cfg.DevServer); err != nil {
+	for i := 0; i < c.cfg.DevServerStartMaxAttempts && c.srv == nil; i++ {
+		c.l.Info("Starting Temporal dev server", zap.Int("attempt", i))
+
+		if i > 0 {
+			select {
+			case <-time.After(c.cfg.DevServerStartRetryInterval):
+				// nop
+			case <-ctx.Done():
+				err = fmt.Errorf("context done: %w", ctx.Err())
+			}
+		}
+
+		startCtx := ctx
+
+		if c.cfg.DevServerStartTimeout != 0 {
+			var done func()
+			startCtx, done = context.WithTimeout(ctx, c.cfg.DevServerStartTimeout)
+			defer done()
+		}
+
+		c.srv, err = testsuite.StartDevServer(startCtx, c.cfg.DevServer)
+		if err != nil {
+			c.l.Error("Failed to start Temporal dev server", zap.Error(err), zap.Int("attempt", i))
+		}
+	}
+
+	if err != nil {
 		return fmt.Errorf("start Temporal dev server: %w", err)
 	}
 

--- a/internal/backend/temporalclient/client_test.go
+++ b/internal/backend/temporalclient/client_test.go
@@ -3,6 +3,7 @@ package temporalclient
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/client"
@@ -18,7 +19,10 @@ func TestStartDevServer(t *testing.T) {
 
 	c := &impl{
 		cfg: &Config{
-			DevServer: testsuite.DevServerOptions{},
+			DevServer:                   testsuite.DevServerOptions{},
+			DevServerStartMaxAttempts:   3,
+			DevServerStartRetryInterval: time.Second,
+			DevServerStartTimeout:       time.Second * 5,
 		},
 		opts: client.Options{},
 		done: make(chan struct{}),

--- a/internal/backend/temporalclient/config.go
+++ b/internal/backend/temporalclient/config.go
@@ -35,8 +35,12 @@ type Config struct {
 	Namespace             string `koanf:"namespace"`
 
 	// DevServer.ClientOptions is not used.
-	DevServer testsuite.DevServerOptions `koanf:"dev_server"`
-	TLS       tlsConfig                  `koanf:"tls"`
+	DevServer                   testsuite.DevServerOptions `koanf:"dev_server"`
+	DevServerStartMaxAttempts   int                        `koanf:"dev_server_start_max_attempts"`
+	DevServerStartRetryInterval time.Duration              `koanf:"dev_server_start_retry_interval"`
+	DevServerStartTimeout       time.Duration              `koanf:"dev_server_start_timeout"`
+
+	TLS tlsConfig `koanf:"tls"`
 
 	DataConverter DataConverterConfig `koanf:"data_converter"`
 
@@ -68,7 +72,9 @@ var (
 				EnableUI:   true,
 				DBFilename: filepath.Join(xdg.DataHomeDir(), "temporal_dev.sqlite"),
 			},
-			EnableHelperRedirect: true,
+			DevServerStartMaxAttempts: 1,
+			DevServerStartTimeout:     time.Second * 5,
+			EnableHelperRedirect:      true,
 		},
 		Test: &Config{
 			Monitor:              defaultMonitorConfig,
@@ -77,6 +83,9 @@ var (
 				LogLevel: zapcore.WarnLevel.String(),
 				EnableUI: true,
 			},
+			DevServerStartMaxAttempts:   3,
+			DevServerStartRetryInterval: time.Second,
+			DevServerStartTimeout:       time.Second * 5,
 		},
 	}
 )

--- a/tests/sessions/run.sh
+++ b/tests/sessions/run.sh
@@ -42,7 +42,7 @@ up() {
     "${ak_filename}" --config "http.addr=:0" --config "runtimes.lazy_load_local_venv=true" --config "http.addr_filename=${addr_filename}" up -m test >& "${logfn}" &
     echo "waiting for autokitteh to be ready"
 
-    while IFS= read -r LL || [[ -n "$LL" ]]; do
+    while IFS= read -t 10 -r LL || [[ -n "$LL" ]]; do
         # TODO: maybe a more accurate way to parse.
         if [[ "${LL}" =~ "ready" ]]; then
             break

--- a/tests/sessions/run.sh
+++ b/tests/sessions/run.sh
@@ -42,12 +42,20 @@ up() {
     "${ak_filename}" --config "http.addr=:0" --config "runtimes.lazy_load_local_venv=true" --config "http.addr_filename=${addr_filename}" up -m test >& "${logfn}" &
     echo "waiting for autokitteh to be ready"
 
+    ready=0
     while IFS= read -t 10 -r LL || [[ -n "$LL" ]]; do
         # TODO: maybe a more accurate way to parse.
         if [[ "${LL}" =~ "ready" ]]; then
+            ready=1
             break
         fi
     done < <(tail -f "${logfn}")
+
+    if [[ ${ready} -eq 0 ]]; then
+        echo "autokitteh failed to start"
+        cat "${logfn}"
+        exit 1
+    fi
 
     echo "autokitteh is ready"
 }


### PR DESCRIPTION
looks like the session tests get stuck because temporal start dev fails to run from the binary. this attempts to start it multiple times on failure. i tested it lots of times and now it looks to be solved using this very heavy handed fix.

we should consider not starting temporal ourselves, but that might be bothersome to the users in test mode.