### PR TITLE
refactor: auto fixes from golangci-lint

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           # Keep the same version in "/Makefile"!
           # See: https://github.com/golangci/golangci-lint
-          version: v1.60.3
+          version: v1.63.1
           # https://github.com/golangci/golangci-lint-action/issues/308
           args: --timeout=5m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
     - gocritic
     - intrange
     - loggercheck
-    - misspell
     - nosprintfhostport
     - perfsprint
     - unconvert

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,33 @@
+linters:
+  disable-all: true
+  enable:
+    # Enabled by Default.
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    # Disabled by Default, but useful for us.
+    - errname
+    - gci
+    - gocritic
+    - intrange
+    - loggercheck
+    - misspell
+    - nosprintfhostport
+    - perfsprint
+    - unconvert
+    - usestdlibvars
+
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(go.autokitteh.dev/autokitteh)
+  loggercheck:
+    zap: true
+
+issues:
+  new: false

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ golangci_lint=$(shell which golangci-lint)
 $(OUTDIR)/tools/golangci-lint:
 	mkdir -p $(OUTDIR)/tools
 ifeq ($(golangci_lint),)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(OUTDIR)/tools" v1.60.3
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(OUTDIR)/tools" v1.63.1
 else
 	ln -fs $(golangci_lint) $(OUTDIR)/tools/golangci-lint
 endif

--- a/cmd/ak/cmd/auth/login.go
+++ b/cmd/ak/cmd/auth/login.go
@@ -6,11 +6,10 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 
 	"go.autokitteh.dev/autokitteh/cmd/ak/common"
-
-	"github.com/pkg/browser"
 )
 
 var loginCmd = common.StandardCommand(&cobra.Command{

--- a/cmd/ak/cmd/deploy.go
+++ b/cmd/ak/cmd/deploy.go
@@ -43,7 +43,7 @@ var deployCmd = common.StandardCommand(&cobra.Command{
 				return err
 			}
 		} else if projectName != "" {
-			return fmt.Errorf("project name provided without manifest")
+			return errors.New("project name provided without manifest")
 		}
 
 		pid, err := r.ProjectNameOrID(ctx, project)
@@ -64,7 +64,7 @@ var deployCmd = common.StandardCommand(&cobra.Command{
 		// Step 2: build the project (see also the "build" and "project" parent commands).
 		if len(dirPaths) == 0 && len(filePaths) == 0 {
 			if manifestPath == "" {
-				return fmt.Errorf("no dir/file paths provided")
+				return errors.New("no dir/file paths provided")
 			}
 			dirPaths = append(dirPaths, filepath.Dir(manifestPath))
 		}

--- a/cmd/ak/cmd/events/verify.go
+++ b/cmd/ak/cmd/events/verify.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"go.autokitteh.dev/autokitteh/cmd/ak/common"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )

--- a/cmd/ak/cmd/runtimes/run.go
+++ b/cmd/ak/cmd/runtimes/run.go
@@ -51,7 +51,7 @@ var runCmd = common.StandardCommand(&cobra.Command{
 
 			a := txtar.Parse(bs)
 			if len(a.Files) == 0 {
-				return fmt.Errorf("empty txtar archive")
+				return errors.New("empty txtar archive")
 			}
 
 			fs, err := kittehs.TxtarToFS(a)

--- a/cmd/ak/cmd/runtimes/test.go
+++ b/cmd/ak/cmd/runtimes/test.go
@@ -44,7 +44,7 @@ var testCmd = common.StandardCommand(&cobra.Command{
 
 		a := txtar.Parse(bs)
 		if len(a.Files) == 0 {
-			return fmt.Errorf("empty txtar archive")
+			return errors.New("empty txtar archive")
 		}
 
 		expectedPrints = strings.TrimRight(string(a.Comment), "\n")

--- a/cmd/ak/cmd/sessions/log.go
+++ b/cmd/ak/cmd/sessions/log.go
@@ -101,7 +101,7 @@ func printLogs(logs []sdktypes.SessionLogRecord) {
 			} else if state := r.GetState(); state.IsValid() && state.Type() == sdktypes.SessionStateTypeError {
 				if stateErr := state.GetError(); stateErr.IsValid() {
 					pe := stateErr.GetProgramError()
-					msg = fmt.Sprintf("Error: %s", pe.ErrorString())
+					msg = "Error: " + pe.ErrorString()
 				}
 			}
 

--- a/cmd/ak/cmd/sessions/test.go
+++ b/cmd/ak/cmd/sessions/test.go
@@ -48,12 +48,12 @@ var testCmd = common.StandardCommand(&cobra.Command{
 
 		a := txtar.Parse(bs)
 		if len(a.Files) == 0 {
-			return fmt.Errorf("empty txtar archive")
+			return errors.New("empty txtar archive")
 		}
 
 		if !ep.IsValid() {
 			if len(a.Files) == 0 {
-				return fmt.Errorf("no entrypoint specified and no files found in txtar archive")
+				return errors.New("no entrypoint specified and no files found in txtar archive")
 			}
 
 			if ep, err = sdktypes.StrictParseCodeLocation(a.Files[0].Name); err != nil {

--- a/cmd/ak/cmd/up.go
+++ b/cmd/ak/cmd/up.go
@@ -3,9 +3,8 @@ package cmd
 import (
 	"fmt"
 
-	"go.uber.org/automaxprocs/maxprocs"
-
 	"github.com/spf13/cobra"
+	"go.uber.org/automaxprocs/maxprocs"
 
 	"go.autokitteh.dev/autokitteh/cmd/ak/common"
 )

--- a/cmd/ak/cmd/version.go
+++ b/cmd/ak/cmd/version.go
@@ -26,16 +26,16 @@ func (v Version) String() string {
 	w.WriteString(v.Version)
 
 	if v.Commit != "" {
-		w.WriteString(fmt.Sprintf(" %s", v.Commit))
+		w.WriteString(" " + v.Commit)
 	}
 	if v.Date != "" {
-		w.WriteString(fmt.Sprintf(" %s", v.Date))
+		w.WriteString(" " + v.Date)
 	}
 	if v.User != "" {
-		w.WriteString(fmt.Sprintf(" by %s", v.User))
+		w.WriteString(" by " + v.User)
 	}
 	if v.Host != "" {
-		w.WriteString(fmt.Sprintf(" on %s", v.Host))
+		w.WriteString(" on " + v.Host)
 	}
 	if v.BuildInfo != nil {
 		w.WriteString(fmt.Sprintf("\n\n%v", v.BuildInfo))

--- a/cmd/ak/common/consume.go
+++ b/cmd/ak/common/consume.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -20,7 +21,7 @@ func Consume(args []string) (data []byte, path string, err error) {
 			err = NewExitCodeError(NotFoundExitCode, err)
 		}
 	default:
-		return nil, "", fmt.Errorf("too many arguments")
+		return nil, "", errors.New("too many arguments")
 	}
 
 	return

--- a/cmd/ak/common/exit.go
+++ b/cmd/ak/common/exit.go
@@ -60,7 +60,7 @@ func ToExitCode(err error) (code int) {
 		code = UnauthenticatedExitCode
 	case errors.Is(err, sdkerrors.ErrNotFound):
 		code = NotFoundExitCode
-	case errors.As(err, resolver.NotFoundErrorType):
+	case errors.As(err, resolver.ErrNotFound):
 		code = NotFoundExitCode
 	case errors.Is(err, sdkerrors.ErrFailedPrecondition):
 		code = FailedPreconditionExitCode
@@ -82,7 +82,7 @@ func WrapError(err error, whats ...string) error {
 	case errors.Is(err, sdkerrors.ErrNotFound):
 		// Replace "not found" with "<whats> not found".
 		return fmt.Errorf("%s: %w", strings.Join(whats, " "), sdkerrors.ErrNotFound)
-	case errors.As(err, resolver.NotFoundErrorType):
+	case errors.As(err, resolver.ErrNotFound):
 		// Replace "<type> [name] not found" with "<whats> not found".
 		return fmt.Errorf("%s: %w", strings.Join(whats, " "), sdkerrors.ErrNotFound)
 	case errors.Is(err, sdkerrors.ErrFailedPrecondition):

--- a/integrations/asana/client.go
+++ b/integrations/asana/client.go
@@ -5,13 +5,14 @@ import (
 	"io"
 	"net/http"
 
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/integrations"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.uber.org/zap"
 )
 
 type integration struct{ vars sdkservices.Vars }
@@ -95,7 +96,7 @@ func connTest(i *integration) sdkintegrations.OptFn {
 			return sdktypes.InvalidStatus, err
 		}
 
-		req, err := http.NewRequest("GET", "https://app.asana.com/api/1.0/users/me", nil)
+		req, err := http.NewRequest(http.MethodGet, "https://app.asana.com/api/1.0/users/me", nil)
 		if err != nil {
 			return sdktypes.InvalidStatus, err
 		}

--- a/integrations/asana/save.go
+++ b/integrations/asana/save.go
@@ -5,10 +5,11 @@ import (
 	"net/http"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/integrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.uber.org/zap"
 )
 
 const (
@@ -45,7 +46,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Test the PAT's usability
-	req, err := http.NewRequest("GET", "https://app.asana.com/api/1.0/users/me", nil)
+	req, err := http.NewRequest(http.MethodGet, "https://app.asana.com/api/1.0/users/me", nil)
 	if err != nil {
 		l.Error("Failed to create HTTP request", zap.Error(err))
 		c.AbortServerError("request creation error")

--- a/integrations/atlassian/confluence/client.go
+++ b/integrations/atlassian/confluence/client.go
@@ -3,13 +3,14 @@ package confluence
 import (
 	"context"
 
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/integrations"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.uber.org/zap"
 )
 
 type integration struct {

--- a/integrations/atlassian/confluence/event.go
+++ b/integrations/atlassian/confluence/event.go
@@ -130,10 +130,10 @@ func extractEntityType(l *zap.Logger, atlassianEvent map[string]any, category st
 
 	// Some "attachment_*" and "relation_*" events look a little different.
 	if _, ok := atlassianEvent["attachments"]; ok {
-		return fmt.Sprintf("attachment_%s", category), true
+		return "attachment_" + category, true
 	}
 	if _, ok := atlassianEvent["relationData"]; ok {
-		return fmt.Sprintf("relation_%s", category), true
+		return "relation_" + category, true
 	}
 
 	// Last but not least: "content_*" events.

--- a/integrations/atlassian/confluence/oauth.go
+++ b/integrations/atlassian/confluence/oauth.go
@@ -94,8 +94,8 @@ type resource struct {
 // https://developer.atlassian.com/cloud/confluence/oauth-2-3lo-apps/#3--make-calls-to-the-api-using-the-access-token
 // https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/#3--make-calls-to-the-api-using-the-access-token
 func accessibleResources(l *zap.Logger, baseURL string, token string) ([]resource, error) {
-	u := fmt.Sprintf("%s/oauth/token/accessible-resources", baseURL)
-	req, err := http.NewRequest("GET", u, nil)
+	u := baseURL + "/oauth/token/accessible-resources"
+	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
 		logWarnIfNotNil(l, "Failed to construct HTTP request for OAuth token test", zap.Error(err))
 		return nil, err

--- a/integrations/atlassian/confluence/save.go
+++ b/integrations/atlassian/confluence/save.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"go.uber.org/zap"
@@ -94,7 +95,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 		initData = initData.Set(webhookSecret(category), secret, true)
 		// }
 
-		initData = initData.Set(webhookID(category), fmt.Sprintf("%d", id), false)
+		initData = initData.Set(webhookID(category), strconv.Itoa(id), false)
 	}
 
 	c.Finalize(initData)

--- a/integrations/atlassian/confluence/webhooks.go
+++ b/integrations/atlassian/confluence/webhooks.go
@@ -110,7 +110,7 @@ var webhookEvents = map[string][]string{
 // https://confluence.atlassian.com/doc/managing-webhooks-1021225606.html
 func getWebhook(l *zap.Logger, base, user, key, category string) (int, bool) {
 	// TODO(ENG-965): Support pagination.
-	req, err := http.NewRequest("GET", base+restPath, nil)
+	req, err := http.NewRequest(http.MethodGet, base+restPath, nil)
 	if err != nil {
 		l.Warn("Failed to construct HTTP request to list Confluence webhooks", zap.Error(err))
 		return 0, false
@@ -190,7 +190,7 @@ func registerWebhook(l *zap.Logger, base, user, key, category string) (int, stri
 	}
 
 	jsonReader := bytes.NewReader(body)
-	req, err := http.NewRequest("POST", base+restPath, jsonReader)
+	req, err := http.NewRequest(http.MethodPost, base+restPath, jsonReader)
 	if err != nil {
 		l.Warn("Failed to construct HTTP request to register Confluence webhook", zap.Error(err))
 		return 0, "", err
@@ -258,7 +258,7 @@ func extractIDSuffixFromURL(url string) (int, error) {
 
 func deleteWebhook(l *zap.Logger, base, user, key string, id int) error {
 	url := fmt.Sprintf("%s%s/%d", base, restPath, id)
-	req, err := http.NewRequest("DELETE", url, nil)
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
 		l.Error("Failed to construct HTTP request to delete Confluence webhook", zap.Error(err))
 		return err

--- a/integrations/atlassian/jira/client.go
+++ b/integrations/atlassian/jira/client.go
@@ -3,13 +3,14 @@ package jira
 import (
 	"context"
 
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/integrations"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.uber.org/zap"
 )
 
 type integration struct {

--- a/integrations/atlassian/jira/event.go
+++ b/integrations/atlassian/jira/event.go
@@ -3,10 +3,11 @@ package jira
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -110,7 +111,7 @@ func (h handler) handleEvent(w http.ResponseWriter, r *http.Request) {
 
 	ctx := extrazap.AttachLoggerToContext(l, r.Context())
 	for _, id := range ids {
-		value := fmt.Sprintf("%d", id)
+		value := strconv.Itoa(id)
 		cids, err := h.vars.FindConnectionIDs(ctx, integrationID, webhookID, value)
 		if err != nil {
 			l.Error("Failed to find connection IDs", zap.Error(err))
@@ -159,7 +160,7 @@ func constructEvent(l *zap.Logger, jiraEvent map[string]any) (sdktypes.Event, er
 	eventType, ok := jiraEvent["webhookEvent"].(string)
 	if !ok {
 		l.Error("Invalid event type")
-		return sdktypes.InvalidEvent, fmt.Errorf("invalid event type")
+		return sdktypes.InvalidEvent, errors.New("invalid event type")
 	}
 
 	akEvent, err := sdktypes.EventFromProto(&sdktypes.EventPB{

--- a/integrations/atlassian/jira/oauth.go
+++ b/integrations/atlassian/jira/oauth.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 
 	"go.uber.org/zap"
 
@@ -91,7 +92,7 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	c.Finalize(sdktypes.NewVars(data.ToVars()...).Append(res[0].toVars()...).
-		Set(webhookID, fmt.Sprintf("%d", id), false).
+		Set(webhookID, strconv.Itoa(id), false).
 		Set(webhookExpiration, t.String(), false))
 }
 
@@ -117,8 +118,8 @@ type resource struct {
 // OAuth token, which is necessary for API calls and webhook events. Based on:
 // https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/#3--make-calls-to-the-api-using-the-access-token
 func accessibleResources(l *zap.Logger, baseURL string, token string) ([]resource, error) {
-	u := fmt.Sprintf("%s/oauth/token/accessible-resources", baseURL)
-	req, err := http.NewRequest("GET", u, nil)
+	u := baseURL + "/oauth/token/accessible-resources"
+	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
 		logWarnIfNotNil(l, "Failed to construct HTTP request for OAuth token test", zap.Error(err))
 		return nil, err

--- a/integrations/atlassian/jira/webhooks.go
+++ b/integrations/atlassian/jira/webhooks.go
@@ -83,7 +83,7 @@ type webhookListResponse struct {
 // https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-webhooks/
 func getWebhook(l *zap.Logger, base, token string) (int, bool) {
 	// TODO(ENG-965): Support pagination.
-	req, err := http.NewRequest("GET", base+"/rest/api/3/webhook", nil)
+	req, err := http.NewRequest(http.MethodGet, base+"/rest/api/3/webhook", nil)
 	if err != nil {
 		l.Warn("Failed to construct HTTP request to list Jira webhooks", zap.Error(err))
 		return 0, false
@@ -183,7 +183,7 @@ func registerWebhook(l *zap.Logger, base, token string) (int, bool) {
 	}
 
 	jsonReader := bytes.NewReader(body)
-	req, err := http.NewRequest("POST", base+"/rest/api/3/webhook", jsonReader)
+	req, err := http.NewRequest(http.MethodPost, base+"/rest/api/3/webhook", jsonReader)
 	if err != nil {
 		l.Error("Failed to construct HTTP request to register Jira webhook", zap.Error(err))
 		return 0, false
@@ -243,7 +243,7 @@ type webhookRefreshResponse struct {
 // extendWebhookLife extends the expiration date of the given webhook ID by 30 days.
 func extendWebhookLife(l *zap.Logger, baseURL, oauthToken string, id int) (time.Time, bool) {
 	jsonReader := bytes.NewReader([]byte(fmt.Sprintf(`{"webhookIds": [%d]}`, id)))
-	req, err := http.NewRequest("PUT", baseURL+"/rest/api/3/webhook/refresh", jsonReader)
+	req, err := http.NewRequest(http.MethodPut, baseURL+"/rest/api/3/webhook/refresh", jsonReader)
 	if err != nil {
 		l.Error("Failed to construct HTTP request to refresh Jira webhook", zap.Error(err))
 		return time.Time{}, false

--- a/integrations/auth0/client.go
+++ b/integrations/auth0/client.go
@@ -3,13 +3,14 @@ package auth0
 import (
 	"context"
 
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/integrations"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.uber.org/zap"
 )
 
 type integration struct{ vars sdkservices.Vars }

--- a/integrations/auth0/oauth.go
+++ b/integrations/auth0/oauth.go
@@ -6,11 +6,12 @@ import (
 	"io"
 	"net/http"
 
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/integrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.uber.org/zap"
 )
 
 type handler struct {
@@ -70,7 +71,7 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Tests OAuth0's Management API.
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/api/v2/roles", d), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s/api/v2/roles", d), nil)
 
 	if err != nil {
 		l.Error("Failed to create HTTP request", zap.Error(err))
@@ -78,7 +79,7 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", oauthToken.AccessToken))
+	req.Header.Set("Authorization", "Bearer "+oauthToken.AccessToken)
 
 	client := &http.Client{}
 	resp, err := client.Do(req)

--- a/integrations/auth0/save.go
+++ b/integrations/auth0/save.go
@@ -6,9 +6,10 @@ import (
 	"net/http"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.uber.org/zap"
 )
 
 const (

--- a/integrations/github/jwt.go
+++ b/integrations/github/jwt.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -37,7 +38,7 @@ func newClientWithInstallJWT(data sdktypes.Vars) (*github.Client, error) {
 	// Initialize and return a GitHub client with a JWT.
 	s := data.GetValue(vars.AppID)
 	if s == "" {
-		return nil, fmt.Errorf("app ID not found")
+		return nil, errors.New("app ID not found")
 	}
 	aid, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
@@ -46,7 +47,7 @@ func newClientWithInstallJWT(data sdktypes.Vars) (*github.Client, error) {
 
 	s = data.GetValue(vars.InstallID)
 	if s == "" {
-		return nil, fmt.Errorf("install ID not found")
+		return nil, errors.New("install ID not found")
 	}
 	iid, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {

--- a/integrations/github/oauth.go
+++ b/integrations/github/oauth.go
@@ -118,7 +118,7 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	name := string(*i.Account.Login)
+	name := *i.Account.Login
 
 	events := fmt.Sprintf("%s", i.Events)
 	events = events[1 : len(events)-1]
@@ -132,12 +132,12 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 
 	c.Finalize(sdktypes.NewVars().
 		Set(vars.AppID, appID, false).
-		Set(vars.AppName, string(*i.AppSlug), false).
+		Set(vars.AppName, *i.AppSlug, false).
 		Set(vars.InstallID, installID, false).
 		Set(vars.TargetID, strconv.FormatInt(*i.TargetID, 10), false).
 		Set(vars.TargetName, name, false).
-		Set(vars.TargetType, string(*i.TargetType), false).
-		Set(vars.RepoSelection, string(*i.RepositorySelection), false).
+		Set(vars.TargetType, *i.TargetType, false).
+		Set(vars.RepoSelection, *i.RepositorySelection, false).
 		Set(vars.Permissions, ps, false).
 		Set(vars.Events, events, false).
 		Set(vars.UpdatedAt, i.UpdatedAt.Format(time.RFC3339), false).

--- a/integrations/google/calendar/watches.go
+++ b/integrations/google/calendar/watches.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"strconv"
 
+	"go.uber.org/zap"
+	"google.golang.org/api/calendar/v3"
+
 	"go.autokitteh.dev/autokitteh/integrations/google/internal/vars"
 	"go.autokitteh.dev/autokitteh/integrations/internal/extrazap"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.uber.org/zap"
-	"google.golang.org/api/calendar/v3"
 )
 
 // UpdateWatches creates or renews calendar watches for a specific

--- a/integrations/google/connections/connections.go
+++ b/integrations/google/connections/connections.go
@@ -5,14 +5,15 @@ import (
 	"io"
 	"net/http"
 
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+
 	"go.autokitteh.dev/autokitteh/integrations"
 	"go.autokitteh.dev/autokitteh/integrations/google/internal/vars"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.uber.org/zap"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 )
 
 // connStatus is an optional connection status check provided by

--- a/integrations/google/gemini/client.go
+++ b/integrations/google/gemini/client.go
@@ -3,6 +3,10 @@ package gemini
 import (
 	"context"
 
+	"github.com/google/generative-ai-go/genai"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+
 	"go.autokitteh.dev/autokitteh/integrations"
 	"go.autokitteh.dev/autokitteh/integrations/google/internal/vars"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
@@ -10,10 +14,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-
-	"github.com/google/generative-ai-go/genai"
-	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
 )
 
 var integrationID = sdktypes.NewIntegrationIDFromName("googlegemini")

--- a/integrations/hubspot/client.go
+++ b/integrations/hubspot/client.go
@@ -2,8 +2,9 @@ package hubspot
 
 import (
 	"context"
-	"fmt"
 	"net/http"
+
+	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/integrations"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
@@ -11,7 +12,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.uber.org/zap"
 )
 
 type integration struct{ vars sdkservices.Vars }
@@ -93,8 +93,8 @@ func connTest(i *integration) sdkintegrations.OptFn {
 		}
 
 		token := vs.GetValueByString("oauth_RefreshToken")
-		url := fmt.Sprintf("https://api.hubapi.com/oauth/v1/refresh-tokens/%s", token)
-		req, err := http.NewRequest("GET", url, nil)
+		url := "https://api.hubapi.com/oauth/v1/refresh-tokens/" + token
+		req, err := http.NewRequest(http.MethodGet, url, nil)
 		if err != nil {
 			return sdktypes.NewStatus(sdktypes.StatusCodeError, err.Error()), nil
 		}

--- a/integrations/hubspot/oauth.go
+++ b/integrations/hubspot/oauth.go
@@ -4,10 +4,11 @@ import (
 	"errors"
 	"net/http"
 
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.uber.org/zap"
 )
 
 // handler is an autokitteh webhook which implements [http.Handler]
@@ -48,7 +49,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Test the OAuth token's usability and get authoritative installation details.
-	req, err := http.NewRequest("GET", "https://api.hubapi.com/crm/v3/owners/", nil)
+	req, err := http.NewRequest(http.MethodGet, "https://api.hubapi.com/crm/v3/owners/", nil)
 	if err != nil {
 		l.Error("Failed to create HTTP request", zap.Error(err))
 		c.AbortServerError("request creation error")

--- a/integrations/redis/clients.go
+++ b/integrations/redis/clients.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -39,7 +40,7 @@ func loadConfig() *Config {
 
 	// See https://github.com/knadh/koanf#reading-environment-variables.
 	kittehs.Must0(k.Load(env.Provider(prefix, ".", func(s string) string {
-		return strings.Replace(strings.ToLower(strings.TrimPrefix(s, prefix)), "_", ".", -1)
+		return strings.ReplaceAll(strings.ToLower(strings.TrimPrefix(s, prefix)), "_", ".")
 	}), nil))
 
 	config := defaultConfig
@@ -79,7 +80,7 @@ func (m *module) externalClient(ctx context.Context) (*redis.Client, error) {
 
 	urlVar := vars.Get(urlVarName)
 	if !urlVar.IsValid() {
-		return nil, fmt.Errorf("missing URL var")
+		return nil, errors.New("missing URL var")
 	}
 
 	url := urlVar.Value()

--- a/integrations/redis/redis.go
+++ b/integrations/redis/redis.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -115,7 +116,7 @@ func makeOpts(m *module) []sdkmodule.Optfn {
 // This function is not included in the integration when used as an internal client. See `NewModule`.
 func (m *module) do(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
 	if len(kwargs) != 0 {
-		return sdktypes.InvalidValue, fmt.Errorf("not expecting kwargs")
+		return sdktypes.InvalidValue, errors.New("not expecting kwargs")
 	}
 
 	unwrappedArgs := make([]any, len(args))

--- a/integrations/redis/utils.go
+++ b/integrations/redis/utils.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"encoding"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -30,12 +31,12 @@ func unwrap(v sdktypes.Value) (any, error) {
 		// just using unwrapped is fine, no need to modify it.
 	case encoding.BinaryMarshaler:
 		// TODO: figure out how it's used in the redis client.
-		return nil, fmt.Errorf("unhandled type")
+		return nil, errors.New("unhandled type")
 	case net.IP:
 		// TODO: return w.bytes(v)
-		return nil, fmt.Errorf("unhandled type")
+		return nil, errors.New("unhandled type")
 	default:
-		return nil, fmt.Errorf("unhandled type")
+		return nil, errors.New("unhandled type")
 	}
 
 	return u, nil

--- a/integrations/slack/api/bookmarks/methods.go
+++ b/integrations/slack/api/bookmarks/methods.go
@@ -3,11 +3,10 @@ package bookmarks
 import (
 	"context"
 
+	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-
-	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 )
 
 type API struct {

--- a/integrations/slack/api/conversations/methods.go
+++ b/integrations/slack/api/conversations/methods.go
@@ -5,11 +5,10 @@ import (
 	"net/url"
 	"strconv"
 
+	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-
-	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 )
 
 type API struct {

--- a/integrations/slack/api/reactions/methods.go
+++ b/integrations/slack/api/reactions/methods.go
@@ -3,11 +3,10 @@ package reactions
 import (
 	"context"
 
+	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-
-	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 )
 
 type API struct {

--- a/integrations/slack/api/users/methods.go
+++ b/integrations/slack/api/users/methods.go
@@ -5,11 +5,10 @@ import (
 	"net/url"
 	"strconv"
 
+	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-
-	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 )
 
 type API struct {

--- a/integrations/slack/client.go
+++ b/integrations/slack/client.go
@@ -3,6 +3,8 @@ package slack
 import (
 	"context"
 
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/integrations"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/auth"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/bookmarks"
@@ -17,7 +19,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.uber.org/zap"
 )
 
 var integrationID = sdktypes.NewIntegrationIDFromName("slack")

--- a/integrations/slack/webhooks/webhook_test.go
+++ b/integrations/slack/webhooks/webhook_test.go
@@ -2,7 +2,6 @@ package webhooks
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -58,7 +57,7 @@ func TestWebhookCheckRequest(t *testing.T) {
 			name:            "X-Slack-Request-Timestamp_in_the_past",
 			gotContentType:  api.ContentTypeForm,
 			wantContentType: api.ContentTypeForm,
-			timestampHeader: fmt.Sprintf("%d", time.Now().Add(-time.Hour).Unix()),
+			timestampHeader: strconv.FormatInt(time.Now().Add(-time.Hour).Unix(), 10),
 			signatureHeader: "v0=test",
 			r:               nil,
 			want:            nil,

--- a/integrations/slack/websockets/socketmode.go
+++ b/integrations/slack/websockets/socketmode.go
@@ -2,7 +2,6 @@ package websockets
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/slack-go/slack"
@@ -73,7 +72,7 @@ func (h handler) OpenSocketModeConnection(appID, botToken, appToken string) {
 }
 
 func (h handler) socketModeHandler(e *socketmode.Event, c *socketmode.Client) {
-	msg := fmt.Sprintf("Slack Socket Mode event: %s", string(e.Type))
+	msg := "Slack Socket Mode event: " + string(e.Type)
 	switch string(e.Type) {
 	// WebSocket connection flow.
 	case "connecting", "connected":

--- a/integrations/twilio/client.go
+++ b/integrations/twilio/client.go
@@ -3,6 +3,9 @@ package twilio
 import (
 	"context"
 
+	"github.com/twilio/twilio-go"
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/integrations"
 	"go.autokitteh.dev/autokitteh/integrations/twilio/webhooks"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
@@ -10,9 +13,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.uber.org/zap"
-
-	"github.com/twilio/twilio-go"
 )
 
 type integration struct{ vars sdkservices.Vars }

--- a/internal/backend/applygrpcsvc/svc.go
+++ b/internal/backend/applygrpcsvc/svc.go
@@ -2,7 +2,6 @@ package applygrpcsvc
 
 import (
 	"context"
-	"fmt"
 
 	"connectrpc.com/connect"
 
@@ -56,14 +55,14 @@ func (s *server) Apply(ctx context.Context, req *connect.Request[applyv1.ApplyRe
 	var logs []string
 
 	actions, err := manifest.Plan(ctx, man, s.client, manifest.WithLogger(func(msg string) {
-		logs = append(logs, fmt.Sprintf("[plan] %s", msg))
+		logs = append(logs, "[plan] "+msg)
 	}), manifest.WithProjectName(msg.ProjectName), manifest.WithOrgID(oid))
 	if err != nil {
 		return nil, connect.NewError(connect.CodeUnknown, err)
 	}
 
 	effects, err := manifest.Execute(ctx, actions, s.client, func(msg string) {
-		logs = append(logs, fmt.Sprintf("[exec] %s", msg))
+		logs = append(logs, "[exec] "+msg)
 	})
 	if err != nil {
 		return nil, connect.NewError(connect.CodeUnknown, err)

--- a/internal/backend/auth/authcontext/context.go
+++ b/internal/backend/auth/authcontext/context.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authusers"
-
 	"go.autokitteh.dev/autokitteh/sdk/sdklogger"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )

--- a/internal/backend/auth/authhttpmiddleware/authmiddleware_test.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware_test.go
@@ -75,7 +75,7 @@ func newOverallTestHandler(t *testing.T) (http.Handler, func() *sdktypes.UserID)
 }
 
 func newRequest(u sdktypes.User, authHeader string, cookies []*http.Cookie) *http.Request {
-	req := kittehs.Must1(http.NewRequest("GET", "/", nil))
+	req := kittehs.Must1(http.NewRequest(http.MethodGet, "/", nil))
 
 	if u.IsValid() {
 		req = req.WithContext(ctxWithUserID(context.Background(), u.ID()))

--- a/internal/backend/auth/authloginhttpsvc/google.go
+++ b/internal/backend/auth/authloginhttpsvc/google.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/dghubble/gologin/v2/google"
-
 	"golang.org/x/oauth2"
 	googleOAuth2 "golang.org/x/oauth2/google"
 )

--- a/internal/backend/auth/authloginhttpsvc/svc.go
+++ b/internal/backend/auth/authloginhttpsvc/svc.go
@@ -10,6 +10,9 @@ import (
 	"net/url"
 	"strconv"
 
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authcontext"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authloginhttpsvc/web"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authsessions"
@@ -20,9 +23,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-
-	"go.uber.org/fx"
-	"go.uber.org/zap"
 )
 
 type Deps struct {
@@ -71,7 +71,7 @@ func (a *svc) registerRoutes(muxes *muxes.Muxes) error {
 
 	if a.Cfg.Descope.Enabled {
 		if a.Cfg.GithubOAuth.Enabled || a.Cfg.GoogleOAuth.Enabled {
-			return fmt.Errorf("cannot enable descope with other providers enabled")
+			return errors.New("cannot enable descope with other providers enabled")
 		}
 
 		if err := registerDescopeRoutes(muxes.NoAuth, a.Cfg.Descope, a.newSuccessLoginHandler); err != nil {
@@ -156,7 +156,7 @@ func (a *svc) registerRoutes(muxes *muxes.Muxes) error {
 			return
 		}
 
-		http.Redirect(w, r, fmt.Sprintf("vscode://autokitteh.autokitteh/authenticate?token=%s", token), http.StatusFound)
+		http.Redirect(w, r, "vscode://autokitteh.autokitteh/authenticate?token="+token, http.StatusFound)
 	})
 
 	muxes.Auth.HandleFunc("/whoami", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/backend/auth/authsessions/store.go
+++ b/internal/backend/auth/authsessions/store.go
@@ -62,7 +62,7 @@ func New(cfg *Config) (Store, error) {
 
 	domain := cfg.Domain
 	if len(domain) > 0 && !strings.HasPrefix(domain, ".") {
-		domain = fmt.Sprintf(".%s", cfg.Domain)
+		domain = "." + cfg.Domain
 	}
 
 	cookieConfig := sessions.CookieConfig{

--- a/internal/backend/auth/authsessions/store_test.go
+++ b/internal/backend/auth/authsessions/store_test.go
@@ -1,7 +1,6 @@
 package authsessions
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -25,7 +24,7 @@ func newStore(t *testing.T) Store {
 func newRequestWithLoggedInCookie(value string) http.Request {
 	return http.Request{
 		Header: http.Header{
-			"Cookie": []string{fmt.Sprintf("ak_logged_in=%s", value)},
+			"Cookie": []string{"ak_logged_in=" + value},
 		},
 	}
 }

--- a/internal/backend/auth/authz/policy.go
+++ b/internal/backend/auth/authz/policy.go
@@ -3,6 +3,7 @@ package authz
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -41,7 +42,7 @@ func NewPolicyCheckFunc(l *zap.Logger, db db.DB, decide policy.DecideFunc) Check
 
 		decision, ok := result.(bool)
 		if !ok {
-			return fmt.Errorf("authz opa decision: not a boolean")
+			return errors.New("authz opa decision: not a boolean")
 		}
 
 		l := l.With(zap.Any("input", input), zap.Any("result", result))

--- a/internal/backend/builds/metrics.go
+++ b/internal/backend/builds/metrics.go
@@ -1,8 +1,9 @@
 package builds
 
 import (
-	"go.autokitteh.dev/autokitteh/internal/backend/telemetry"
 	"go.opentelemetry.io/otel/metric"
+
+	"go.autokitteh.dev/autokitteh/internal/backend/telemetry"
 )
 
 var buildsCreatedCounter metric.Int64Counter

--- a/internal/backend/connectionsinitsvc/svc.go
+++ b/internal/backend/connectionsinitsvc/svc.go
@@ -151,7 +151,7 @@ func (s Svc) refreshConnection(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.Redirect(w, r, fmt.Sprintf("/connections/%s", id), http.StatusFound)
+	http.Redirect(w, r, "/connections/"+id, http.StatusFound)
 }
 
 func (s Svc) success(w http.ResponseWriter, _ *http.Request) {

--- a/internal/backend/dashboardsvc/render_list.go
+++ b/internal/backend/dashboardsvc/render_list.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"net/http"
 	"sort"
+	"strconv"
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -125,7 +126,7 @@ func genListData[T listItem[M], M proto.Message](scope any, xs []T, drops ...str
 					} else if en := fd.Enum(); en != nil {
 						v = fmt.Sprint(en.Values().ByNumber(fv.Enum()).Name())
 					} else if fd.Cardinality() == protoreflect.Repeated {
-						v = fmt.Sprintf("%d", fv.List().Len())
+						v = strconv.Itoa(fv.List().Len())
 					}
 				} else {
 					v = fmt.Sprint(x.ExtraFields()[n])

--- a/internal/backend/dashboardsvc/render_object.go
+++ b/internal/backend/dashboardsvc/render_object.go
@@ -33,7 +33,7 @@ func renderObject[M proto.Message](w http.ResponseWriter, r *http.Request, title
 		Extra   any
 	}{
 		Title: title,
-		JSON:  template.HTML(json),
+		JSON:  json,
 	}); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/internal/backend/db/dbgorm/connections.go
+++ b/internal/backend/db/dbgorm/connections.go
@@ -2,7 +2,6 @@ package dbgorm
 
 import (
 	"context"
-	"fmt"
 	"maps"
 
 	"github.com/google/uuid"
@@ -37,7 +36,7 @@ func (gdb *gormdb) deleteConnectionsAndVars(ctx context.Context, what string, id
 	var ids []uuid.UUID
 	q := gdb.db.WithContext(ctx).Model(&scheme.Connection{})
 	q = q.Clauses(clause.Returning{Columns: []clause.Column{{Name: "connection_id"}}})
-	if err := q.Delete(&ids, fmt.Sprintf("%s = ?", what), id).Error; err != nil {
+	if err := q.Delete(&ids, what+" = ?", id).Error; err != nil {
 		return err
 		// REVIEW: proceed to vars deletion if there are any?
 	}

--- a/internal/backend/db/dbgorm/dbgorm.go
+++ b/internal/backend/db/dbgorm/dbgorm.go
@@ -8,13 +8,12 @@ import (
 	"sync"
 	"time"
 
+	_ "ariga.io/atlas-provider-gorm/gormschema"
 	"github.com/google/uuid"
 	"github.com/pressly/goose/v3"
 	"go.jetify.com/typeid"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-
-	_ "ariga.io/atlas-provider-gorm/gormschema"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authusers"
 	"go.autokitteh.dev/autokitteh/internal/backend/db"
@@ -63,7 +62,7 @@ func New(z *zap.Logger, cfg *Config) (db.DB, error) {
 
 func (db *gormdb) GormDB() *gorm.DB { return db.db }
 
-func connect(ctx context.Context, z *zap.Logger, cfg *Config) (*gorm.DB, error) {
+func connect(_ context.Context, z *zap.Logger, cfg *Config) (*gorm.DB, error) {
 	client, err := gormkitteh.OpenZ(z, cfg, func(cfg *gorm.Config) {
 		cfg.SkipDefaultTransaction = true
 	})
@@ -211,7 +210,7 @@ func (db *gormdb) backfillUsersAndOrgs(ctx context.Context) error {
 		// Prepare a personal org for each user.
 		org := scheme.Org{
 			OrgID:       kittehs.Must1(uuid.NewV7()),
-			DisplayName: fmt.Sprintf("%s's Personal Org", user.DisplayName),
+			DisplayName: user.DisplayName + "'s Personal Org",
 			Base: scheme.Base{
 				CreatedBy: authusers.SystemUser.DefaultOrgID().UUIDValue(),
 				CreatedAt: time.Now().UTC(),

--- a/internal/backend/db/dbgorm/deployments_test.go
+++ b/internal/backend/db/dbgorm/deployments_test.go
@@ -217,7 +217,7 @@ func TestUpdateDeploymentStateReturning(t *testing.T) {
 	states := []sdktypes.DeploymentState{
 		sdktypes.DeploymentStateActive, sdktypes.DeploymentStateDraining, sdktypes.DeploymentStateInactive,
 	}
-	for i := 0; i < len(states); i++ {
+	for i := range states {
 		newState := states[i]
 		prevStateFromUpdate, err := f.gormdb.updateDeploymentState(f.ctx, d.DeploymentID, newState)
 		assert.NoError(t, err)

--- a/internal/backend/db/dbgorm/gorm_test.go
+++ b/internal/backend/db/dbgorm/gorm_test.go
@@ -109,7 +109,7 @@ func newTestID() uuid.UUID {
 	id += 1
 	binary.BigEndian.PutUint64(bytes[8:], uint64(id)) // fill the last 8 bytes, leave the first 8 bytes as zero
 
-	return kittehs.Must1(uuid.FromBytes(bytes[:]))
+	return kittehs.Must1(uuid.FromBytes(bytes))
 }
 
 func idToName(id uuid.UUID, prefix string) string {
@@ -323,8 +323,7 @@ func (f *dbFixture) newBuild(args ...any) scheme.Build {
 		Base:    scheme.Base{CreatedAt: now},
 	}
 	for _, a := range args {
-		switch a := a.(type) {
-		case scheme.Project:
+		if a, ok := a.(scheme.Project); ok {
 			b.ProjectID = a.ProjectID
 		}
 	}
@@ -423,7 +422,7 @@ func (f *dbFixture) newConnection(args ...any) scheme.Connection {
 }
 
 func (f *dbFixture) newEvent(args ...any) scheme.Event {
-	f.eventSequence = f.eventSequence + 1
+	f.eventSequence++
 	e := scheme.Event{
 		EventID: newTestID(),
 		Base:    scheme.Base{CreatedAt: now},
@@ -450,8 +449,7 @@ func (f *dbFixture) newSignal(args ...any) scheme.Signal {
 		CreatedAt: now,
 	}
 	for _, a := range args {
-		switch a := a.(type) {
-		case scheme.Connection:
+		if a, ok := a.(scheme.Connection); ok {
 			s.ConnectionID = &a.ConnectionID
 			s.DestinationID = a.ConnectionID
 		}
@@ -470,7 +468,7 @@ func resetTimes(vs ...any) {
 
 		rv = rv.Elem()
 
-		for i := 0; i < rv.NumField(); i++ {
+		for i := range rv.NumField() {
 			fv := rv.Field(i)
 			if fv.Kind() == reflect.Struct {
 				if fv.Type().Name() == "Time" {

--- a/internal/backend/db/dbgorm/owner_org.go
+++ b/internal/backend/db/dbgorm/owner_org.go
@@ -2,7 +2,6 @@ package dbgorm
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/google/uuid"
 
@@ -43,7 +42,7 @@ func (gdb *gormdb) getRecordProjectOwner(
 
 	err := gdb.db.WithContext(ctx).
 		Model(m).
-		Where(fmt.Sprintf("%s = ?", m.IDFieldName()), id.UUIDValue()).
+		Where(m.IDFieldName()+" = ?", id.UUIDValue()).
 		Preload("Project").
 		Select("project_id").
 		First(&p).
@@ -112,7 +111,7 @@ func (gdb *gormdb) GetProjectIDOf(ctx context.Context, id sdktypes.ID) (sdktypes
 
 	err := gdb.db.WithContext(ctx).
 		Model(m).
-		Where(fmt.Sprintf("%s = ?", m.IDFieldName()), id.UUIDValue()).
+		Where(m.IDFieldName()+" = ?", id.UUIDValue()).
 		Select("project_id").
 		First(&p).
 		Error

--- a/internal/backend/db/dbgorm/projects_test.go
+++ b/internal/backend/db/dbgorm/projects_test.go
@@ -210,7 +210,7 @@ func TestUpdateProject(t *testing.T) {
 	f.createProjectsAndAssert(t, p)
 
 	// update project
-	p.Name = p.Name + "_updated"
+	p.Name += "_updated"
 	assert.NoError(t, f.gormdb.updateProject(f.ctx, &p))
 	res := findAndAssertCount[scheme.Project](t, f, 1, "project_id = ?", p.ProjectID)
 	resetTimes(&res[0])

--- a/internal/backend/db/dbgorm/scheme/records.go
+++ b/internal/backend/db/dbgorm/scheme/records.go
@@ -495,11 +495,12 @@ type Signal struct {
 func ParseSignal(r *Signal) (*types.Signal, error) {
 	var dstID sdktypes.EventDestinationID
 
-	if r.ConnectionID != nil {
+	switch {
+	case r.ConnectionID != nil:
 		dstID = sdktypes.NewEventDestinationID(sdktypes.NewIDFromUUIDPtr[sdktypes.ConnectionID](r.ConnectionID))
-	} else if r.TriggerID != nil {
+	case r.TriggerID != nil:
 		dstID = sdktypes.NewEventDestinationID(sdktypes.NewIDFromUUIDPtr[sdktypes.TriggerID](r.TriggerID))
-	} else {
+	default:
 		return nil, sdkerrors.NewInvalidArgumentError("signal must have a connection or trigger")
 	}
 

--- a/internal/backend/dispatcher/activities.go
+++ b/internal/backend/dispatcher/activities.go
@@ -168,7 +168,8 @@ func (d *Dispatcher) getEventSessionDataActivity(ctx context.Context, event sdkt
 			}
 
 			if len(activeDeployments)+len(testingDeployments) != 0 {
-				deployments = append(activeDeployments, testingDeployments...)
+				deployments = append(deployments, activeDeployments...)
+				deployments = append(deployments, testingDeployments...)
 
 				if opts.DeploymentID.IsValid() {
 					deployments = kittehs.Filter(deployments, func(deployment sdktypes.Deployment) bool { return opts.DeploymentID == deployment.ID() })

--- a/internal/backend/dispatcher/dispatcher.go
+++ b/internal/backend/dispatcher/dispatcher.go
@@ -3,6 +3,7 @@ package dispatcher
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"go.temporal.io/sdk/workflow"
@@ -70,7 +71,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, event sdktypes.Event, opts *s
 		"event_uuid":       eid.UUIDValue().String(),
 		"destination_id":   event.DestinationID().String(),
 		"destination_uuid": event.DestinationID().UUIDValue().String(),
-		"seq":              fmt.Sprintf("%d", event.Seq()),
+		"seq":              strconv.FormatUint(event.Seq(), 10),
 		"process_id":       fixtures.ProcessID(),
 	}
 

--- a/internal/backend/health/healthchecker/svc.go
+++ b/internal/backend/health/healthchecker/svc.go
@@ -3,10 +3,11 @@ package healthchecker
 import (
 	"errors"
 
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/internal/backend/db"
 	"go.autokitteh.dev/autokitteh/internal/backend/health/healthreporter"
 	"go.autokitteh.dev/autokitteh/internal/backend/temporalclient"
-	"go.uber.org/zap"
 )
 
 type healthChecker struct {

--- a/internal/backend/httpsvc/metrics.go
+++ b/internal/backend/httpsvc/metrics.go
@@ -26,7 +26,7 @@ func acquireServiceAPIMetrics(serviceAPI string, t *telemetry.Telemetry) (*apiMe
 		return m.(*apiMetrics), nil
 	}
 
-	cntName := fmt.Sprintf("api.%s", serviceAPI)
+	cntName := "api." + serviceAPI
 	histName := fmt.Sprintf("api.%s.duration", serviceAPI)
 
 	counter, err := t.NewCounter(cntName, fmt.Sprintf("GRPC request counter (%s)", cntName))

--- a/internal/backend/oauth/oauth.go
+++ b/internal/backend/oauth/oauth.go
@@ -112,9 +112,9 @@ func New(l *zap.Logger, vars sdkservices.Vars) sdkservices.OAuth {
 				// https://developer.atlassian.com/cloud/confluence/oauth-2-3lo-apps/
 				// https://auth.atlassian.com/.well-known/openid-configuration
 				Endpoint: oauth2.Endpoint{
-					AuthURL:       fmt.Sprintf("%s/authorize", atlassianBaseURL),
-					TokenURL:      fmt.Sprintf("%s/oauth/token", atlassianBaseURL),
-					DeviceAuthURL: fmt.Sprintf("%s/oauth/device/code", atlassianBaseURL),
+					AuthURL:       atlassianBaseURL + "/authorize",
+					TokenURL:      atlassianBaseURL + "/oauth/token",
+					DeviceAuthURL: atlassianBaseURL + "/oauth/device/code",
 				},
 				RedirectURL: redirectURL + "confluence",
 				// https://developer.atlassian.com/cloud/confluence/scopes-for-oauth-2-3LO-and-forge-apps/
@@ -149,10 +149,10 @@ func New(l *zap.Logger, vars sdkservices.Vars) sdkservices.OAuth {
 					// https://docs.github.com/en/apps/using-github-apps/installing-a-github-app-from-a-third-party#installing-a-github-app
 					AuthURL: fmt.Sprintf("%s/%s/%s/installations/new", githubBaseURL, appsDir, os.Getenv("GITHUB_APP_NAME")),
 					// https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow
-					DeviceAuthURL: fmt.Sprintf("%s/login/device/code", githubBaseURL),
+					DeviceAuthURL: githubBaseURL + "/login/device/code",
 					// https://docs.github.com/en/enterprise-server/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github
 					// https://docs.github.com/en/enterprise-server/apps/sharing-github-apps/making-your-github-app-available-for-github-enterprise-server#the-app-code-must-use-the-correct-urls
-					TokenURL: fmt.Sprintf("%s/login/oauth/access_token", githubBaseURL),
+					TokenURL: githubBaseURL + "/login/oauth/access_token",
 					// https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#3-use-the-access-token-to-access-the-api
 					AuthStyle: oauth2.AuthStyleInHeader,
 				},
@@ -337,9 +337,9 @@ func New(l *zap.Logger, vars sdkservices.Vars) sdkservices.OAuth {
 				// https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/
 				// https://auth.atlassian.com/.well-known/openid-configuration
 				Endpoint: oauth2.Endpoint{
-					AuthURL:       fmt.Sprintf("%s/authorize", atlassianBaseURL),
-					TokenURL:      fmt.Sprintf("%s/oauth/token", atlassianBaseURL),
-					DeviceAuthURL: fmt.Sprintf("%s/oauth/device/code", atlassianBaseURL),
+					AuthURL:       atlassianBaseURL + "/authorize",
+					TokenURL:      atlassianBaseURL + "/oauth/token",
+					DeviceAuthURL: atlassianBaseURL + "/oauth/device/code",
 				},
 				RedirectURL: redirectURL + "jira",
 				// https://developer.atlassian.com/cloud/jira/platform/scopes-for-oauth-2-3LO-and-forge-apps/

--- a/internal/backend/projects/metrics.go
+++ b/internal/backend/projects/metrics.go
@@ -1,8 +1,9 @@
 package projects
 
 import (
-	"go.autokitteh.dev/autokitteh/internal/backend/telemetry"
 	"go.opentelemetry.io/otel/metric"
+
+	"go.autokitteh.dev/autokitteh/internal/backend/telemetry"
 )
 
 var projectsCreatedCounter metric.Int64Counter

--- a/internal/backend/projectsgrpcsvc/svc.go
+++ b/internal/backend/projectsgrpcsvc/svc.go
@@ -144,7 +144,7 @@ func (s *Server) Get(ctx context.Context, req *connect.Request[projectsv1.GetReq
 	if !n.IsValid() {
 		// essentially should never happen since we validate existence of name xor uid
 		// in proto. Hence Unknown error.
-		return nil, sdkerrors.AsConnectError(fmt.Errorf("missing name"))
+		return nil, sdkerrors.AsConnectError(errors.New("missing name"))
 	}
 
 	return toResponse(s.projects.GetByName(ctx, oid, n))

--- a/internal/backend/secrets/aws.go
+++ b/internal/backend/secrets/aws.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
-
 	"go.uber.org/zap"
 )
 

--- a/internal/backend/secrets/svc.go
+++ b/internal/backend/secrets/svc.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/internal/backend/db"
 	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
-	"go.uber.org/zap"
 )
 
 type Secrets interface {

--- a/internal/backend/sessions/sessioncalls/callopts.go
+++ b/internal/backend/sessions/sessioncalls/callopts.go
@@ -1,6 +1,7 @@
 package sessioncalls
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -45,7 +46,7 @@ func parseCallSpec(spec sdktypes.SessionCallSpec) (v sdktypes.Value, args []sdkt
 	if vopts.IsValid() && !vopts.IsNothing() {
 		if found {
 			// Already specified in args, gevalt!
-			err = fmt.Errorf("call options found in both args and kwargs")
+			err = errors.New("call options found in both args and kwargs")
 			return
 		}
 

--- a/internal/backend/sessions/sessionworkflows/module.go
+++ b/internal/backend/sessions/sessionworkflows/module.go
@@ -2,7 +2,7 @@ package sessionworkflows
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authcontext"
 	"go.autokitteh.dev/autokitteh/internal/backend/fixtures"
@@ -33,7 +33,7 @@ func (w *sessionWorkflow) newModule() sdkexecutor.Executor {
 
 func callopts(_ context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
 	if len(args) > 0 {
-		return sdktypes.InvalidValue, fmt.Errorf("expecting only key value arguments")
+		return sdktypes.InvalidValue, errors.New("expecting only key value arguments")
 	}
 
 	return sdktypes.NewStructValue(sdktypes.NewSymbolValue(fixtures.CallOptsCtorSymbol), kwargs)

--- a/internal/backend/sessions/sessionworkflows/modules/testtools/testtools.go
+++ b/internal/backend/sessions/sessionworkflows/modules/testtools/testtools.go
@@ -102,10 +102,9 @@ func freeze(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktyp
 		replaying := workflow.IsReplaying(wctx)
 
 		// This makes sure that the IsReplaying function above will
-		// return true if if the workflow froze the last iteration.
-		// If this wouldn't be here, and the workflow froze the last
-		// replay, there would be nothing to replay and IsReplay would
-		// return false.
+		// return true if the workflow froze the last iteration.
+		// If this wouldn't be here, and the workflow froze the last replay,
+		// there would be nothing to replay and IsReplay would return false.
 		if err := workflow.Sleep(wctx, time.Millisecond); err != nil {
 			return sdktypes.InvalidValue, err
 		}

--- a/internal/backend/sessions/sessionworkflows/modules/time/time.go
+++ b/internal/backend/sessions/sessionworkflows/modules/time/time.go
@@ -3,7 +3,7 @@ package time
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"time"
 
 	"go.temporal.io/sdk/workflow"
@@ -79,7 +79,7 @@ func newTime(_ context.Context, args []sdktypes.Value, kwargs map[string]sdktype
 		return sdktypes.InvalidValue, err
 	}
 	if len(args) > 0 {
-		return sdktypes.InvalidValue, fmt.Errorf("time: unexpected positional arguments")
+		return sdktypes.InvalidValue, errors.New("time: unexpected positional arguments")
 	}
 	location, err := time.LoadLocation(loc)
 	if err != nil {

--- a/internal/backend/sessions/sessionworkflows/syscalls.go
+++ b/internal/backend/sessions/sessionworkflows/syscalls.go
@@ -26,7 +26,7 @@ const (
 
 func (w *sessionWorkflow) syscall(ctx context.Context, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
 	if len(args) == 0 {
-		return sdktypes.InvalidValue, fmt.Errorf("expecting syscall operation name as first argument")
+		return sdktypes.InvalidValue, errors.New("expecting syscall operation name as first argument")
 	}
 
 	var op string
@@ -119,11 +119,12 @@ func (w *sessionWorkflow) subscribe(ctx context.Context, args []sdktypes.Value, 
 
 	var did sdktypes.EventDestinationID
 
-	if connection.IsValid() {
+	switch {
+	case connection.IsValid():
 		did = sdktypes.NewEventDestinationID(connection.ID())
-	} else if trigger.IsValid() {
+	case trigger.IsValid():
 		did = sdktypes.NewEventDestinationID(trigger.ID())
-	} else {
+	default:
 		return sdktypes.InvalidValue, fmt.Errorf("source %q not found", name)
 	}
 

--- a/internal/backend/sessions/sessionworkflows/workflow.go
+++ b/internal/backend/sessions/sessionworkflows/workflow.go
@@ -2,6 +2,7 @@ package sessionworkflows
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"strings"
@@ -100,8 +101,8 @@ func (w *sessionWorkflow) cleanupSignals(ctx workflow.Context) {
 	goCtx := temporalclient.NewWorkflowContextAsGOContext(ctx)
 	for signalID := range w.lastReadEventSeqForSignal {
 		if err := w.ws.svcs.DB.RemoveSignal(goCtx, signalID); err != nil {
-			// No need to to any handling in case of an error, it won't be used again
-			// at most we would have db garbage we can clear up later with background jobs
+			// No need to any handling in case of an error, it won't be used again at
+			// most we would have db garbage we can clear up later with background jobs.
 			w.l.Sugar().With("signalID", signalID, "err", err).Warnf("failed removing signal %v, err: %v", signalID, err)
 		}
 	}
@@ -451,7 +452,7 @@ func (w *sessionWorkflow) run(wctx workflow.Context, l *zap.Logger) (prints []st
 
 			if run == nil {
 				l.Debug("run not initialized")
-				return sdktypes.InvalidValue, fmt.Errorf("cannot call before the run is initialized")
+				return sdktypes.InvalidValue, errors.New("cannot call before the run is initialized")
 			}
 
 			if xid := v.GetFunction().ExecutorID(); xid.ToRunID() == runID && w.executors.GetCaller(xid) == nil {
@@ -459,12 +460,12 @@ func (w *sessionWorkflow) run(wctx workflow.Context, l *zap.Logger) (prints []st
 
 				// This happens only during initial evaluation (the first run because invoking the entrypoint function),
 				// and the runtime tries to call itself in order to start an activity with its own functions.
-				return sdktypes.InvalidValue, fmt.Errorf("cannot call self during initial evaluation")
+				return sdktypes.InvalidValue, errors.New("cannot call self during initial evaluation")
 			}
 
 			if isActivity {
 				l.Debug("nested activity call")
-				return sdktypes.InvalidValue, fmt.Errorf("nested activities are not supported")
+				return sdktypes.InvalidValue, errors.New("nested activities are not supported")
 			}
 
 			return w.call(wctx, runID, v, args, kwargs)
@@ -563,7 +564,7 @@ func (w *sessionWorkflow) run(wctx workflow.Context, l *zap.Logger) (prints []st
 		}
 
 		if callValue.GetFunction().ExecutorID().ToRunID() != runID {
-			return prints, fmt.Errorf("entry point does not belong to main run")
+			return prints, errors.New("entry point does not belong to main run")
 		}
 
 		if err := w.updateState(wctx, sdktypes.NewSessionStateRunning(runID, callValue)); err != nil {

--- a/internal/backend/storegrpcsvc/svc.go
+++ b/internal/backend/storegrpcsvc/svc.go
@@ -2,7 +2,7 @@ package storegrpcsvc
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"connectrpc.com/connect"
 
@@ -16,7 +16,7 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-var errNotConfigured = connect.NewError(connect.CodeUnimplemented, fmt.Errorf("store service not configured"))
+var errNotConfigured = connect.NewError(connect.CodeUnimplemented, errors.New("store service not configured"))
 
 type server struct {
 	store sdkservices.Store

--- a/internal/backend/svc/banner.go
+++ b/internal/backend/svc/banner.go
@@ -2,8 +2,8 @@ package svc
 
 import (
 	_ "embed"
-	"fmt"
 	"os"
+	"strconv"
 	"text/template"
 
 	"github.com/fatih/color"
@@ -48,9 +48,9 @@ func printBanner(cfg *bannerConfig, opts RunOptions, addr, wpAddr, wpVersion, te
 		temporalUIAddr = "Temporal UI:    " + fieldColor(temporalUIAddr) + " "
 	}
 
-	webAddr := fmt.Sprintf("http://%s", addr)
+	webAddr := "http://" + addr
 	if wpAddr != "" {
-		webAddr = fmt.Sprintf("http://%s", wpAddr)
+		webAddr = "http://" + wpAddr
 	}
 
 	if wpVersion != "" {
@@ -71,7 +71,7 @@ func printBanner(cfg *bannerConfig, opts RunOptions, addr, wpAddr, wpVersion, te
 		Temporal, TemporalUI string
 	}{
 		Version:         fieldColor(version.Version),
-		PID:             fieldColor(fmt.Sprintf("%d", os.Getpid())),
+		PID:             fieldColor(strconv.Itoa(os.Getpid())),
 		Addr:            fieldColor(addr),
 		WebPlatformAddr: fieldColor(wpAddr),
 		WebAddr:         fieldColor(webAddr),

--- a/internal/backend/svc/config.go
+++ b/internal/backend/svc/config.go
@@ -88,7 +88,7 @@ func parseKoanfTags(prefix string, v reflect.Value) []string {
 	var result []string
 
 	t := v.Type()
-	for i := 0; i < v.NumField(); i++ {
+	for i := range v.NumField() {
 		field := v.Field(i)
 		fieldType := t.Field(i)
 

--- a/internal/backend/svc/fx.go
+++ b/internal/backend/svc/fx.go
@@ -24,7 +24,7 @@ func fxGetConfig[T any](path string, def T) func(c *Config) (*T, error) {
 }
 
 func chooseConfig[T any](set configset.Set[T]) (T, error) {
-	return set.Choose(configset.Mode(fxRunOpts.Mode))
+	return set.Choose(fxRunOpts.Mode)
 }
 
 func Component[T any](name string, set configset.Set[T], opts ...fx.Option) fx.Option {

--- a/internal/backend/temporalclient/client.go
+++ b/internal/backend/temporalclient/client.go
@@ -61,11 +61,12 @@ func New(cfg *Config, l *zap.Logger) (Client, LazyTemporalClient, error) {
 	if cfg.TLS.Enabled {
 		var cert tls.Certificate
 		var err error
-		if cfg.TLS.Certificate != "" && cfg.TLS.Key != "" {
+		switch {
+		case cfg.TLS.Certificate != "" && cfg.TLS.Key != "":
 			cert, err = tls.X509KeyPair([]byte(cfg.TLS.Certificate), []byte(cfg.TLS.Key))
-		} else if cfg.TLS.CertFilePath != "" && cfg.TLS.KeyFilePath != "" {
+		case cfg.TLS.CertFilePath != "" && cfg.TLS.KeyFilePath != "":
 			cert, err = tls.LoadX509KeyPair(cfg.TLS.CertFilePath, cfg.TLS.KeyFilePath)
-		} else {
+		default:
 			return nil, nil, errors.New("tls enabled without certificate or key")
 		}
 
@@ -190,7 +191,7 @@ func (c *impl) TemporalAddr() (frontend, ui string) {
 		// temporal's default is frontend+1000 for dev server.
 		nport += 1000
 
-		ui = fmt.Sprintf("http://%s:%d", host, nport)
+		ui = "http://" + net.JoinHostPort(host, strconv.Itoa(nport))
 	}
 
 	return

--- a/internal/backend/temporalclient/dataconverter.go
+++ b/internal/backend/temporalclient/dataconverter.go
@@ -58,7 +58,7 @@ func NewDataConverter(l *zap.Logger, cfg *DataConverterConfig, parent converter.
 			n, v = strings.TrimSpace(n), strings.TrimSpace(v)
 
 			if len(n) == 0 {
-				return nil, fmt.Errorf("empty key name")
+				return nil, errors.New("empty key name")
 			}
 
 			if codec.main == "" {

--- a/internal/backend/temporalclient/encryption_codec.go
+++ b/internal/backend/temporalclient/encryption_codec.go
@@ -3,6 +3,7 @@ package temporalclient
 import (
 	"crypto/cipher"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (c encryptionCodec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Paylo
 
 		keyName, ok := p.Metadata[metadataEncryptionKeyID]
 		if !ok {
-			return payloads, fmt.Errorf("no encryption key id")
+			return payloads, errors.New("no encryption key id")
 		}
 
 		cipher := c.ciphers[string(keyName)]

--- a/internal/backend/usagereporter/dataposter.go
+++ b/internal/backend/usagereporter/dataposter.go
@@ -7,7 +7,7 @@ import (
 )
 
 func post(endpoint string, data []byte) error {
-	req, err := http.NewRequest("POST", endpoint, bytes.NewReader(data))
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("constructing request: %w", err)
 	}
@@ -20,7 +20,7 @@ func post(endpoint string, data []byte) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("invalid status code: %d", resp.StatusCode)
 	}
 

--- a/internal/backend/users/users.go
+++ b/internal/backend/users/users.go
@@ -65,7 +65,7 @@ func (u *users) Create(ctx context.Context, user sdktypes.User) (sdktypes.UserID
 				org := sdktypes.NewOrg()
 
 				if user.DisplayName() != "" {
-					org = org.WithDisplayName(fmt.Sprintf("%s's Personal Org", user.DisplayName()))
+					org = org.WithDisplayName(user.DisplayName() + "'s Personal Org")
 				}
 
 				var err error

--- a/internal/backend/vars/vars_test.go
+++ b/internal/backend/vars/vars_test.go
@@ -54,7 +54,7 @@ func TestGetVarNotFound(t *testing.T) {
 	callCounter := 0
 
 	d.GetVarsFunc = func(ctx context.Context, vsi sdktypes.VarScopeID, s []sdktypes.Symbol) (sdktypes.Vars, error) {
-		callCounter = callCounter + 1
+		callCounter++
 		return nil, nil
 	}
 
@@ -77,7 +77,7 @@ func TestGetVarFound(t *testing.T) {
 	vv := sdktypes.NewVar(sdktypes.NewSymbol("efi")).SetValue("value")
 
 	d.GetVarsFunc = func(context.Context, sdktypes.VarScopeID, []sdktypes.Symbol) (sdktypes.Vars, error) {
-		callCounter = callCounter + 1
+		callCounter++
 		return []sdktypes.Var{vv}, nil
 	}
 
@@ -99,7 +99,7 @@ func TestSetVar(t *testing.T) {
 	dbCallCounter := 0
 
 	d.SetVarsFunc = func(ctx context.Context, v []sdktypes.Var) error {
-		dbCallCounter = dbCallCounter + 1
+		dbCallCounter++
 		return nil
 	}
 
@@ -107,7 +107,7 @@ func TestSetVar(t *testing.T) {
 	sCallCounter := 0
 
 	s.SetFunc = func(ctx context.Context, key string, value string) error {
-		sCallCounter = sCallCounter + 1
+		sCallCounter++
 		return nil
 	}
 
@@ -129,7 +129,7 @@ func TestSetSecretVar(t *testing.T) {
 	dbCallCounter := 0
 
 	d.SetVarsFunc = func(ctx context.Context, v []sdktypes.Var) error {
-		dbCallCounter = dbCallCounter + 1
+		dbCallCounter++
 		return nil
 	}
 
@@ -141,7 +141,7 @@ func TestSetSecretVar(t *testing.T) {
 	s.SetFunc = func(ctx context.Context, key string, value string) error {
 		actualSecretKey = key
 		actualSecretValue = value
-		sCallCounter = sCallCounter + 1
+		sCallCounter++
 		return nil
 	}
 
@@ -171,7 +171,7 @@ func TestSetMultipleSecretVar(t *testing.T) {
 		dbVals = kittehs.Transform(v, func(v sdktypes.Var) string {
 			return v.Value()
 		})
-		dbCallCounter = dbCallCounter + 1
+		dbCallCounter++
 		return nil
 	}
 
@@ -183,7 +183,7 @@ func TestSetMultipleSecretVar(t *testing.T) {
 	s.SetFunc = func(ctx context.Context, key string, value string) error {
 		keys = append(keys, key)
 		vals = append(vals, value)
-		sCallCounter = sCallCounter + 1
+		sCallCounter++
 		return nil
 	}
 

--- a/internal/kittehs/addresses.go
+++ b/internal/kittehs/addresses.go
@@ -1,7 +1,6 @@
 package kittehs
 
 import (
-	"fmt"
 	"net"
 )
 
@@ -10,7 +9,7 @@ import (
 // because using "localhost" or "127.0.0.1" will bind the port to the loopback
 // interface, making it inaccessible from outside the container.
 func BindingAddress(port string) string {
-	return fmt.Sprintf("0.0.0.0:%s", port)
+	return net.JoinHostPort("0.0.0.0", port)
 }
 
 // DisplayAddress returns a human-readable address for the given binding address.
@@ -23,7 +22,7 @@ func DisplayAddress(bindingAddress string) string {
 	}
 
 	if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
-		return fmt.Sprintf("localhost:%s", port)
+		return net.JoinHostPort("localhost", port)
 	}
 
 	return bindingAddress

--- a/internal/kittehs/fs.go
+++ b/internal/kittehs/fs.go
@@ -1,6 +1,7 @@
 package kittehs
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"path/filepath"
@@ -77,7 +78,7 @@ type FilterFS struct {
 // `nil` pred assumes to always return true.
 func NewFilterFS(fsys fs.FS, pred func(fs.DirEntry) bool) (*FilterFS, error) {
 	if fsys == nil {
-		return nil, fmt.Errorf("fsys is nil")
+		return nil, errors.New("fsys is nil")
 	}
 
 	ffs := FilterFS{

--- a/internal/kittehs/strings.go
+++ b/internal/kittehs/strings.go
@@ -22,7 +22,7 @@ func ToString[T any](t T) string { return fmt.Sprint(t) }
 // (in Alan I trust: https://github.com/google/starlark-go/blob/f86470692795f8abcf9f837a3c53cf031c5a3d7e/starlark/hashtable.go#L435)
 func HashString32(s string) uint32 {
 	var h uint32 = 2166136261
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		h ^= uint32(s[i])
 		h *= 16777619
 	}

--- a/internal/kittehs/strings_test.go
+++ b/internal/kittehs/strings_test.go
@@ -10,7 +10,7 @@ func TestToString(t *testing.T) {
 	assert.Equal(t, ToString(String("meow")), "meow")
 }
 
-func TestMatchLongetSuffix(t *testing.T) {
+func TestMatchLongestSuffix(t *testing.T) {
 	assert.Equal(t, "", MatchLongestSuffix("", []string{"1", "3"}))
 	assert.Equal(t, "234", MatchLongestSuffix("1234", []string{"4", "234", "34", "23"}))
 }

--- a/internal/kittehs/transforms.go
+++ b/internal/kittehs/transforms.go
@@ -114,5 +114,5 @@ func TransformMapValuesError[A comparable, B0, B1 any](m map[A]B0, f func(B0) (B
 }
 
 func TransformToStrings[T any](ts []T) []string {
-	return Transform(ts, func(t T) string { return ToString(t) })
+	return Transform(ts, ToString)
 }

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -84,11 +84,12 @@ func (t Trigger) GetKey() string {
 
 	what := ""
 
-	if t.Schedule != nil {
+	switch {
+	case t.Schedule != nil:
 		what = "schedule:" + *t.Schedule
-	} else if t.Webhook != nil {
+	case t.Webhook != nil:
 		what = "webhook"
-	} else if t.ConnectionKey != nil {
+	case t.ConnectionKey != nil:
 		what = "connection:" + *t.ConnectionKey
 	}
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -26,7 +26,7 @@ type NotFoundError struct {
 	Type, Name string
 }
 
-var NotFoundErrorType = new(NotFoundError)
+var ErrNotFound = new(NotFoundError)
 
 func (e NotFoundError) Error() string {
 	name := e.Name

--- a/proto/validate.go
+++ b/proto/validate.go
@@ -40,7 +40,7 @@ func parse(fds []protoreflect.FileDescriptor) func(proto.Message) error {
 	for _, fd := range fds {
 		msgs := fd.Messages()
 
-		for i := 0; i < msgs.Len(); i++ {
+		for i := range msgs.Len() {
 			descs = append(descs, msgs.Get(i))
 		}
 	}

--- a/runtimes/configrt/runtime/build.go
+++ b/runtimes/configrt/runtime/build.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"maps"
@@ -36,7 +37,7 @@ func Build(ctx context.Context, fs fs.FS, mainPath string) (sdktypes.BuildArtifa
 	}
 
 	if !compiled.IsDict() && !compiled.IsStruct() && !compiled.IsModule() {
-		return sdktypes.InvalidBuildArtifact, fmt.Errorf("source represents neither a dict, struct or module")
+		return sdktypes.InvalidBuildArtifact, errors.New("source represents neither a dict, struct or module")
 	}
 
 	exports, err := evaluateValue(compiled)

--- a/runtimes/configrt/runtime/run.go
+++ b/runtimes/configrt/runtime/run.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"google.golang.org/protobuf/proto"
@@ -117,7 +118,7 @@ func evaluateValue(v sdktypes.Value) (map[string]sdktypes.Value, error) {
 			v.Items(),
 			func(it sdktypes.DictItem) (string, sdktypes.Value, error) {
 				if !it.K.IsString() {
-					return "", sdktypes.InvalidValue, fmt.Errorf("dict key is not a string")
+					return "", sdktypes.InvalidValue, errors.New("dict key is not a string")
 				}
 				return it.K.GetString().Value(), it.V, nil
 			},
@@ -130,7 +131,7 @@ func evaluateValue(v sdktypes.Value) (map[string]sdktypes.Value, error) {
 	case sdktypes.ModuleValue:
 		exports = v.Members()
 	default:
-		return nil, fmt.Errorf("unhandled value type")
+		return nil, errors.New("unhandled value type")
 	}
 
 	return exports, nil

--- a/runtimes/pythonrt/build.go
+++ b/runtimes/pythonrt/build.go
@@ -14,9 +14,10 @@ import (
 	"path"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.uber.org/zap"
 )
 
 func isBuildFile(entry fs.DirEntry) bool {

--- a/runtimes/pythonrt/build_test.go
+++ b/runtimes/pythonrt/build_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.uber.org/zap"
+
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
 )
 
 func TestBuildFiles(t *testing.T) {

--- a/runtimes/pythonrt/dockerclient.go
+++ b/runtimes/pythonrt/dockerclient.go
@@ -16,9 +16,10 @@ import (
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
-	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapio"
+
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 const (
@@ -138,7 +139,7 @@ func (d *dockerClient) StartRunner(ctx context.Context, runnerImage string, sess
 
 func (d *dockerClient) nextFreePort(ctx context.Context, cid string) (string, error) {
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		inspect, err := d.client.ContainerInspect(ctx, cid)
 		if err != nil {
 			return "", err

--- a/runtimes/pythonrt/local_runner.go
+++ b/runtimes/pythonrt/local_runner.go
@@ -13,13 +13,15 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
-	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 	"go.jetify.com/typeid"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapio"
+
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 var (
@@ -145,7 +147,7 @@ func (r *LocalPython) Start(pyExe string, tarData []byte, env map[string]string,
 	cmd := exec.Command(
 		pyExe, "-u", mainPy,
 		"--worker-address", workerAddr,
-		"--port", fmt.Sprintf("%d", r.port),
+		"--port", strconv.Itoa(r.port),
 		"--runner-id", r.id,
 		"--code-dir", r.userDir,
 	)
@@ -336,7 +338,7 @@ func adjustPythonPath(env []string, runnerPath string) []string {
 		}
 	}
 
-	return append(env, fmt.Sprintf("PYTHONPATH=%s", runnerPath))
+	return append(env, "PYTHONPATH="+runnerPath)
 }
 
 func overrideEnv(envMap map[string]string, runnerPath string) []string {

--- a/runtimes/pythonrt/local_runner_test.go
+++ b/runtimes/pythonrt/local_runner_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path"
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -86,7 +87,7 @@ var envRe = regexp.MustCompile(`([^ ]+)=([^ \n]+)`)
 
 func processEnv(t *testing.T, pid int) map[string]string {
 	var buf bytes.Buffer
-	cmd := exec.Command("ps", "e", "-ww", "-p", fmt.Sprintf("%d", pid))
+	cmd := exec.Command("ps", "e", "-ww", "-p", strconv.Itoa(pid))
 	cmd.Stdout = &buf
 	cmd.Stderr = os.Stderr
 
@@ -183,7 +184,7 @@ func Test_parsePyVersion(t *testing.T) {
 	}
 }
 
-//TODO: What to here
+// TODO: What to here
 // func Test_pyExports(t *testing.T) {
 // 	skipIfNoPython(t)
 

--- a/runtimes/pythonrt/pythonrt.go
+++ b/runtimes/pythonrt/pythonrt.go
@@ -212,15 +212,15 @@ func loadSyscall(values map[string]sdktypes.Value) (sdktypes.Value, error) {
 	}
 
 	if !ak.IsStruct() {
-		return sdktypes.InvalidValue, fmt.Errorf("`ak` is not a struct")
+		return sdktypes.InvalidValue, errors.New("`ak` is not a struct")
 	}
 
 	syscall, ok := ak.GetStruct().Fields()["syscall"]
 	if !ok {
-		return sdktypes.InvalidValue, fmt.Errorf("`syscall` not found in `ak`")
+		return sdktypes.InvalidValue, errors.New("`syscall` not found in `ak`")
 	}
 	if !syscall.IsFunction() {
-		return sdktypes.InvalidValue, fmt.Errorf("`syscall` is not a function")
+		return sdktypes.InvalidValue, errors.New("`syscall` is not a function")
 	}
 
 	return syscall, nil
@@ -391,7 +391,7 @@ func (py *pySvc) call(ctx context.Context, val sdktypes.Value, args []sdktypes.V
 // We split it from Call since Call is also used to execute activities.
 func (py *pySvc) initialCall(ctx context.Context, funcName string, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
 	if len(args) > 0 {
-		return sdktypes.InvalidValue, fmt.Errorf("initial call can't have positional args")
+		return sdktypes.InvalidValue, errors.New("initial call can't have positional args")
 	}
 
 	defer func() {

--- a/runtimes/pythonrt/pythonrt_test.go
+++ b/runtimes/pythonrt/pythonrt_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
@@ -23,8 +24,6 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {

--- a/runtimes/pythonrt/runner_manager.go
+++ b/runtimes/pythonrt/runner_manager.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"time"
 
-	userCode "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/user_code/v1"
-	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	userCode "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/user_code/v1"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 type RunnerManager interface {

--- a/runtimes/pythonrt/runner_manager_docker.go
+++ b/runtimes/pythonrt/runner_manager_docker.go
@@ -51,7 +51,7 @@ func configureDockerRunnerManager(log *zap.Logger, cfg DockerRuntimeConfig) erro
 				continue
 			}
 
-			log.Debug(fmt.Sprintf("stopped runner: %s", rid))
+			log.Debug("stopped runner: " + rid)
 		}
 	}
 
@@ -94,7 +94,7 @@ func (rm *dockerRunnerManager) Start(ctx context.Context, sessionID sdktypes.Ses
 
 	hash := md5.Sum(buildArtifacts)
 	version := fmt.Sprintf("u%x", hash)
-	containerName := fmt.Sprintf("usercode:%s", version)
+	containerName := "usercode:" + version
 
 	if err := rm.client.BuildImage(ctx, containerName, codePath); err != nil {
 		return "", nil, fmt.Errorf("build image: %w", err)
@@ -112,7 +112,7 @@ func (rm *dockerRunnerManager) Start(ctx context.Context, sessionID sdktypes.Ses
 		return "", nil, fmt.Errorf("start runner: %w", err)
 	}
 
-	runnerAddr := fmt.Sprintf("127.0.0.1:%s", port)
+	runnerAddr := "127.0.0.1:" + port
 	client, err := dialRunner(runnerAddr)
 	if err != nil {
 

--- a/runtimes/pythonrt/runner_manager_local.go
+++ b/runtimes/pythonrt/runner_manager_local.go
@@ -11,8 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 	"go.uber.org/zap"
+
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 type localRunnerManager struct {

--- a/runtimes/pythonrt/runner_manager_remote_client.go
+++ b/runtimes/pythonrt/runner_manager_remote_client.go
@@ -48,7 +48,7 @@ func configureRemoteRunnerManager(cfg RemoteRuntimeConfig) error {
 
 		resp, err := runner.Health(context.Background(), connect.NewRequest(&rmv1.HealthRequest{}))
 		if err != nil {
-			return fmt.Errorf("could not verify runner manager health")
+			return errors.New("could not verify runner manager health")
 		}
 
 		if resp.Msg.Error != "" {

--- a/runtimes/pythonrt/worker_grpc_handler.go
+++ b/runtimes/pythonrt/worker_grpc_handler.go
@@ -390,7 +390,7 @@ func (s *workerGRPCHandler) EncodeJWT(ctx context.Context, req *userCode.EncodeJ
 	// GitHub's JWTs must be signed using the RS256 algorithm:
 	// https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app
 	if req.Algorithm != jwt.SigningMethodRS256.Name {
-		return &userCode.EncodeJWTResponse{Error: fmt.Sprintf("unsupported signing method: %s", req.Algorithm)}, nil
+		return &userCode.EncodeJWTResponse{Error: "unsupported signing method: " + req.Algorithm}, nil
 	}
 
 	claims := jwt.MapClaims{}

--- a/runtimes/starlarkrt/internal/libs/parsers/parsers.go
+++ b/runtimes/starlarkrt/internal/libs/parsers/parsers.go
@@ -1,7 +1,7 @@
 package parsers
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"go.starlark.net/starlark"
@@ -27,7 +27,7 @@ func parse(thread *starlark.Thread, bi *starlark.Builtin, args starlark.Tuple, k
 
 	parse := parsers.Parsers[ext]
 	if parse == nil {
-		return nil, fmt.Errorf("no such parser")
+		return nil, errors.New("no such parser")
 	}
 
 	v, err := parse(strings.NewReader(text))

--- a/runtimes/starlarkrt/internal/values/convert.go
+++ b/runtimes/starlarkrt/internal/values/convert.go
@@ -1,6 +1,7 @@
 package values
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -122,7 +123,7 @@ func (vctx *Context) FromStarlarkValue(v starlark.Value) (sdktypes.Value, error)
 		i64, ok := v.Int64()
 		if !ok {
 			// TODO(ENG-61): support big int.
-			return sdktypes.InvalidValue, fmt.Errorf("convert from starlark int")
+			return sdktypes.InvalidValue, errors.New("convert from starlark int")
 		}
 		return sdktypes.NewIntegerValue(i64), nil
 	case starlark.Bytes:
@@ -157,7 +158,7 @@ func (vctx *Context) FromStarlarkValue(v starlark.Value) (sdktypes.Value, error)
 			if err != nil {
 				return sdktypes.InvalidValue, fmt.Errorf("dict value get: %w", err)
 			} else if !found {
-				return sdktypes.InvalidValue, fmt.Errorf("dict value missing")
+				return sdktypes.InvalidValue, errors.New("dict value missing")
 			}
 
 			vv, err := vctx.FromStarlarkValue(v)

--- a/runtimes/starlarkrt/internal/values/funcs.go
+++ b/runtimes/starlarkrt/internal/values/funcs.go
@@ -2,6 +2,7 @@ package values
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.starlark.net/starlark"
@@ -55,7 +56,7 @@ func (vctx *Context) functionToStarlark(v sdktypes.Value) (starlark.Value, error
 			akkwargs := make(map[string]sdktypes.Value, len(kwargs))
 			for _, kwarg := range kwargs {
 				if len(kwarg) != 2 {
-					return nil, fmt.Errorf("invalid kwarg")
+					return nil, errors.New("invalid kwarg")
 				}
 
 				kstr, ok := starlark.AsString(kwarg[0])
@@ -120,7 +121,7 @@ func (vctx *Context) fromStarlarkFunction(v *starlark.Function) (sdktypes.Value,
 	vctx.internalFuncs[sig] = v
 
 	argNames := make([]string, v.NumParams())
-	for i := 0; i < v.NumParams(); i++ {
+	for i := range v.NumParams() {
 		argNames[i], _ = v.Param(i)
 	}
 

--- a/runtimes/starlarkrt/runtime/build.go
+++ b/runtimes/starlarkrt/runtime/build.go
@@ -136,7 +136,7 @@ func Build(ctx context.Context, fs fs.FS, path string, symbols []sdktypes.Symbol
 		data[path] = modBuf.Bytes()
 		dir := filepath.Dir(path)
 
-		for i := 0; i < mod.NumLoads(); i++ {
+		for i := range mod.NumLoads() {
 			lpath, pos := mod.Load(i)
 
 			if lpath == "" {

--- a/runtimes/starlarkrt/runtime/builtins.go
+++ b/runtimes/starlarkrt/runtime/builtins.go
@@ -32,17 +32,17 @@ var (
 
 func runActivityBuiltinFunc(th *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if len(args) == 0 {
-		return nil, fmt.Errorf("missing function argument")
+		return nil, errors.New("missing function argument")
 	}
 
 	tlsContext := tls.Get(th)
 	if tlsContext == nil {
-		return nil, fmt.Errorf("context is not set")
+		return nil, errors.New("context is not set")
 	}
 
 	vctx := values.FromTLS(th)
 	if vctx == nil {
-		return nil, fmt.Errorf("value context is not set")
+		return nil, errors.New("value context is not set")
 	}
 
 	akV, err := vctx.FromStarlarkValue(args[0])
@@ -94,7 +94,7 @@ func catchBuiltinFunc(th *starlark.Thread, _ *starlark.Builtin, args starlark.Tu
 
 	vctx := values.FromTLS(th)
 	if vctx == nil {
-		return nil, fmt.Errorf("value context is not set")
+		return nil, errors.New("value context is not set")
 	}
 
 	value, err := starlark.Call(th, fn, args[1:], kwargs)
@@ -114,11 +114,11 @@ func catchBuiltinFunc(th *starlark.Thread, _ *starlark.Builtin, args starlark.Tu
 func failBuiltinFunc(th *starlark.Thread, bi *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	vctx := values.FromTLS(th)
 	if vctx == nil {
-		return nil, fmt.Errorf("value context is not set")
+		return nil, errors.New("value context is not set")
 	}
 
 	if len(args) != 0 && len(kwargs) != 0 {
-		return nil, fmt.Errorf("cannot specify both positional and keyword arguments")
+		return nil, errors.New("cannot specify both positional and keyword arguments")
 	}
 
 	if len(args) == 1 {
@@ -178,7 +178,7 @@ func globalsBuiltinFunc(th *starlark.Thread, bi *starlark.Builtin, args starlark
 
 	tlsContext := tls.Get(th)
 	if tlsContext == nil {
-		return nil, fmt.Errorf("context is not set")
+		return nil, errors.New("context is not set")
 	}
 
 	d := starlark.NewDict(len(tlsContext.Globals))

--- a/sdk/internal/rpcerrors/errors.go
+++ b/sdk/internal/rpcerrors/errors.go
@@ -29,7 +29,7 @@ func ToSDKError(err error) error {
 	case connect.CodeNotFound:
 		sdkErr = sdkerrors.ErrNotFound
 	case connect.CodeInvalidArgument:
-		sdkErr = sdkerrors.ErrInvalidArgument{Underlying: err}
+		sdkErr = sdkerrors.InvalidArgumentError{Underlying: err}
 	case connect.CodeUnimplemented:
 		sdkErr = sdkerrors.ErrNotImplemented
 	case connect.CodeUnauthenticated:
@@ -50,7 +50,7 @@ func ToSDKError(err error) error {
 
 	// err is a connect error (checked in connect.CodeOf), so we can safely cast it
 	if len(connectErr.Details()) != 0 {
-		errMsg = errMsg + fmt.Sprintf(" (%v)", connectErr.Details())
+		errMsg += fmt.Sprintf(" (%v)", connectErr.Details())
 	}
 	if len(errMsg) != 0 {
 		return fmt.Errorf("%w: %s", sdkErr, errMsg)

--- a/sdk/sdkbuildfile/writer.go
+++ b/sdk/sdkbuildfile/writer.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -33,7 +34,7 @@ func write(tw *tar.Writer, name string, size int64, r io.Reader) error {
 	if err := tw.WriteHeader(&tar.Header{
 		Name: name,
 		Mode: 0o600, // rw- --- ---
-		Size: int64(size),
+		Size: size,
 	}); err != nil {
 		return fmt.Errorf("%q: write_header: %w", name, err)
 	}
@@ -122,7 +123,7 @@ func (bf *BuildFile) Write(w io.Writer) error {
 		name := rt.Info.Name
 
 		if names[name.String()] {
-			return fmt.Errorf("multiple runtimes with the same name not allowed")
+			return errors.New("multiple runtimes with the same name not allowed")
 		}
 
 		names[name.String()] = true

--- a/sdk/sdkclients/internal/validate.go
+++ b/sdk/sdkclients/internal/validate.go
@@ -4,7 +4,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	akproto "go.autokitteh.dev/autokitteh/proto"
-
 	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 )
 

--- a/sdk/sdkclients/sdkauthclient/client.go
+++ b/sdk/sdkclients/sdkauthclient/client.go
@@ -8,7 +8,6 @@ import (
 
 	authv1 "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/auth/v1"
 	"go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/auth/v1/authv1connect"
-
 	"go.autokitteh.dev/autokitteh/sdk/sdkclients/internal"
 	"go.autokitteh.dev/autokitteh/sdk/sdkclients/sdkclient"
 	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"

--- a/sdk/sdkclients/sdkorgsclient/client.go
+++ b/sdk/sdkclients/sdkorgsclient/client.go
@@ -8,7 +8,6 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	orgsv1 "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/orgs/v1"
 	"go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/orgs/v1/orgsv1connect"
-
 	"go.autokitteh.dev/autokitteh/sdk/internal/rpcerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdkclients/internal"
 	"go.autokitteh.dev/autokitteh/sdk/sdkclients/sdkclient"

--- a/sdk/sdkclients/sdkprojectsclient/client.go
+++ b/sdk/sdkclients/sdkprojectsclient/client.go
@@ -89,7 +89,7 @@ func (c *client) GetByID(ctx context.Context, pid sdktypes.ProjectID) (sdktypes.
 	project, err := sdktypes.StrictProjectFromProto(resp.Msg.Project)
 	if err != nil {
 		// FIXME: ENG-626: why we check and override errInvalid for project only?
-		var errInvalid sdkerrors.ErrInvalidArgument
+		var errInvalid sdkerrors.InvalidArgumentError
 		if err.Error() == "zero object" && errors.As(err, &errInvalid) {
 			return sdktypes.InvalidProject, nil
 		}

--- a/sdk/sdkclients/sdkusersclient/client.go
+++ b/sdk/sdkclients/sdkusersclient/client.go
@@ -7,7 +7,6 @@ import (
 
 	usersv1 "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/users/v1"
 	"go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/users/v1/usersv1connect"
-
 	"go.autokitteh.dev/autokitteh/sdk/internal/rpcerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdkclients/internal"
 	"go.autokitteh.dev/autokitteh/sdk/sdkclients/sdkclient"

--- a/sdk/sdkclients/sdkvarsclient/client.go
+++ b/sdk/sdkclients/sdkvarsclient/client.go
@@ -7,7 +7,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	varsv1 "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/vars/v1"
-
 	"go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/vars/v1/varsv1connect"
 	"go.autokitteh.dev/autokitteh/sdk/internal/rpcerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdkclients/internal"

--- a/sdk/sdkerrors/errors.go
+++ b/sdk/sdkerrors/errors.go
@@ -60,28 +60,28 @@ func IsRetryableError(err error) bool {
 	return errors.As(err, &r)
 }
 
-type ErrInvalidArgument struct {
+type InvalidArgumentError struct {
 	Underlying error
 }
 
-func (e ErrInvalidArgument) Error() string {
+func (e InvalidArgumentError) Error() string {
 	if e.Underlying != nil {
 		return e.Underlying.Error()
 	}
 	return "invalid argument"
 }
 
-func (e ErrInvalidArgument) ErrorType() string { return "invalid_argument" }
+func (e InvalidArgumentError) ErrorType() string { return "invalid_argument" }
 
-func (e ErrInvalidArgument) Unwrap() error { return e.Underlying }
+func (e InvalidArgumentError) Unwrap() error { return e.Underlying }
 
 func IsInvalidArgumentError(err error) bool {
-	var invalidArg ErrInvalidArgument
+	var invalidArg InvalidArgumentError
 	return errors.As(err, &invalidArg)
 }
 
 func NewInvalidArgumentError(f string, vs ...any) error {
-	return ErrInvalidArgument{Underlying: fmt.Errorf(f, vs...)}
+	return InvalidArgumentError{Underlying: fmt.Errorf(f, vs...)}
 }
 
 // re-wrap sdk as connect error
@@ -92,7 +92,7 @@ func AsConnectError(err error) error {
 		return connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	var invalidArg ErrInvalidArgument
+	var invalidArg InvalidArgumentError
 
 	switch {
 	case errors.Is(err, ErrNotFound):

--- a/sdk/sdkexecutor/executors.go
+++ b/sdk/sdkexecutor/executors.go
@@ -17,7 +17,7 @@ type Executors struct {
 
 func (ms *Executors) Call(ctx context.Context, v sdktypes.Value, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
 	if !v.IsFunction() {
-		return sdktypes.InvalidValue, sdkerrors.ErrInvalidArgument{}
+		return sdktypes.InvalidValue, sdkerrors.InvalidArgumentError{}
 	}
 
 	xid := v.GetFunction().ExecutorID()

--- a/sdk/sdkmodule/module.go
+++ b/sdk/sdkmodule/module.go
@@ -82,7 +82,7 @@ func (m *module) Configure(ctx context.Context, xid sdktypes.ExecutorID, cid sdk
 func (m *module) Call(ctx context.Context, fnv sdktypes.Value, args []sdktypes.Value, kwargs map[string]sdktypes.Value) (sdktypes.Value, error) {
 	name := fnv.GetFunction().Name()
 	if !name.IsValid() {
-		return sdktypes.InvalidValue, sdkerrors.ErrInvalidArgument{}
+		return sdktypes.InvalidValue, sdkerrors.InvalidArgumentError{}
 	}
 
 	fn, ok := m.opts.funcs[name.String()]

--- a/sdk/sdkmodule/unpack.go
+++ b/sdk/sdkmodule/unpack.go
@@ -67,7 +67,7 @@ func UnpackArgs(args []sdktypes.Value, kwargs map[string]sdktypes.Value, dsts ..
 			return fmt.Errorf("dst %d must be a pointer to a struct", i)
 		}
 
-		for j := 0; j < tt.NumField(); j++ {
+		for j := range tt.NumField() {
 			ttf := tt.Field(j)
 
 			name := ttf.Name

--- a/sdk/sdktypes/object.go
+++ b/sdk/sdktypes/object.go
@@ -147,7 +147,7 @@ func strictValidate[M proto.Message, T objectTraits[M]](m M) error {
 
 	var t T
 	if err := t.StrictValidate(m); err != nil {
-		return sdkerrors.ErrInvalidArgument{Underlying: err}
+		return sdkerrors.InvalidArgumentError{Underlying: err}
 	}
 
 	return validate[M, T](m)
@@ -160,12 +160,12 @@ func validate[M proto.Message, T objectTraits[M]](m M) error {
 	}
 
 	if err := akproto.Validate(m); err != nil {
-		return sdkerrors.ErrInvalidArgument{Underlying: err}
+		return sdkerrors.InvalidArgumentError{Underlying: err}
 	}
 
 	var t T
 	if err := t.Validate(m); err != nil {
-		return sdkerrors.ErrInvalidArgument{Underlying: err}
+		return sdkerrors.InvalidArgumentError{Underlying: err}
 	}
 
 	return nil

--- a/sdk/sdktypes/org.go
+++ b/sdk/sdktypes/org.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
-
 	orgv1 "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/orgs/v1"
 )
 

--- a/sdk/sdktypes/str.go
+++ b/sdk/sdktypes/str.go
@@ -25,7 +25,7 @@ func (s validatedString[T]) Hash() string {
 func parseValidatedString[T validatedStringTraits](v string) (s validatedString[T], err error) {
 	var t T
 	if err = t.Validate(v); err != nil {
-		err = sdkerrors.ErrInvalidArgument{Underlying: err}
+		err = sdkerrors.InvalidArgumentError{Underlying: err}
 		return
 	}
 

--- a/sdk/sdktypes/symbol.go
+++ b/sdk/sdktypes/symbol.go
@@ -15,7 +15,7 @@ var InvalidSymbol Symbol
 
 type symbolTraits struct{}
 
-var symbolRE = kittehs.Must1(regexp.Compile(`^[a-zA-Z_][\w]*$`))
+var symbolRE = regexp.MustCompile(`^[a-zA-Z_][\w]*$`)
 
 func (symbolTraits) Validate(s string) error {
 	if s != "" && !symbolRE.MatchString(s) {
@@ -45,5 +45,5 @@ func NewRandomSymbol() Symbol {
 func NewSymbol(s string) Symbol { return forceValidatedString[Symbol](s) }
 
 func NewSymbols(s ...string) []Symbol {
-	return kittehs.Transform(s, func(s string) Symbol { return NewSymbol(s) })
+	return kittehs.Transform(s, NewSymbol)
 }

--- a/sdk/sdktypes/user.go
+++ b/sdk/sdktypes/user.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
-
 	userv1 "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/users/v1"
 )
 

--- a/sdk/sdktypes/value.go
+++ b/sdk/sdktypes/value.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/araddon/dateparse"
@@ -148,11 +149,11 @@ func (v Value) ToString() (string, error) {
 	case StringValue:
 		return v.Value(), nil
 	case IntegerValue:
-		return fmt.Sprintf("%d", v.Value()), nil
+		return strconv.FormatInt(v.Value(), 10), nil
 	case FloatValue:
 		return fmt.Sprintf("%f", v.Value()), nil
 	case BooleanValue:
-		return fmt.Sprintf("%t", v.Value()), nil
+		return strconv.FormatBool(v.Value()), nil
 	case DurationValue:
 		return v.Value().String(), nil
 	case TimeValue:

--- a/sdk/sdktypes/value_function.go
+++ b/sdk/sdktypes/value_function.go
@@ -159,7 +159,7 @@ func NewConstFunctionError(name string, in error) (Value, error) {
 
 func (f FunctionValue) ConstValue() (Value, error) {
 	if !f.HasFlag(ConstFunctionFlag) {
-		return InvalidValue, fmt.Errorf("function is not a const")
+		return InvalidValue, errors.New("function is not a const")
 	}
 
 	bs := f.m.Data

--- a/sdk/sdktypes/value_scalar.go
+++ b/sdk/sdktypes/value_scalar.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"golang.org/x/exp/constraints"
-
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -69,7 +68,7 @@ func (v Value) IsSymbol() bool         { return v.read().Symbol != nil }
 func (v Value) GetSymbol() SymbolValue { return forceFromProto[SymbolValue](v.read().Symbol) }
 
 func NewSymbolValue(s Symbol) Value {
-	return forceFromProto[Value](&ValuePB{Symbol: &SymbolValuePB{Name: string(s.String())}})
+	return forceFromProto[Value](&ValuePB{Symbol: &SymbolValuePB{Name: s.String()}})
 }
 
 func init() {

--- a/sdk/sdktypes/value_unwrap.go
+++ b/sdk/sdktypes/value_unwrap.go
@@ -182,7 +182,7 @@ func (w ValueWrapper) unwrapInto(path string, dstv reflect.Value, v Value) error
 
 	// prefix is the string to prepend to error messages to indicate what errored.
 	if path != "" {
-		path = fmt.Sprintf("%s: ", path)
+		path += ": "
 	}
 
 	// deref ptrs if needed.

--- a/sdk/sdktypes/value_wrap.go
+++ b/sdk/sdktypes/value_wrap.go
@@ -71,7 +71,7 @@ func (w ValueWrapper) Wrap(v any) (Value, error) {
 		fallthrough
 
 	case reflect.Invalid:
-		return InvalidValue, sdkerrors.ErrInvalidArgument{}
+		return InvalidValue, sdkerrors.InvalidArgumentError{}
 
 	case reflect.Ptr:
 		if !vv.IsNil() {
@@ -135,7 +135,7 @@ func (w ValueWrapper) Wrap(v any) (Value, error) {
 		}
 
 		vs := make([]Value, vv.Len())
-		for i := 0; i < vv.Len(); i++ {
+		for i := range vv.Len() {
 			var err error
 			if vs[i], err = w.Wrap(vv.Index(i).Interface()); err != nil {
 				return InvalidValue, fmt.Errorf("%d: %w", i, err)

--- a/sdk/sdktypes/value_wrap_test.go
+++ b/sdk/sdktypes/value_wrap_test.go
@@ -153,7 +153,7 @@ func TestValueWrapper(t *testing.T) {
 }
 
 func TestWrapReader(t *testing.T) {
-	buf := bytes.NewBuffer([]byte("meow"))
+	buf := bytes.NewBufferString("meow")
 	v, err := w.Wrap(buf)
 	if assert.NoError(t, err) {
 		assert.Equal(t, []byte("meow"), v.GetBytes().Value())
@@ -161,14 +161,14 @@ func TestWrapReader(t *testing.T) {
 
 	ww := w
 	ww.WrapReaderAsString = true
-	buf = bytes.NewBuffer([]byte("meow"))
+	buf = bytes.NewBufferString("meow")
 	v, err = ww.Wrap(buf)
 	if assert.NoError(t, err) {
 		assert.Equal(t, "meow", v.GetString().Value())
 	}
 
 	ww.IgnoreReader = true
-	buf = bytes.NewBuffer([]byte("meow"))
+	buf = bytes.NewBufferString("meow")
 	v, err = ww.Wrap(buf)
 	if assert.NoError(t, err) {
 		assert.True(t, v.IsNothing())
@@ -188,7 +188,7 @@ func TestUnwrapIntoScalars(t *testing.T) {
 
 	var s string
 	if assert.NoError(t, w.UnwrapInto(&s, iv)) {
-		// yeah yeah don't blame me, blame reflect for doing this.
+		// Yeah don't blame me, blame reflect for doing this.
 		assert.Equal(t, "*" /* ASCII 42 */, s)
 	}
 

--- a/sdk/sdktypes/vars.go
+++ b/sdk/sdktypes/vars.go
@@ -66,7 +66,7 @@ func EncodeVars(in any) (vs Vars) {
 		sdklogger.Panic("invalid type - must be a struct")
 	}
 
-	for i := 0; i < v.NumField(); i++ {
+	for i := range v.NumField() {
 		fv := v.Field(i)
 		ft := t.Field(i)
 
@@ -100,7 +100,7 @@ func (vs Vars) Decode(out any) {
 		sdklogger.Panic("invalid type - must be a struct")
 	}
 
-	for i := 0; i < v.NumField(); i++ {
+	for i := range v.NumField() {
 		fv := v.Field(i)
 		ft := t.Field(i)
 

--- a/tests/system/client.go
+++ b/tests/system/client.go
@@ -116,13 +116,13 @@ func waitForSession(akPath, akAddr, step string) (string, error) {
 	args = append(serviceUrlArg(akAddr), "event", "list", "--integration=http")
 	result, err := runClient(akPath, args)
 	if err == nil {
-		text += fmt.Sprintf("\nEvent list:\n%s", result.output)
+		text += "\nEvent list:\n" + result.output
 	}
 
 	args = append(serviceUrlArg(akAddr), "session", "list", "-J")
 	result, err = runClient(akPath, args)
 	if err == nil {
-		text += fmt.Sprintf("\n---\nSession list:\n%s", result.output)
+		text += "\n---\nSession list:\n" + result.output
 	}
 	return "", errors.New(text)
 }

--- a/tests/system/server.go
+++ b/tests/system/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -105,7 +106,7 @@ func queryReadyz(result chan<- string) {
 
 		// For now, the availability of "/readyz" is sufficient,
 		// no need to check the response body yet.
-		if resp.resp.StatusCode == 200 {
+		if resp.resp.StatusCode == http.StatusOK {
 			result <- addr
 			return
 		}

--- a/web/webplatform/webplatform.go
+++ b/web/webplatform/webplatform.go
@@ -11,11 +11,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/psanford/memfs"
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
-
-	"github.com/psanford/memfs"
 )
 
 //go:embed VERSION *.zip


### PR DESCRIPTION
Many auto-fixes from linters in `golangci-lint` that we haven't enabled before:

dupword, errname, gci (import order), gocritic, intrange, mirror, nosprintfhostport, perfsprint, unconvert, usestdlibvars

All these fixes are automatic, tiny, and obvious - so this PR should be easy to review even though it contains many files.

This PR is motivated by ENG-1933, even though it doesn't actually address it.

I added some of these linters to our default linting, because `golangci-lint` runs them in parallel, so there shouldn't be a time penalty.

There are actually more important linters to try out, with more important fixes (security bugs, context misuse, complexity, testify mistakes), but they require manual work - which we don't have time for right now.