### PR TITLE
fix(docker): expose web UI outside the container

### DIFF
--- a/internal/backend/httpsvc/config.go
+++ b/internal/backend/httpsvc/config.go
@@ -4,6 +4,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/configset"
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkclients/sdkclient"
 )
 
@@ -55,7 +56,7 @@ type Config struct {
 
 var Configs = configset.Set[Config]{
 	Default: &Config{
-		Addr:                 "0.0.0.0:" + sdkclient.DefaultPort,
+		Addr:                 kittehs.BindingAddress(sdkclient.DefaultPort),
 		ServiceUrl:           sdkclient.DefaultLocalURL,
 		H2C:                  httpH2CConfig{Enable: true},
 		EnableGRPCReflection: true,

--- a/internal/backend/httpsvc/http.go
+++ b/internal/backend/httpsvc/http.go
@@ -17,6 +17,7 @@ import (
 
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authz"
 	"go.autokitteh.dev/autokitteh/internal/backend/telemetry"
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/proto"
 )
 
@@ -81,20 +82,7 @@ func New(lc fx.Lifecycle, z *zap.Logger, cfg *Config, authzCheckFunc authz.Check
 				return fmt.Errorf("listen: %w", err)
 			}
 
-			svc.addr = ln.Addr().String()
-			if host, port, err := net.SplitHostPort(svc.addr); err == nil {
-				ip := net.ParseIP(host)
-
-				var addr string
-				if ip.IsUnspecified() {
-					addr = "localhost"
-				} else {
-					addr = ip.To4().String()
-				}
-
-				svc.addr = fmt.Sprintf("%s:%s", addr, port)
-			}
-
+			svc.addr = kittehs.DisplayAddress(ln.Addr().String())
 			z.Debug("listening", zap.String("addr", svc.addr))
 
 			if cfg.AddrFilename != "" {

--- a/internal/backend/webplatform/webplatform.go
+++ b/internal/backend/webplatform/webplatform.go
@@ -65,7 +65,7 @@ func (w *Svc) Start(context.Context) error {
 	fsrv := http.FileServer(http.FS(webfs))
 
 	srv := &http.Server{
-		Addr: fmt.Sprintf("localhost:%d", w.Config.Port),
+		Addr: fmt.Sprintf("0.0.0.0:%d", w.Config.Port),
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// If path actually exists in fs, serve it.
 			if f, _ := webfs.Open(strings.TrimPrefix(r.URL.Path, "/")); f != nil {

--- a/internal/backend/webplatform/webplatform.go
+++ b/internal/backend/webplatform/webplatform.go
@@ -3,13 +3,14 @@ package webplatform
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/configset"
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/web/webplatform"
 )
@@ -65,7 +66,7 @@ func (w *Svc) Start(context.Context) error {
 	fsrv := http.FileServer(http.FS(webfs))
 
 	srv := &http.Server{
-		Addr: fmt.Sprintf("0.0.0.0:%d", w.Config.Port),
+		Addr: kittehs.BindingAddress(strconv.Itoa(w.Config.Port)),
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// If path actually exists in fs, serve it.
 			if f, _ := webfs.Open(strings.TrimPrefix(r.URL.Path, "/")); f != nil {
@@ -79,7 +80,7 @@ func (w *Svc) Start(context.Context) error {
 		}),
 	}
 
-	w.addr = srv.Addr
+	w.addr = kittehs.DisplayAddress(srv.Addr)
 
 	go func() {
 		err := srv.ListenAndServe()

--- a/internal/kittehs/addresses.go
+++ b/internal/kittehs/addresses.go
@@ -1,0 +1,30 @@
+package kittehs
+
+import (
+	"fmt"
+	"net"
+)
+
+// BindingAddress returns an unspecified address with the given port.
+// This is needed in order to expose AutoKitteh ports in Docker containers,
+// because using "localhost" or "127.0.0.1" will bind the port to the loopback
+// interface, making it inaccessible from outside the container.
+func BindingAddress(port string) string {
+	return fmt.Sprintf("0.0.0.0:%s", port)
+}
+
+// DisplayAddress returns a human-readable address for the given binding address.
+// If the host is unspecified, it will be replaced with "localhost". Motivation:
+// https://www.oligo.security/blog/0-0-0-0-day-exploiting-localhost-apis-from-the-browser
+func DisplayAddress(bindingAddress string) string {
+	host, port, err := net.SplitHostPort(bindingAddress)
+	if err != nil {
+		return bindingAddress
+	}
+
+	if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
+		return fmt.Sprintf("localhost:%s", port)
+	}
+
+	return bindingAddress
+}

--- a/internal/kittehs/addresses_test.go
+++ b/internal/kittehs/addresses_test.go
@@ -1,0 +1,36 @@
+package kittehs
+
+import (
+	"testing"
+)
+
+func TestBindingAddress(t *testing.T) {
+	input := "1234"
+	got := BindingAddress("1234")
+	want := "0.0.0.0:1234"
+	if got != want {
+		t.Errorf("BindingAddress(%q) = %q, want %q", input, got, want)
+	}
+}
+
+func TestDisplayAddress(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{"0.0.0.0:1", "localhost:1"},
+		{"[::]:22", "localhost:22"},
+		{"[::1]:333", "[::1]:333"},
+		{"127.0.0.1:333", "127.0.0.1:333"},
+		{"localhost:4444", "localhost:4444"},
+		{"host.com:55555", "host.com:55555"},
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			if got := DisplayAddress(test.input); got != test.want {
+				t.Errorf("DisplayAddress(%q) = %q, want %q", test.input, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
One does not simply expose ports in a Docker container...

![image](https://github.com/user-attachments/assets/13279321-d3fa-4139-b216-4b98adaf7108)

Refs: #915 