### PR TITLE
fix(ENG-1930): fix double https:// in auth0 connection

### DIFF
--- a/integrations/auth0/oauth.go
+++ b/integrations/auth0/oauth.go
@@ -70,7 +70,8 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Tests OAuth0's Management API.
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/api/v2/roles", d), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v2/roles", d), nil)
+
 	if err != nil {
 		l.Error("Failed to create HTTP request", zap.Error(err))
 		c.AbortServerError("request creation error")


### PR DESCRIPTION
Removed the `https://`, since we're adding inside the `http.NewRequest`:
https://github.com/autokitteh/autokitteh/blob/5b6a2fe0a284e4b3bfce0909d7a7ce836b8f666b/internal/backend/oauth/oauth.go#L41

(in the `redirectURL`)