### PR TITLE
refactorish(authn): default user is just a user, and simpler authentication and thorough testing

### DIFF
--- a/internal/backend/auth/authhttpmiddleware/authmiddleware.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware.go
@@ -29,7 +29,7 @@ var Configs = configset.Set[Config]{
 
 // The middleware passes around internally the authenticated user ID,
 // so that we can check only once in the AuthMiddlewareDecorator for
-// the common stuff - if the user exists and if it is not disabled.
+// the common stuff - that the user exists and that it is not disabled.
 // The AuthMiddlewareDecorator will call eventually the authcontext.SetAuthnUser
 // if the user is deemed worthy of authentication.
 type userIDCtxKey string

--- a/internal/backend/auth/authhttpmiddleware/authmiddleware.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware.go
@@ -27,7 +27,7 @@ var Configs = configset.Set[Config]{
 	Dev:     &Config{UseDefaultUser: true},
 }
 
-// The middlewares passes around internally the authenticated user id,
+// The middleware passes around internally the authenticated user ID,
 // so that we can check only once in the AuthMiddlewareDecorator for
 // the common stuff - if the user exists and if it is not disabled.
 // The AuthMiddlewareDecorator will call eventually the authcontext.SetAuthnUser

--- a/internal/backend/auth/authhttpmiddleware/authmiddleware.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware.go
@@ -1,6 +1,7 @@
 package authhttpmiddleware
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -16,13 +17,36 @@ import (
 )
 
 type Config struct {
-	// If set, not authn is required. The default user is always used.
+	// If set, no authn is required. If no other authn supplied,
+	// the default user will be considered authenticated.
 	UseDefaultUser bool `koanf:"use_default_user"`
 }
 
 var Configs = configset.Set[Config]{
 	Default: &Config{},
 	Dev:     &Config{UseDefaultUser: true},
+}
+
+// The middlewares passes around internally the authenticated user id,
+// so that we can check only once in the AuthMiddlewareDecorator for
+// the common stuff - if the user exists and if it is not disabled.
+// The AuthMiddlewareDecorator will call eventually the authcontext.SetAuthnUser
+// if the user is deemed worthy of authentication.
+type userIDCtxKey string
+
+var userIDContextKey = userIDCtxKey("authn_user_id")
+
+func ctxWithUserID(ctx context.Context, id sdktypes.UserID) context.Context {
+	return context.WithValue(ctx, userIDContextKey, id)
+}
+
+func getCtxUserID(ctx context.Context) sdktypes.UserID {
+	v := ctx.Value(userIDContextKey)
+	if v == nil {
+		return sdktypes.InvalidUserID
+	}
+
+	return v.(sdktypes.UserID)
 }
 
 type AuthMiddlewareDecorator func(http.Handler) http.Handler
@@ -36,99 +60,113 @@ type Deps struct {
 	Tokens   authtokens.Tokens  `optional:"true"`
 }
 
-func newTokensMiddleware(next http.Handler, deps Deps) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
+// ifAuthenticated is a middleware that checks if the user is authenticated.
+// If the user is authenticated, it calls the `yes` handler, otherwise it calls the `no` handler.
+func ifAuthenticated(yes, no http.Handler) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next := no
 
-		user := authcontext.GetAuthnUser(r.Context())
-		authHdr := r.Header.Get("Authorization")
-
-		if deps.Cfg.UseDefaultUser {
-			if user.IsValid() || authHdr != "" {
-				http.Error(w, "only default user is allowed", http.StatusUnauthorized)
-				return
-			}
-			ctx = authcontext.SetAuthnUser(ctx, authusers.DefaultUser)
-		} else {
-			if !user.IsValid() && authHdr != "" {
-				kind, payload, _ := strings.Cut(authHdr, " ")
-				switch kind {
-				case "Bearer":
-					u, err := deps.Tokens.Parse(payload)
-					if err != nil {
-						http.Error(w, "invalid token", http.StatusUnauthorized)
-						return
-					}
-
-					// make sure the user exists.
-					u, err = deps.Users.Get(authcontext.SetAuthnSystemUser(r.Context()), u.ID(), "")
-					if err != nil {
-						http.Error(w, "unknown user", http.StatusUnauthorized)
-						return
-					}
-
-					if u.Disabled() {
-						http.Error(w, "user is disabled", http.StatusUnauthorized)
-						return
-					}
-
-					ctx = authcontext.SetAuthnUser(ctx, u)
-
-				default:
-					http.Error(w, "invalid authorization header", http.StatusUnauthorized)
-					return
-				}
-			}
+		if getCtxUserID(r.Context()).IsValid() {
+			next = yes
 		}
 
-		r = r.WithContext(ctx)
+		next.ServeHTTP(w, r)
+	})
+}
+
+func newTokensMiddleware(next http.Handler, tokens authtokens.Tokens) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		authHdr := r.Header.Get("Authorization")
+
+		if authHdr == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		ctx := r.Context()
+
+		kind, payload, _ := strings.Cut(authHdr, " ")
+
+		if kind != "Bearer" {
+			http.Error(w, "invalid authorization header", http.StatusUnauthorized)
+			return
+		}
+
+		u, err := tokens.Parse(payload)
+		if err != nil {
+			http.Error(w, "invalid token", http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(w, r.WithContext(ctxWithUserID(ctx, u.ID())))
+	}
+}
+
+func newSessionsMiddleware(next http.Handler, sessions authsessions.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		session, err := sessions.Get(r)
+		if err != nil {
+			http.Error(w, "invalid session", http.StatusUnauthorized)
+			return
+		}
+
+		if session != nil {
+			r = r.WithContext(ctxWithUserID(r.Context(), session.UserID))
+		}
+
 		next.ServeHTTP(w, r)
 	}
 }
 
-func newSessionsMiddleware(next http.Handler, sessions authsessions.Store, users sdkservices.Users) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-
-		if u := authcontext.GetAuthnUser(ctx); !u.IsValid() {
-			session, err := sessions.Get(r)
-			if err != nil {
-				http.Error(w, "invalid session", http.StatusUnauthorized)
-				return
-			}
-
-			if session != nil {
-				u, err := users.Get(authcontext.SetAuthnSystemUser(ctx), session.UserID, "")
-				if err != nil {
-					http.Error(w, "invalid user", http.StatusUnauthorized)
-					return
-				}
-
-				r = r.WithContext(authcontext.SetAuthnUser(ctx, u))
-			}
-		}
-
-		next.ServeHTTP(w, r)
-	}
+func newSetDefaultUserMiddleware(next http.Handler) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r.WithContext(ctxWithUserID(r.Context(), authusers.DefaultUser.ID())))
+	})
 }
 
 func New(deps Deps) AuthMiddlewareDecorator {
+	sessions, users, tokens := deps.Sessions, deps.Users, deps.Tokens
+
 	return func(next http.Handler) http.Handler {
-		f := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if user := authcontext.GetAuthnUser(r.Context()); !user.IsValid() {
+		// Order matters here!
+
+		// Evaluated last.
+		f := ifAuthenticated(
+			/* authenticated: */ http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// make sure the user exists.
+				ctx := r.Context()
+
+				uid := getCtxUserID(ctx)
+
+				u, err := users.Get(authcontext.SetAuthnSystemUser(ctx), uid, "")
+				if err != nil {
+					http.Error(w, "unknown user", http.StatusUnauthorized)
+					return
+				}
+
+				if u.Disabled() {
+					http.Error(w, "user is disabled", http.StatusUnauthorized)
+					return
+				}
+
+				next.ServeHTTP(w, r.WithContext(authcontext.SetAuthnUser(ctx, u)))
+			}),
+			/* not authenticated: */ http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "unauthenticated", http.StatusUnauthorized)
-				return
-			}
+			}),
+		)
 
-			next.ServeHTTP(w, r)
-		})
-
-		if deps.Sessions != nil {
-			f = newSessionsMiddleware(f, deps.Sessions, deps.Users)
+		if deps.Cfg.UseDefaultUser {
+			f = ifAuthenticated(f, newSetDefaultUserMiddleware(f))
 		}
 
-		if deps.Tokens != nil {
-			f = newTokensMiddleware(f, deps)
+		if sessions != nil {
+			f = ifAuthenticated(f, newSessionsMiddleware(f, sessions))
+		}
+
+		// Evaluated first.
+		if tokens != nil {
+			f = ifAuthenticated(f, newTokensMiddleware(f, tokens))
 		}
 
 		return f

--- a/internal/backend/auth/authhttpmiddleware/authmiddleware_test.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware_test.go
@@ -166,7 +166,7 @@ func TestSessionsMiddleware(t *testing.T) {
 	assertCalledWithoutAuthn(t, check())
 
 	w = httptest.NewRecorder()
-	sessions.Set(w, authsessions.NewSessionData(testUser1.ID()))
+	kittehs.Must0(sessions.Set(w, authsessions.NewSessionData(testUser1.ID())))
 	cookies := w.Result().Cookies()
 
 	w = httptest.NewRecorder()
@@ -204,7 +204,7 @@ func TestNewWithoutDefaultUser(t *testing.T) {
 
 	// correct token, but no such user.
 	w = httptest.NewRecorder()
-	sessions.Set(w, authsessions.NewSessionData(testUser1.ID()))
+	kittehs.Must0(sessions.Set(w, authsessions.NewSessionData(testUser1.ID())))
 	cookies := w.Result().Cookies()
 
 	w = httptest.NewRecorder()
@@ -303,7 +303,7 @@ func TestNewWithDefaultUser(t *testing.T) {
 
 	// correct session, but no such user.
 	w = httptest.NewRecorder()
-	sessions.Set(w, authsessions.NewSessionData(testUser1.ID()))
+	kittehs.Must0(sessions.Set(w, authsessions.NewSessionData(testUser1.ID())))
 	cookies := w.Result().Cookies()
 
 	w = httptest.NewRecorder()

--- a/internal/backend/auth/authhttpmiddleware/authmiddleware_test.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware_test.go
@@ -1,0 +1,345 @@
+package authhttpmiddleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authcontext"
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authsessions"
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authtokens/authtokensjwt"
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authusers"
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/sdk/sdktest"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+var (
+	testUser1 = kittehs.Must1(sdktypes.UserFromProto(&sdktypes.UserPB{
+		UserId:      sdktypes.NewUserID().String(),
+		DisplayName: "Test User 1",
+	}))
+
+	testUser2 = kittehs.Must1(sdktypes.UserFromProto(&sdktypes.UserPB{
+		UserId:      sdktypes.NewUserID().String(),
+		DisplayName: "Test User 2",
+	}))
+)
+
+func newTestHandler(t *testing.T, getUser func(context.Context) sdktypes.UserID) (http.Handler, func() *sdktypes.UserID) {
+	var (
+		uid    sdktypes.UserID
+		called bool
+	)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called, uid = true, getUser(r.Context())
+			t.Logf("handler called, user_id=%v", uid)
+		}),
+		func() *sdktypes.UserID {
+			u, c := uid, called
+			uid, called = sdktypes.InvalidUserID, false
+
+			if !c {
+				return nil
+			}
+
+			return &u
+		}
+}
+
+func assertCalledWithUser(t *testing.T, expected sdktypes.UserID, given *sdktypes.UserID) {
+	if assert.NotNil(t, given) {
+		assert.Equal(t, expected, *given)
+	}
+}
+
+func assertCalledWithoutAuthn(t *testing.T, given *sdktypes.UserID) {
+	if assert.NotNil(t, given) {
+		assert.False(t, given.IsValid())
+	}
+}
+
+// Returns a handler and a function that returns the authenticated user.
+// If the handle was not called, the function will return nil.
+// That function also resets the user and called states when its called.
+func newInternalTestHandler(t *testing.T) (http.Handler, func() *sdktypes.UserID) {
+	return newTestHandler(t, getCtxUserID)
+}
+
+func newOverallTestHandler(t *testing.T) (http.Handler, func() *sdktypes.UserID) {
+	return newTestHandler(t, authcontext.GetAuthnUserID)
+}
+
+func newRequest(u sdktypes.User, authHeader string, cookies []*http.Cookie) *http.Request {
+	req := kittehs.Must1(http.NewRequest("GET", "/", nil))
+
+	if u.IsValid() {
+		req = req.WithContext(ctxWithUserID(context.Background(), u.ID()))
+	}
+
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+
+	for _, cookie := range cookies {
+		req.AddCookie(cookie)
+	}
+
+	return req
+}
+
+func TestIfAuthenticated(t *testing.T) {
+	yup, yupped := newInternalTestHandler(t)
+	nope, noped := newInternalTestHandler(t)
+
+	mw := ifAuthenticated(yup, nope)
+
+	mw.ServeHTTP(nil, newRequest(sdktypes.InvalidUser, "", nil))
+	assertCalledWithoutAuthn(t, noped())
+	assert.Nil(t, yupped())
+
+	mw.ServeHTTP(nil, newRequest(testUser1, "", nil))
+	assert.Nil(t, noped())
+	assertCalledWithUser(t, testUser1.ID(), yupped())
+}
+
+func TestDefaultUserMiddleware(t *testing.T) {
+	h, check := newInternalTestHandler(t)
+
+	mw := ifAuthenticated(h, newSetDefaultUserMiddleware(h))
+
+	// When no other auth in context, should use default user.
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(nil, newRequest(sdktypes.InvalidUser, "", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assertCalledWithUser(t, authusers.DefaultUser.ID(), check())
+
+	// When other auth in context, use that authn user.
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(nil, newRequest(testUser1, "", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assertCalledWithUser(t, testUser1.ID(), check())
+}
+
+func TestTokensMiddleware(t *testing.T) {
+	h, check := newInternalTestHandler(t)
+
+	tokens := kittehs.Must1(authtokensjwt.New(authtokensjwt.Configs.Dev))
+
+	mw := newTokensMiddleware(h, tokens)
+
+	// no header - should be nop.
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assertCalledWithoutAuthn(t, check())
+
+	// correct token.
+	tok := kittehs.Must1(tokens.Create(testUser1))
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok, nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assertCalledWithUser(t, testUser1.ID(), check())
+
+	// bad token.
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "meow", nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Nil(t, check())
+}
+
+func TestSessionsMiddleware(t *testing.T) {
+	h, check := newInternalTestHandler(t)
+
+	sessions := kittehs.Must1(authsessions.New(authsessions.Configs.Dev))
+
+	mw := newSessionsMiddleware(h, sessions)
+
+	// no session - should be nop.
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assertCalledWithoutAuthn(t, check())
+
+	w = httptest.NewRecorder()
+	sessions.Set(w, authsessions.NewSessionData(testUser1.ID()))
+	cookies := w.Result().Cookies()
+
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", cookies))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assertCalledWithUser(t, testUser1.ID(), check())
+}
+
+func TestNewWithoutDefaultUser(t *testing.T) {
+	h, check := newOverallTestHandler(t)
+
+	sessions := kittehs.Must1(authsessions.New(authsessions.Configs.Dev))
+	tokens := kittehs.Must1(authtokensjwt.New(authtokensjwt.Configs.Dev))
+	users := &sdktest.TestUsers{}
+
+	mw := New(Deps{
+		Sessions: sessions,
+		Tokens:   tokens,
+		Users:    users,
+		Cfg:      &Config{UseDefaultUser: false},
+	})(h)
+
+	// no auth - reject.
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Nil(t, check())
+
+	// correct token, but no such user.
+	tok1 := kittehs.Must1(tokens.Create(testUser1))
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok1, nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Nil(t, check())
+
+	// correct token, but no such user.
+	w = httptest.NewRecorder()
+	sessions.Set(w, authsessions.NewSessionData(testUser1.ID()))
+	cookies := w.Result().Cookies()
+
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", cookies))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Nil(t, check())
+
+	// create a disabled user.
+	users.Users = map[sdktypes.UserID]sdktypes.User{
+		testUser1.ID(): testUser1.WithDisabled(true),
+	}
+
+	// correct token, user is disabled.
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok1, nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Nil(t, check())
+
+	// correct session, user is disabled.
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", cookies))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Nil(t, check())
+
+	// enable the user.
+	users.Users = map[sdktypes.UserID]sdktypes.User{
+		testUser1.ID(): testUser1,
+	}
+
+	// correct token, user is ok.
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok1, nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assertCalledWithUser(t, testUser1.ID(), check())
+
+	// correct session, user is ok.
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", cookies))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assertCalledWithUser(t, testUser1.ID(), check())
+
+	// both token and session for same user.
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok1, cookies))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assertCalledWithUser(t, testUser1.ID(), check())
+
+	// token for token user, session for other user.
+	// token > session.
+	users.Users[testUser2.ID()] = testUser2
+	w = httptest.NewRecorder()
+	tok2 := kittehs.Must1(tokens.Create(testUser2))
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok2, cookies))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assertCalledWithUser(t, testUser2.ID(), check())
+
+	// token for token user who is disabled, session for other user.
+	// token > session, and is rejected.
+	users.Users[testUser2.ID()] = testUser2.WithDisabled(true)
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok2, cookies))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Nil(t, check())
+}
+
+func TestNewWithDefaultUser(t *testing.T) {
+	h, check := newOverallTestHandler(t)
+
+	sessions := kittehs.Must1(authsessions.New(authsessions.Configs.Dev))
+	tokens := kittehs.Must1(authtokensjwt.New(authtokensjwt.Configs.Dev))
+	users := &sdktest.TestUsers{
+		Users: map[sdktypes.UserID]sdktypes.User{
+			authusers.DefaultUser.ID(): authusers.DefaultUser,
+		},
+	}
+
+	mw := New(Deps{
+		Sessions: sessions,
+		Tokens:   tokens,
+		Users:    users,
+		Cfg:      &Config{UseDefaultUser: true},
+	})(h)
+
+	// no auth.
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assertCalledWithUser(t, authusers.DefaultUser.ID(), check())
+
+	// correct token, but no such user.
+	tok1 := kittehs.Must1(tokens.Create(testUser1))
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok1, nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Nil(t, check())
+
+	// correct session, but no such user.
+	w = httptest.NewRecorder()
+	sessions.Set(w, authsessions.NewSessionData(testUser1.ID()))
+	cookies := w.Result().Cookies()
+
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", cookies))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Nil(t, check())
+
+	// create a disabled user.
+	users.Users[testUser1.ID()] = testUser1.WithDisabled(true)
+
+	// correct token, user is disabled.
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok1, nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Nil(t, check())
+
+	// correct token, user is disabled.
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", cookies))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Nil(t, check())
+
+	// enable the user.
+	users.Users = map[sdktypes.UserID]sdktypes.User{
+		testUser1.ID(): testUser1,
+	}
+
+	// correct token, user is ok.
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok1, nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assertCalledWithUser(t, testUser1.ID(), check())
+
+	// correct session, user is ok.
+	w = httptest.NewRecorder()
+	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", cookies))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assertCalledWithUser(t, testUser1.ID(), check())
+}

--- a/internal/backend/auth/authtokens/authtokensjwt/jwt.go
+++ b/internal/backend/auth/authtokens/authtokensjwt/jwt.go
@@ -1,4 +1,4 @@
-package authjwttokens
+package authtokensjwt
 
 import (
 	"encoding/hex"

--- a/internal/backend/auth/authz/context.go
+++ b/internal/backend/auth/authz/context.go
@@ -35,6 +35,8 @@ func getContextCheckFunc(ctx context.Context) CheckFunc {
 
 func CheckContext(ctx context.Context, id sdktypes.ID, action string, opts ...func(*checkCfg)) error {
 	if authcontext.IsAuthnSystemUser(ctx) {
+		// When system user is specified there is usually no authz check in context, so we should
+		// just make it all approved here.
 		return nil
 	}
 

--- a/internal/backend/svc/svc.go
+++ b/internal/backend/svc/svc.go
@@ -20,10 +20,10 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/backend/applygrpcsvc"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authgrpcsvc"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authhttpmiddleware"
-	"go.autokitteh.dev/autokitteh/internal/backend/auth/authjwttokens"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authloginhttpsvc"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authsessions"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authsvc"
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authtokens/authtokensjwt"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authz"
 	"go.autokitteh.dev/autokitteh/internal/backend/builds"
 	"go.autokitteh.dev/autokitteh/internal/backend/buildsgrpcsvc"
@@ -138,7 +138,7 @@ func makeFxOpts(cfg *Config, opts RunOptions) []fx.Option {
 		DBFxOpt(),
 
 		Component("auth", configset.Empty, fx.Provide(authsvc.New)),
-		Component("authjwttokens", authjwttokens.Configs, fx.Provide(authjwttokens.New)),
+		Component("authtokensjwt", authtokensjwt.Configs, fx.Provide(authtokensjwt.New)),
 		Component("authsessions", authsessions.Configs, fx.Provide(authsessions.New)),
 		Component(
 			"authhttpmiddleware",

--- a/internal/backend/users/users.go
+++ b/internal/backend/users/users.go
@@ -18,7 +18,7 @@ import (
 
 type Config struct {
 	// If set, do not create a personal org for new users. Instead, set this as their default org.
-	// This is useful for single tenants setups where all users belong to the same org.
+	// This is useful for single-tenant setups where all users belong to the same org.
 	DefaultOrgID string `json:"default_org_id"`
 }
 

--- a/sdk/sdktest/users.go
+++ b/sdk/sdktest/users.go
@@ -1,0 +1,29 @@
+package sdktest
+
+import (
+	"context"
+
+	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+// TestUsers is a test implementation of the Users service.
+type TestUsers struct {
+	Users map[sdktypes.UserID]sdktypes.User
+}
+
+func (t *TestUsers) Create(_ context.Context, user sdktypes.User) (sdktypes.UserID, error) {
+	return sdktypes.InvalidUserID, sdkerrors.ErrNotImplemented
+}
+
+func (t *TestUsers) Get(_ context.Context, id sdktypes.UserID, email string) (sdktypes.User, error) {
+	if user, ok := t.Users[id]; ok {
+		return user, nil
+	}
+
+	return sdktypes.InvalidUser, sdkerrors.ErrNotFound
+}
+
+func (t *TestUsers) Update(_ context.Context, user sdktypes.User) error {
+	return sdkerrors.ErrNotImplemented
+}

--- a/tests/system/auth.go
+++ b/tests/system/auth.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"go.autokitteh.dev/autokitteh/internal/backend/auth/authjwttokens"
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authtokens/authtokensjwt"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
@@ -30,7 +30,7 @@ var (
 )
 
 func init() {
-	js := kittehs.Must1(authjwttokens.New(authjwttokens.Configs.Test))
+	js := kittehs.Must1(authtokensjwt.New(authtokensjwt.Configs.Test))
 
 	// org name -> org id.
 	orgs := make(map[string]uuid.UUID)


### PR DESCRIPTION
simplified authentication workflow, now well defined behaviour of priorities between session, tokens and default user, as well as enforced in testing.

this is not a pure refactor - default user is now used only when not authenticated by any other mean. prior - default user was always used and rejected other authn methods.