### PR TITLE
feat(deployments): auto deactivate drained deployments

### DIFF
--- a/internal/backend/db/db.go
+++ b/internal/backend/db/db.go
@@ -111,6 +111,10 @@ type DB interface {
 	CreateDeployment(ctx context.Context, deployment sdktypes.Deployment) error
 	DeleteDeployment(ctx context.Context, deploymentID sdktypes.DeploymentID) error
 	DeploymentHasActiveSessions(ctx context.Context, deploymentID sdktypes.DeploymentID) (bool, error)
+	// Returns number of deployments affected.
+	DeactivateAllDrainedDeployments(ctx context.Context) (int, error)
+	// Returns true if the deployment was deactivated.
+	DeactivateDrainedDeployment(ctx context.Context, did sdktypes.DeploymentID) (bool, error)
 
 	// -----------------------------------------------------------------------
 	CreateSession(ctx context.Context, session sdktypes.Session) error

--- a/internal/backend/db/dbgorm/scheme/records.go
+++ b/internal/backend/db/dbgorm/scheme/records.go
@@ -395,7 +395,7 @@ type Deployment struct {
 	ProjectID    uuid.UUID `gorm:"index;type:uuid;not null"`
 	DeploymentID uuid.UUID `gorm:"primaryKey;type:uuid;not null"`
 	BuildID      uuid.UUID `gorm:"type:uuid;not null"`
-	State        int32
+	State        int32     `gorm:"index"`
 
 	UpdatedBy uuid.UUID `gorm:"type:uuid"`
 	UpdatedAt time.Time

--- a/internal/backend/deployments/deployments_test.go
+++ b/internal/backend/deployments/deployments_test.go
@@ -98,7 +98,7 @@ func (db *testDB) ListSessions(_ context.Context, f sdkservices.ListSessionsFilt
 
 func newTestDeployments(deps map[sdktypes.DeploymentID]*testDeployment) *deployments {
 	return &deployments{
-		z:  zap.NewNop(),
+		l:  zap.NewNop(),
 		db: &testDB{deployments: deps},
 	}
 }

--- a/internal/backend/svc/svc.go
+++ b/internal/backend/svc/svc.go
@@ -190,7 +190,7 @@ func makeFxOpts(cfg *Config, opts RunOptions) []fx.Option {
 		Component("store", store.Configs, fx.Provide(store.New)),
 		Component("builds", configset.Empty, fx.Provide(builds.New)),
 		Component("connections", configset.Empty, fx.Provide(connections.New)),
-		Component("deployments", configset.Empty, fx.Provide(deployments.New)),
+		Component("deployments", deployments.Configs, fx.Provide(deployments.New)),
 		Component("projects", configset.Empty, fx.Provide(projects.New)),
 		Component("projectsgrpcsvc", projectsgrpcsvc.Configs, fx.Provide(projectsgrpcsvc.New)),
 		Component(

--- a/migrations/postgres/20250108023052_deployment_state_index.sql
+++ b/migrations/postgres/20250108023052_deployment_state_index.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+-- create index "idx_deployments_state" to table: "deployments"
+CREATE INDEX "idx_deployments_state" ON "deployments" ("state");
+
+-- +goose Down
+-- reverse: create index "idx_deployments_state" to table: "deployments"
+DROP INDEX "idx_deployments_state";

--- a/migrations/postgres/atlas.sum
+++ b/migrations/postgres/atlas.sum
@@ -1,4 +1,4 @@
-h1:nlmvdMhy4lp0iIAVopHqz8bL0x3ZDThYMJ/35LcneA8=
+h1:FnwKodmw7Vh1SSiU6vJq68kdn1LQ/dkdurOaISR+GOI=
 20240704121932_baseline.sql h1:1JS9FYe08Ef0wTpJIeeL4wIqHc8E/RXhuqmTI/FwkzY=
 20240714051207_no-db-user.sql h1:tx0AwepNeeL/XWD74sLRGwisrkNs4lyH/H4BG/663FQ=
 20240727114921_project-not-nil-name.sql h1:ZG3tDLzQSxd81S4BDe/IOMktltkurwyuFwu5gkqQvrA=
@@ -18,3 +18,4 @@ h1:nlmvdMhy4lp0iIAVopHqz8bL0x3ZDThYMJ/35LcneA8=
 20241225035419_authz.sql h1:p2Z0lqxgfXhUaeG5HfhMzJhu030pjwG9Mm5ETme1bPE=
 20250103031743_user_status.sql h1:4ko5UhMG28jG0fhxC40ZRaYhJ5eDe2mHfsNaSJ33hoo=
 20250103230229_org_member_status.sql h1:ZjWNeb7vKcOAArzVbQA+wf+tmrkt/fX4QPVptV8AhHY=
+20250108023052_deployment_state_index.sql h1:2Oj+RjmmA6LiARWXDbmzZoOzxIBFn3Lkd7e3vMyTCtg=

--- a/migrations/sqlite/20250108023047_deployment_state_index.sql
+++ b/migrations/sqlite/20250108023047_deployment_state_index.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+-- create index "idx_deployments_state" to table: "deployments"
+CREATE INDEX `idx_deployments_state` ON `deployments` (`state`);
+
+-- +goose Down
+-- reverse: create index "idx_deployments_state" to table: "deployments"
+DROP INDEX `idx_deployments_state`;

--- a/migrations/sqlite/atlas.sum
+++ b/migrations/sqlite/atlas.sum
@@ -1,4 +1,4 @@
-h1:NBr7ahsvRXsbH5sfu47tGH4lwjfu2qv0vMpjb4sc4a4=
+h1:Zd5VOSke/i14gBn1sMRv7YyJEEMebK2d5E+vDgVT+WQ=
 20240704121927_baseline.sql h1:Urgmm304lCno+ou4WguUjFGiqu2PYoIOlswHpSL1lRg=
 20240714051159_no-db-user.sql h1:FRReTH5AzKrGU3qp0laWWzkgiBc5693KZIpgrjY81d8=
 20240727114913_project-not-nil-name.sql h1:tRZh+O1yx/QZuytlirQJA0f9Ga/m3FDNM9yE5eJDv1I=
@@ -18,3 +18,4 @@ h1:NBr7ahsvRXsbH5sfu47tGH4lwjfu2qv0vMpjb4sc4a4=
 20241225035414_authz.sql h1:fX2jMEUWARnoa2NRaeZ5q98KSakQXjwl8hM2wYbLhqA=
 20250103031738_user_status.sql h1:NsU2CwIh+hQ8tWraxQRn0S4vK+eYzZm0ywDs1rszCAo=
 20250103230218_org_member_status.sql h1:0lpi9/QFb5eMlvtYmvw5Fn1l4dw5mmADe2RlYAI8zkA=
+20250108023047_deployment_state_index.sql h1:2l5gSt3f+6Tk59IQhihjssWas4NiBEYFDp7+Z9r8OQ0=

--- a/sdk/sdktypes/enum.go
+++ b/sdk/sdktypes/enum.go
@@ -34,6 +34,8 @@ func (e enum[T, E]) Prefix() string { var t T; return t.Prefix() }
 
 func (e enum[T, E]) ToProto() E { return e.v }
 
+func (e enum[T, E]) ToInt() int { return int(e.v) }
+
 func (e enum[T, E]) Strict() error {
 	if e.v == 0 {
 		return sdkerrors.NewInvalidArgumentError("unspecified")

--- a/sdk/sdktypes/session_state_type.go
+++ b/sdk/sdktypes/session_state_type.go
@@ -40,8 +40,6 @@ func ParseSessionStateType(raw string) (SessionStateType, error) {
 	return ParseEnum[SessionStateType](raw)
 }
 
-func (e SessionStateType) IsFinal() bool {
-	return e.v == sessionsv1.SessionStateType_SESSION_STATE_TYPE_ERROR ||
-		e.v == sessionsv1.SessionStateType_SESSION_STATE_TYPE_COMPLETED ||
-		e.v == sessionsv1.SessionStateType_SESSION_STATE_TYPE_STOPPED
-}
+var FinalSessionStateTypes = []SessionStateType{SessionStateTypeError, SessionStateTypeCompleted, SessionStateTypeStopped}
+
+func (e SessionStateType) IsFinal() bool { return kittehs.ContainedIn(FinalSessionStateTypes...)(e) }


### PR DESCRIPTION
- improve deactivation logic by performing it in a single SQL query.
- periodically auto-deactivate drained deployments in the deployments module. use interval and jitter to minimize collisions between instances.