### PR TITLE
fix(auth0): fix connection init endpoint's HTTP method

### DIFF
--- a/integrations/auth0/server.go
+++ b/integrations/auth0/server.go
@@ -33,5 +33,5 @@ func Start(l *zap.Logger, muxes *muxes.Muxes, vars sdkservices.Vars) {
 	// through AutoKitteh's auth middleware to extract the user ID from a cookie.
 	h := NewHTTPHandler(l, vars)
 	muxes.Auth.HandleFunc("GET "+oauthPath, h.handleOAuth)
-	muxes.Auth.HandleFunc("POST "+savePath, h.handleSave)
+	muxes.Auth.HandleFunc("GET "+savePath, h.handleSave)
 }

--- a/web/static/auth0/connect/index.html
+++ b/web/static/auth0/connect/index.html
@@ -49,7 +49,7 @@
       </li>
     </ul>
 
-    <form id="save-form" method="post" action="/auth0/save">
+    <form id="save-form" method="get" action="/auth0/save">
       <input type="hidden" name="auth_type" value="oauth" />
 
       <div class="form-group">


### PR DESCRIPTION
Align auth0 to receive the data using the GET method instead of the POST, since that's the way we work with OAuth in WebUI: We are opening a modal that goes to the server, and is redirected from there to the relevant URL.

For example:
The auth0/save should be GET, like in Google: [link to the code](https://github.com/autokitteh/autokitteh/blob/0c4bba46348c1474a11c2dbce6f7e90d7f55dfa5/integrations/google/server.go#L61)

Currently, it's [POST](https://github.com/autokitteh/autokitteh/blob/0c4bba46348c1474a11c2dbce6f7e90d7f55dfa5/integrations/auth0/server.go#L36), meaning our web UI can't work with it.

Refs: ENG-1926