### PR TITLE
fix(scheduler): remove erronous authz check on delete

### DIFF
--- a/internal/backend/scheduler/scheduler.go
+++ b/internal/backend/scheduler/scheduler.go
@@ -11,7 +11,6 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authcontext"
-	"go.autokitteh.dev/autokitteh/internal/backend/auth/authz"
 	"go.autokitteh.dev/autokitteh/internal/backend/configset"
 	"go.autokitteh.dev/autokitteh/internal/backend/temporalclient"
 	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
@@ -98,10 +97,6 @@ func (sch *Scheduler) Create(ctx context.Context, tid sdktypes.TriggerID, schedu
 }
 
 func (sch *Scheduler) Delete(ctx context.Context, tid sdktypes.TriggerID) error {
-	if err := authz.CheckContext(ctx, tid, "write:delete-schedule"); err != nil {
-		return err
-	}
-
 	sl := sch.sl.With("trigger_id", tid)
 
 	scheduleHandle := sch.temporal.Temporal().ScheduleClient().GetHandle(ctx, tid.String()) // validity of scheduleID is not checked by temporal


### PR DESCRIPTION
check would always fail since trigger is deleted by time this function is called. also there are no other checks in the module since the check is performed in the triggers module. this is a left over check i forgot to remove when i refactored this some time ago.

Ref: ENG-1929