### PR TITLE
fix(db): use DISTINCT instead of GROUP BY to remove duplicates when joining with project's org

### DIFF
--- a/internal/backend/db/dbgorm/connections.go
+++ b/internal/backend/db/dbgorm/connections.go
@@ -79,7 +79,7 @@ func (gdb *gormdb) listConnections(ctx context.Context, filter sdkservices.ListC
 
 	q = withProjectID(q, "", filter.ProjectID)
 
-	q = withProjectOrgID(q, filter.OrgID, "connection_id")
+	q = withProjectOrgID(q, filter.OrgID)
 
 	if filter.IntegrationID.IsValid() {
 		q = q.Where("integration_id = ?", filter.IntegrationID.UUIDValue())

--- a/internal/backend/db/dbgorm/deployments.go
+++ b/internal/backend/db/dbgorm/deployments.go
@@ -90,7 +90,7 @@ func (gdb *gormdb) listDeploymentsCommonQuery(ctx context.Context, filter sdkser
 
 	q = withProjectID(q, "deployments", filter.ProjectID)
 
-	q = withProjectOrgID(q, filter.OrgID, "deployment_id")
+	q = withProjectOrgID(q, filter.OrgID)
 
 	if filter.BuildID.IsValid() {
 		q = q.Where("deployments.build_id = ?", filter.BuildID.UUIDValue())

--- a/internal/backend/db/dbgorm/events.go
+++ b/internal/backend/db/dbgorm/events.go
@@ -29,7 +29,7 @@ func (gdb *gormdb) getEvent(ctx context.Context, eventID uuid.UUID) (*scheme.Eve
 func (gdb *gormdb) listEvents(ctx context.Context, filter sdkservices.ListEventsFilter) ([]scheme.Event, error) {
 	q := gdb.db.WithContext(ctx)
 
-	q = withProjectOrgID(q, filter.OrgID, "event_id")
+	q = withProjectOrgID(q, filter.OrgID)
 
 	if filter.ProjectID.IsValid() {
 		q = q.Where("project_id = ?", filter.ProjectID.UUIDValue())

--- a/internal/backend/db/dbgorm/helpers.go
+++ b/internal/backend/db/dbgorm/helpers.go
@@ -35,12 +35,12 @@ func withProjectID(q *gorm.DB, field string, pid sdktypes.ProjectID) *gorm.DB {
 }
 
 // groupBy is necessary to avoid duplications because of the join.
-func withProjectOrgID(q *gorm.DB, oid sdktypes.OrgID, groupBy string) *gorm.DB {
+func withProjectOrgID(q *gorm.DB, oid sdktypes.OrgID) *gorm.DB {
 	if !oid.IsValid() {
 		return q
 	}
 
-	return q.Joins("INNER JOIN projects ON projects.org_id = ?", oid.UUIDValue()).Group(groupBy)
+	return q.Joins("INNER JOIN projects ON projects.org_id = ?", oid.UUIDValue()).Distinct()
 }
 
 // ---

--- a/internal/backend/db/dbgorm/sessions.go
+++ b/internal/backend/db/dbgorm/sessions.go
@@ -70,7 +70,7 @@ func (gdb *gormdb) listSessions(ctx context.Context, f sdkservices.ListSessionsF
 
 	q = withProjectID(q, "", f.ProjectID)
 
-	q = withProjectOrgID(q, f.OrgID, "session_id")
+	q = withProjectOrgID(q, f.OrgID)
 
 	if f.DeploymentID.IsValid() {
 		q = q.Where("deployment_id = ?", f.DeploymentID.UUIDValue())

--- a/internal/backend/db/dbgorm/triggers.go
+++ b/internal/backend/db/dbgorm/triggers.go
@@ -38,7 +38,7 @@ func (gdb *gormdb) listTriggers(ctx context.Context, filter sdkservices.ListTrig
 		q = q.Where("triggers.project_id = ?", filter.ProjectID.UUIDValue())
 	}
 
-	q = withProjectOrgID(q, filter.OrgID, "trigger_id")
+	q = withProjectOrgID(q, filter.OrgID)
 
 	if filter.ConnectionID.IsValid() {
 		q = q.Where("connection_id = ?", filter.ConnectionID.UUIDValue())


### PR DESCRIPTION
currently,
```
SELECT "events"."created_at","events"."project_id","events"."event_id","events"."destination_id","events"."integration_id","events"."connection_id","events"."trigger_id","events"."event_type","events"."memo","events"."seq","events"."deleted_at" FROM "events" INNER JOIN projects ON projects.org_id = '019400ec-b7c5-780d-9395-3816c9d2f60c' WHERE seq >= 0 AND "events"."deleted_at" IS NULL GROUP BY "event_id" ORDER BY seq desc LIMIT 500
```
gives
```
ERROR:  column "events.created_at" must appear in the GROUP BY clause or be used in an aggregate function
```

this turns it into
```
SELECT DISTINCT "events"."created_at","events"."project_id","events"."event_id","events"."destination_id","events"."integration_id","events"."connection_id","events"."trigger_id","events"."event_type","events"."memo","events"."seq","events"."deleted_at" FROM "events" INNER JOIN projects ON projects.org_id = '019400ec-b7c5-780d-9395-3816c9d2f60c' WHERE seq >= 0 AND "events"."deleted_at" IS NULL ORDER BY seq desc LIMIT 500
```
which works.
