### PR TITLE
fix: better align banner fields

### DIFF
--- a/internal/backend/svc/banner.go
+++ b/internal/backend/svc/banner.go
@@ -37,15 +37,15 @@ func printBanner(cfg *bannerConfig, opts RunOptions, addr, wpAddr, wpVersion, te
 
 	var mode string
 	if opts.Mode != "" {
-		mode = "Mode:         " + fieldColor(opts.Mode) + " "
+		mode = "Mode:           " + fieldColor(opts.Mode) + " "
 	}
 
 	if temporalFrontendAddr != "" {
-		temporalFrontendAddr = "Temporal:     " + fieldColor(temporalFrontendAddr) + " "
+		temporalFrontendAddr = "Temporal:       " + fieldColor(temporalFrontendAddr) + " "
 	}
 
 	if temporalUIAddr != "" {
-		temporalUIAddr = "Temporal UI:  " + fieldColor(temporalUIAddr) + " "
+		temporalUIAddr = "Temporal UI:    " + fieldColor(temporalUIAddr) + " "
 	}
 
 	webAddr := fmt.Sprintf("http://%s", addr)

--- a/internal/backend/svc/banner.txt
+++ b/internal/backend/svc/banner.txt
@@ -1,8 +1,8 @@
 
-        _..--~~~~--.._             autokitteh    {{ .Version }}
-     _--              --_          PID:          {{ .PID }}
-    '                    `         gRPC/HTTP:    {{ .Addr }}
-   '                      `        Web{{ .WebVer }}  {{ .WebAddr }}
+        _..--~~~~--.._             autokitteh      {{ .Version }}
+     _--              --_          PID:            {{ .PID }}
+    '                    `         gRPC/HTTP:      {{ .Addr }}
+   '                      `        Web{{ .WebVer }}   {{ .WebAddr }}
   '                        `       {{ .Mode }}
  |                    |\   |       
  |                    | \  |       {{ .Temporal }}


### PR DESCRIPTION
web version became too long, added two more spaces to each field.
turned
![image](https://github.com/user-attachments/assets/6bf6a433-aef4-4d82-bfa6-c699bf64b86a)
into
![image](https://github.com/user-attachments/assets/af8cbcf6-24ec-4b08-8be6-255a5083c77c)
