### PR TITLE
feat: add slack channel_rename event handler

### DIFF
--- a/integrations/slack/events/channel.go
+++ b/integrations/slack/events/channel.go
@@ -11,18 +11,22 @@ import (
 )
 
 // https://api.slack.com/events/channel_created
-type ChannelCreatedEvent struct {
+// https://api.slack.com/events/channel_rename
+// https://api.slack.com/events/group_rename
+type ChannelCreatedRenameEvent struct {
 	Type    string                 `json:"type,omitempty"`
 	Channel *conversations.Channel `json:"channel,omitempty"`
 	EventTS string                 `json:"event_ts,omitempty"`
 }
 
 type channelCreatedContainer struct {
-	Event *ChannelCreatedEvent `json:"event"`
+	Event *ChannelCreatedRenameEvent `json:"event"`
 }
 
 // https://api.slack.com/events/channel_created
-func ChannelCreatedHandler(l *zap.Logger, w http.ResponseWriter, body []byte, cb *Callback) any {
+// https://api.slack.com/events/channel_rename
+// https://api.slack.com/events/group_rename
+func ChannelCreatedRenameHandler(l *zap.Logger, w http.ResponseWriter, body []byte, cb *Callback) any {
 	// Parse the inner event details.
 	j := &channelCreatedContainer{}
 	if err := json.Unmarshal(body, j); err != nil {
@@ -104,31 +108,5 @@ func ChannelGroupMemberHandler(l *zap.Logger, w http.ResponseWriter, body []byte
 		invalidEventError(l, w, body, err)
 		return nil
 	}
-	return j.Event
-}
-
-// https://api.slack.com/events/channel_rename
-// https://api.slack.com/events/group_rename
-type ChannelRenameEvent struct {
-	Type    string                 `json:"type,omitempty"`
-	Channel *conversations.Channel `json:"channel,omitempty"`
-	EventTS string                 `json:"event_ts,omitempty"`
-}
-
-type channelRenameContainer struct {
-	Event *ChannelRenameEvent `json:"event"`
-}
-
-// https://api.slack.com/events/channel_rename
-// https://api.slack.com/events/group_rename
-func ChannelRenameHandler(l *zap.Logger, w http.ResponseWriter, body []byte, cb *Callback) any {
-	// Parse the inner event details.
-	j := &channelRenameContainer{}
-	if err := json.Unmarshal(body, j); err != nil {
-		invalidEventError(l, w, body, err)
-		return nil
-	}
-
-	// Return the inner event details.
 	return j.Event
 }

--- a/integrations/slack/events/channel.go
+++ b/integrations/slack/events/channel.go
@@ -106,3 +106,27 @@ func ChannelGroupMemberHandler(l *zap.Logger, w http.ResponseWriter, body []byte
 	}
 	return j.Event
 }
+
+// https://api.slack.com/events/channel_rename
+type ChannelRenameEvent struct {
+	Type    string                 `json:"type,omitempty"`
+	Channel *conversations.Channel `json:"channel,omitempty"`
+	EventTS string                 `json:"event_ts,omitempty"`
+}
+
+type channelRenameContainer struct {
+	Event *ChannelRenameEvent `json:"event"`
+}
+
+// https://api.slack.com/events/channel_rename
+func ChannelRenameHandler(l *zap.Logger, w http.ResponseWriter, body []byte, cb *Callback) any {
+	// Parse the inner event details.
+	j := &channelRenameContainer{}
+	if err := json.Unmarshal(body, j); err != nil {
+		invalidEventError(l, w, body, err)
+		return nil
+	}
+
+	// Return the inner event details.
+	return j.Event
+}

--- a/integrations/slack/events/channel.go
+++ b/integrations/slack/events/channel.go
@@ -108,6 +108,7 @@ func ChannelGroupMemberHandler(l *zap.Logger, w http.ResponseWriter, body []byte
 }
 
 // https://api.slack.com/events/channel_rename
+// https://api.slack.com/events/group_rename
 type ChannelRenameEvent struct {
 	Type    string                 `json:"type,omitempty"`
 	Channel *conversations.Channel `json:"channel,omitempty"`
@@ -119,6 +120,7 @@ type channelRenameContainer struct {
 }
 
 // https://api.slack.com/events/channel_rename
+// https://api.slack.com/events/group_rename
 func ChannelRenameHandler(l *zap.Logger, w http.ResponseWriter, body []byte, cb *Callback) any {
 	// Parse the inner event details.
 	j := &channelRenameContainer{}

--- a/integrations/slack/webhooks/bot_events.go
+++ b/integrations/slack/webhooks/bot_events.go
@@ -24,16 +24,16 @@ var BotEventHandlers = map[string]BotEventHandler{
 	// TODO: app_uninstalled
 
 	"channel_archive": events.ChannelGroupMemberHandler,
-	"channel_created": events.ChannelCreatedHandler,
+	"channel_created": events.ChannelCreatedRenameHandler,
 	// TODO: channel_history_changed
 	// TODO: channel_id_changed
-	"channel_rename":    events.ChannelRenameHandler,
+	"channel_rename":    events.ChannelCreatedRenameHandler,
 	"channel_unarchive": events.ChannelGroupMemberHandler,
 
 	"group_archive": events.ChannelGroupMemberHandler,
 	// TODO: group_history_changed
 	"group_open":      events.ChannelGroupMemberHandler,
-	"group_rename":    events.ChannelRenameHandler,
+	"group_rename":    events.ChannelCreatedRenameHandler,
 	"group_unarchive": events.ChannelGroupMemberHandler,
 
 	// TODO: im_history_changed

--- a/integrations/slack/webhooks/bot_events.go
+++ b/integrations/slack/webhooks/bot_events.go
@@ -32,8 +32,8 @@ var BotEventHandlers = map[string]BotEventHandler{
 
 	"group_archive": events.ChannelGroupMemberHandler,
 	// TODO: group_history_changed
-	"group_open": events.ChannelGroupMemberHandler,
-	// TODO: group_rename
+	"group_open":      events.ChannelGroupMemberHandler,
+	"group_rename":    events.ChannelRenameHandler,
 	"group_unarchive": events.ChannelGroupMemberHandler,
 
 	// TODO: im_history_changed

--- a/integrations/slack/webhooks/bot_events.go
+++ b/integrations/slack/webhooks/bot_events.go
@@ -27,7 +27,7 @@ var BotEventHandlers = map[string]BotEventHandler{
 	"channel_created": events.ChannelCreatedHandler,
 	// TODO: channel_history_changed
 	// TODO: channel_id_changed
-	// TODO: channel_rename
+	"channel_rename":    events.ChannelRenameHandler,
 	"channel_unarchive": events.ChannelGroupMemberHandler,
 
 	"group_archive": events.ChannelGroupMemberHandler,


### PR DESCRIPTION
ChannelRenameHandler has been added to handle the channel_rename event. Additionally, the same handler has been implemented to manage the group_rename event, as it uses an identical JSON structure.

refs: INT-87