### PR TITLE
fix(python): enable project unit tests in Kittehub

### DIFF
--- a/runtimes/pythonrt/py-sdk/autokitteh/github.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/github.py
@@ -27,6 +27,9 @@ def github_client(connection: str, **kwargs) -> Github:
     """
     check_connection_name(connection)
 
+    if os.getenv("AUTOKITTEH_UNIT_TEST"):
+        return Github(auth=Auth.Token("dummy_pat"), **kwargs)
+
     # Optional: GitHub Enterprise Server
     base_url = os.getenv("GITHUB_ENTERPRISE_URL")
     if base_url:

--- a/runtimes/pythonrt/py-sdk/autokitteh/slack.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/slack.py
@@ -30,6 +30,9 @@ def slack_client(connection: str, **kwargs) -> WebClient:
     """
     check_connection_name(connection)
 
+    if os.getenv("AUTOKITTEH_UNIT_TEST"):
+        return WebClient("dummy_bot_token", **kwargs)
+
     bot_token = os.getenv(connection + "__oauth_AccessToken")  # OAuth v2
     if not bot_token:
         bot_token = os.getenv(connection + "__BotToken")  # Socket Mode

--- a/runtimes/pythonrt/py-sdk/pyproject.toml
+++ b/runtimes/pythonrt/py-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'autokitteh'
-version = '0.3.8'
+version = '0.3.9'
 description = 'AutoKitteh Python SDK'
 readme = 'README.md'
 license = {file = 'LICENSE'}


### PR DESCRIPTION
Return dummy GitHub and Slack clients instead of `ConnectionInitError` when the AutoKitteh Python SDK is running within unit tests (determined by the existence of a special environment variable).

Usage of this fix requires releasing to PyPI after merging.

Refs: INT-159