### PR TITLE
fix(temporal): increase dev server start time

### DIFF
--- a/internal/backend/temporalclient/config.go
+++ b/internal/backend/temporalclient/config.go
@@ -73,7 +73,7 @@ var (
 				DBFilename: filepath.Join(xdg.DataHomeDir(), "temporal_dev.sqlite"),
 			},
 			DevServerStartMaxAttempts: 1,
-			DevServerStartTimeout:     time.Second * 5,
+			DevServerStartTimeout:     time.Second * 15,
 			EnableHelperRedirect:      true,
 		},
 		Test: &Config{
@@ -85,7 +85,7 @@ var (
 			},
 			DevServerStartMaxAttempts:   3,
 			DevServerStartRetryInterval: time.Second,
-			DevServerStartTimeout:       time.Second * 5,
+			DevServerStartTimeout:       time.Second * 15,
 		},
 	}
 )


### PR DESCRIPTION
The previous timeout of 5 seconds is too short when the user needs to download the Temporal server, and it's not already cached locally - which can take around 12-13 seconds.

Note about "caching": the Temporal SDK function `testsuite/devserver.go:downloadIfNeeded()` uses `os.TempDir()` if the option `CachedDownload.DestDir` isn't specified - but even then Go reuses temporary directories, which is why the first successful download will cause subsequent downloads to succeed immediately until a lot of time passes (e.g. reboot / version bump).