### PR TITLE
refactor(authn): simplify sub-middlewares and testing

### DIFF
--- a/internal/backend/auth/authhttpmiddleware/authmiddleware.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware.go
@@ -1,11 +1,12 @@
 package authhttpmiddleware
 
 import (
-	"context"
+	"errors"
 	"net/http"
 	"strings"
 
 	"go.uber.org/fx"
+	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authcontext"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authsessions"
@@ -27,145 +28,141 @@ var Configs = configset.Set[Config]{
 	Dev:     &Config{UseDefaultUser: true},
 }
 
-// The middleware passes around internally the authenticated user ID,
-// so that we can check only once in the AuthMiddlewareDecorator for
-// the common stuff - that the user exists and that it is not disabled.
-// The AuthMiddlewareDecorator will call eventually the authcontext.SetAuthnUser
-// if the user is deemed worthy of authentication.
-type userIDCtxKey string
-
-var userIDContextKey = userIDCtxKey("authn_user_id")
-
-func ctxWithUserID(ctx context.Context, id sdktypes.UserID) context.Context {
-	return context.WithValue(ctx, userIDContextKey, id)
-}
-
-func getCtxUserID(ctx context.Context) sdktypes.UserID {
-	v := ctx.Value(userIDContextKey)
-	if v == nil {
-		return sdktypes.InvalidUserID
-	}
-
-	return v.(sdktypes.UserID)
-}
-
 type AuthMiddlewareDecorator func(http.Handler) http.Handler
 
 type Deps struct {
 	fx.In
 
+	L        *zap.Logger
 	Cfg      *Config
 	Users    sdkservices.Users
 	Sessions authsessions.Store `optional:"true"`
 	Tokens   authtokens.Tokens  `optional:"true"`
 }
 
-// ifAuthenticated is a middleware that checks if the user is authenticated.
-// If the user is authenticated, it calls the `yes` handler, otherwise it calls the `no` handler.
-func ifAuthenticated(yes, no http.Handler) http.HandlerFunc {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		next := no
-
-		if getCtxUserID(r.Context()).IsValid() {
-			next = yes
-		}
-
-		next.ServeHTTP(w, r)
-	})
+type middlewareError struct {
+	code int
+	msg  string
 }
 
-func newTokensMiddleware(next http.Handler, tokens authtokens.Tokens) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func (m *middlewareError) apply(w http.ResponseWriter) { http.Error(w, m.msg, m.code) }
+
+func newMiddlewareError(code int, msg string) *middlewareError {
+	return &middlewareError{code: code, msg: msg}
+}
+
+// middlewareFn is a function that extracts a user ID from a request.
+// It returns the user ID and an error if the request is invalid.
+type middlewareFn func(*http.Request) (sdktypes.UserID, *middlewareError)
+
+func newTokensMiddleware(tokens authtokens.Tokens) middlewareFn {
+	return func(r *http.Request) (sdktypes.UserID, *middlewareError) {
 		authHdr := r.Header.Get("Authorization")
-
 		if authHdr == "" {
-			next.ServeHTTP(w, r)
-			return
+			return sdktypes.InvalidUserID, nil
 		}
-
-		ctx := r.Context()
 
 		kind, payload, _ := strings.Cut(authHdr, " ")
 
 		if kind != "Bearer" {
-			http.Error(w, "invalid authorization header", http.StatusUnauthorized)
-			return
+			return sdktypes.InvalidUserID, newMiddlewareError(http.StatusUnauthorized, "invalid authorization header")
 		}
 
 		u, err := tokens.Parse(payload)
 		if err != nil {
-			http.Error(w, "invalid token", http.StatusUnauthorized)
-			return
+			return sdktypes.InvalidUserID, newMiddlewareError(http.StatusUnauthorized, "invalid token")
 		}
 
-		next.ServeHTTP(w, r.WithContext(ctxWithUserID(ctx, u.ID())))
+		return u.ID(), nil
 	}
 }
 
-func newSessionsMiddleware(next http.Handler, sessions authsessions.Store) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func newSessionsMiddleware(sessions authsessions.Store) middlewareFn {
+	return func(r *http.Request) (sdktypes.UserID, *middlewareError) {
 		session, err := sessions.Get(r)
 		// Do not fail on error - graceful degradation in case of session structure changes.
 		if err == nil && session != nil {
-			r = r.WithContext(ctxWithUserID(r.Context(), session.UserID))
+			return session.UserID, nil
 		}
 
-		next.ServeHTTP(w, r)
+		return sdktypes.InvalidUserID, nil
 	}
 }
 
-func newSetDefaultUserMiddleware(next http.Handler) http.HandlerFunc {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		next.ServeHTTP(w, r.WithContext(ctxWithUserID(r.Context(), authusers.DefaultUser.ID())))
-	})
+func setDefaultUserMiddleware(r *http.Request) (sdktypes.UserID, *middlewareError) {
+	return authusers.DefaultUser.ID(), nil
 }
 
 func New(deps Deps) AuthMiddlewareDecorator {
 	sessions, users, tokens := deps.Sessions, deps.Users, deps.Tokens
 
-	return func(next http.Handler) http.Handler {
-		// Order matters here!
+	var mws []middlewareFn
 
-		// Evaluated last.
-		f := ifAuthenticated(
-			/* authenticated: */ http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				// make sure the user exists.
-				ctx := r.Context()
+	if tokens != nil {
+		mws = append(mws, newTokensMiddleware(tokens))
+	}
 
-				uid := getCtxUserID(ctx)
+	if sessions != nil {
+		mws = append(mws, newSessionsMiddleware(sessions))
+	}
 
-				u, err := users.Get(authcontext.SetAuthnSystemUser(ctx), uid, "")
-				if err != nil {
-					http.Error(w, "unknown user", http.StatusUnauthorized)
-					return
+	if deps.Cfg.UseDefaultUser {
+		mws = append(mws, setDefaultUserMiddleware)
+	}
+
+	return func(next http.Handler) http.Handler { // = AuthMiddlewareDecorator
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Process all middlewares.
+			var (
+				uid   sdktypes.UserID
+				mwErr *middlewareError
+			)
+
+			for _, mw := range mws {
+				// Stop processing middlewares if a valid user ID is found or there is an error.
+				if uid, mwErr = mw(r); uid.IsValid() || mwErr != nil {
+					break
 				}
+			}
 
-				if u.Status() != sdktypes.UserStatusActive {
-					http.Error(w, "user is not active", http.StatusUnauthorized)
-					return
-				}
+			l := deps.L
 
-				next.ServeHTTP(w, r.WithContext(authcontext.SetAuthnUser(ctx, u)))
-			}),
-			/* not authenticated: */ http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if mwErr != nil {
+				l.Info("auth middleware error", zap.Error(errors.New(mwErr.msg)))
+				mwErr.apply(w)
+				return
+			}
+
+			// Check if authenticated.
+			if !uid.IsValid() {
+				l.Info("not authenticated")
 				http.Error(w, "unauthenticated", http.StatusUnauthorized)
-			}),
-		)
+				return
+			}
 
-		if deps.Cfg.UseDefaultUser {
-			f = ifAuthenticated(f, newSetDefaultUserMiddleware(f))
-		}
+			// Hydrate user and check if it's active.
+			l = l.With(zap.String("user_id", uid.String()))
 
-		if sessions != nil {
-			f = ifAuthenticated(f, newSessionsMiddleware(f, sessions))
-		}
+			ctx := r.Context()
 
-		// Evaluated first.
-		if tokens != nil {
-			f = ifAuthenticated(f, newTokensMiddleware(f, tokens))
-		}
+			u, err := users.Get(authcontext.SetAuthnSystemUser(ctx), uid, "")
+			if err != nil {
+				l.Warn("failed to get user", zap.Error(err))
+				http.Error(w, "unknown user", http.StatusUnauthorized)
+				return
+			}
 
-		return f
+			if u.Status() != sdktypes.UserStatusActive {
+				l.Info("user is not active")
+				http.Error(w, "user is not active", http.StatusUnauthorized)
+				return
+			}
+
+			ctx = authcontext.SetAuthnUser(ctx, u)
+
+			// Propagate the request to the next handler.
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
 	}
 }
 

--- a/internal/backend/auth/authhttpmiddleware/authmiddleware_test.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware_test.go
@@ -155,7 +155,7 @@ func newTestHarness(t *testing.T, useDefaultUser bool) *harness {
 	}
 
 	mw := New(Deps{
-		L:        zaptest.NewLogger(t),
+		Logger:   zaptest.NewLogger(t),
 		Sessions: sessions,
 		Tokens:   tokens,
 		Users:    users,

--- a/internal/backend/auth/authhttpmiddleware/authmiddleware_test.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authcontext"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authsessions"
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authtokens"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authtokens/authjwttokens"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authusers"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
@@ -56,23 +58,12 @@ func assertCalledWithoutAuthn(t *testing.T, given *sdktypes.UserID) {
 	}
 }
 
-// Returns a handler and a function that returns the authenticated user.
-// If the handle was not called, the function will return nil.
-// That function also resets the user and called states when its called.
-func newInternalTestHandler(t *testing.T) (http.Handler, func() *sdktypes.UserID) {
-	return newTestHandler(t, getCtxUserID)
-}
-
 func newOverallTestHandler(t *testing.T) (http.Handler, func() *sdktypes.UserID) {
 	return newTestHandler(t, authcontext.GetAuthnUserID)
 }
 
-func newRequest(u sdktypes.User, authHeader string, cookies []*http.Cookie) *http.Request {
+func newRequest(authHeader string, cookies []*http.Cookie) *http.Request {
 	req := kittehs.Must1(http.NewRequest(http.MethodGet, "/", nil))
-
-	if u.IsValid() {
-		req = req.WithContext(ctxWithUserID(context.Background(), u.ID()))
-	}
 
 	if authHeader != "" {
 		req.Header.Set("Authorization", authHeader)
@@ -85,300 +76,293 @@ func newRequest(u sdktypes.User, authHeader string, cookies []*http.Cookie) *htt
 	return req
 }
 
-func TestIfAuthenticated(t *testing.T) {
-	yup, yupped := newInternalTestHandler(t)
-	nope, noped := newInternalTestHandler(t)
-
-	mw := ifAuthenticated(yup, nope)
-
-	mw.ServeHTTP(nil, newRequest(sdktypes.InvalidUser, "", nil))
-	assertCalledWithoutAuthn(t, noped())
-	assert.Nil(t, yupped())
-
-	mw.ServeHTTP(nil, newRequest(testUser1, "", nil))
-	assert.Nil(t, noped())
-	assertCalledWithUser(t, testUser1.ID(), yupped())
-}
-
 func TestDefaultUserMiddleware(t *testing.T) {
-	h, check := newInternalTestHandler(t)
-
-	mw := ifAuthenticated(h, newSetDefaultUserMiddleware(h))
-
-	// When no other auth in context, should use default user.
-	w := httptest.NewRecorder()
-	mw.ServeHTTP(nil, newRequest(sdktypes.InvalidUser, "", nil))
-	assert.Equal(t, http.StatusOK, w.Code)
-	assertCalledWithUser(t, authusers.DefaultUser.ID(), check())
-
-	// When other auth in context, use that authn user.
-	w = httptest.NewRecorder()
-	mw.ServeHTTP(nil, newRequest(testUser1, "", nil))
-	assert.Equal(t, http.StatusOK, w.Code)
-	assertCalledWithUser(t, testUser1.ID(), check())
+	uid, mwErr := setDefaultUserMiddleware(newRequest("", nil))
+	if assert.Nil(t, mwErr) {
+		assert.Equal(t, authusers.DefaultUser.ID(), uid)
+	}
 }
 
 func TestTokensMiddleware(t *testing.T) {
-	h, check := newInternalTestHandler(t)
-
 	tokens := kittehs.Must1(authjwttokens.New(authjwttokens.Configs.Dev))
 
-	mw := newTokensMiddleware(h, tokens)
+	mw := newTokensMiddleware(tokens)
 
 	// no header - should be nop.
-	w := httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", nil))
-	assert.Equal(t, http.StatusOK, w.Code)
-	assertCalledWithoutAuthn(t, check())
+	uid, mwErr := mw(newRequest("", nil))
+	if assert.Nil(t, mwErr) {
+		assert.False(t, uid.IsValid())
+	}
 
 	// correct token.
 	tok := kittehs.Must1(tokens.Create(testUser1))
-	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok, nil))
-	assert.Equal(t, http.StatusOK, w.Code)
-	assertCalledWithUser(t, testUser1.ID(), check())
+	uid, mwErr = mw(newRequest("Bearer "+tok, nil))
+	if assert.Nil(t, mwErr) {
+		assert.True(t, uid.IsValid())
+	}
 
 	// bad token.
-	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "meow", nil))
-	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Nil(t, check())
+	uid, mwErr = mw(newRequest("hiss", nil))
+	if assert.NotNil(t, mwErr) {
+		assert.Equal(t, http.StatusUnauthorized, mwErr.code)
+	}
+	assert.False(t, uid.IsValid())
 }
 
 func TestSessionsMiddleware(t *testing.T) {
-	h, check := newInternalTestHandler(t)
-
 	sessions := kittehs.Must1(authsessions.New(authsessions.Configs.Dev))
 
-	mw := newSessionsMiddleware(h, sessions)
+	mw := newSessionsMiddleware(sessions)
 
 	// no session - should be nop.
-	w := httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", nil))
-	assert.Equal(t, http.StatusOK, w.Code)
-	assertCalledWithoutAuthn(t, check())
+	uid, mwErr := mw(newRequest("", nil))
+	if assert.Nil(t, mwErr) {
+		assert.False(t, uid.IsValid())
+	}
 
-	w = httptest.NewRecorder()
+	w := httptest.NewRecorder()
 	kittehs.Must0(sessions.Set(w, authsessions.NewSessionData(testUser1.ID())))
 	cookies := w.Result().Cookies()
 
 	// legit cookies.
-	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", cookies))
-	assert.Equal(t, http.StatusOK, w.Code)
-	assertCalledWithUser(t, testUser1.ID(), check())
+	uid, mwErr = mw(newRequest("", cookies))
+	if assert.Nil(t, mwErr) {
+		assert.True(t, uid.IsValid())
+	}
 
-	// bad cookie - nop.
+	// bad cookie - nop (a bad cookie should not fail the middleware).
 	for i := range cookies {
-		w = httptest.NewRecorder()
-
 		badCookies := make([]*http.Cookie, len(cookies))
 		copy(badCookies, cookies)
 		badCookies[i].Value = "hiss"
 
-		mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", badCookies))
-		assert.Equal(t, http.StatusOK, w.Code)
-		assertCalledWithoutAuthn(t, check())
+		uid, mwErr = mw(newRequest("", badCookies))
+		if assert.Nil(t, mwErr) {
+			assert.False(t, uid.IsValid())
+		}
 	}
 }
 
-func TestNewWithoutDefaultUser(t *testing.T) {
+type harness struct {
+	mw       http.Handler
+	check    func() *sdktypes.UserID
+	sessions authsessions.Store
+	tokens   authtokens.Tokens
+	users    *sdktest.TestUsers
+}
+
+func newTestHarness(t *testing.T, useDefaultUser bool) *harness {
 	h, check := newOverallTestHandler(t)
 
 	sessions := kittehs.Must1(authsessions.New(authsessions.Configs.Dev))
 	tokens := kittehs.Must1(authjwttokens.New(authjwttokens.Configs.Dev))
 	users := &sdktest.TestUsers{}
 
+	if useDefaultUser {
+		users.Users = map[sdktypes.UserID]sdktypes.User{
+			authusers.DefaultUser.ID(): authusers.DefaultUser,
+		}
+	}
+
 	mw := New(Deps{
+		L:        zaptest.NewLogger(t),
 		Sessions: sessions,
 		Tokens:   tokens,
 		Users:    users,
-		Cfg:      &Config{UseDefaultUser: false},
+		Cfg:      &Config{UseDefaultUser: useDefaultUser},
 	})(h)
+
+	return &harness{
+		mw:       mw,
+		check:    check,
+		sessions: sessions,
+		tokens:   tokens,
+		users:    users,
+	}
+}
+
+func TestMiddlewareError(t *testing.T) {
+	h := newTestHarness(t, false)
+
+	w := httptest.NewRecorder()
+	h.mw.ServeHTTP(w, newRequest("Bearer hisss", nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Nil(t, h.check())
+
+	assert.Equal(t, "invalid token\n", w.Body.String())
+}
+
+func TestNewWithoutDefaultUser(t *testing.T) {
+	h := newTestHarness(t, false)
 
 	// no auth - reject.
 	w := httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", nil))
+	h.mw.ServeHTTP(w, newRequest("", nil))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Nil(t, check())
+	assert.Nil(t, h.check())
 
 	// correct token, but no such user.
-	tok1 := kittehs.Must1(tokens.Create(testUser1))
+	tok1 := kittehs.Must1(h.tokens.Create(testUser1))
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok1, nil))
+	h.mw.ServeHTTP(w, newRequest("Bearer "+tok1, nil))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Nil(t, check())
+	assert.Nil(t, h.check())
 
 	// correct token, but no such user.
 	w = httptest.NewRecorder()
-	kittehs.Must0(sessions.Set(w, authsessions.NewSessionData(testUser1.ID())))
+	kittehs.Must0(h.sessions.Set(w, authsessions.NewSessionData(testUser1.ID())))
 	cookies := w.Result().Cookies()
 
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", cookies))
+	h.mw.ServeHTTP(w, newRequest("", cookies))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Nil(t, check())
+	assert.Nil(t, h.check())
 
 	// create a disabled user.
-	users.Users = map[sdktypes.UserID]sdktypes.User{
+	h.users.Users = map[sdktypes.UserID]sdktypes.User{
 		testUser1.ID(): testUser1.WithStatus(sdktypes.UserStatusDisabled),
 	}
 
 	// correct token, user is disabled.
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok1, nil))
+	h.mw.ServeHTTP(w, newRequest("Bearer "+tok1, nil))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Nil(t, check())
+	assert.Nil(t, h.check())
 
 	// correct session, user is disabled.
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", cookies))
+	h.mw.ServeHTTP(w, newRequest("", cookies))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Nil(t, check())
+	assert.Nil(t, h.check())
 
 	// create a invited user.
-	users.Users = map[sdktypes.UserID]sdktypes.User{
+	h.users.Users = map[sdktypes.UserID]sdktypes.User{
 		testUser1.ID(): testUser1.WithStatus(sdktypes.UserStatusInvited),
 	}
 
 	// correct token, user is invited.
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok1, nil))
+	h.mw.ServeHTTP(w, newRequest("Bearer "+tok1, nil))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Nil(t, check())
+	assert.Nil(t, h.check())
 
 	// correct session, user is invited.
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", cookies))
+	h.mw.ServeHTTP(w, newRequest("", cookies))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Nil(t, check())
+	assert.Nil(t, h.check())
 
 	// enable the user.
-	users.Users = map[sdktypes.UserID]sdktypes.User{
+	h.users.Users = map[sdktypes.UserID]sdktypes.User{
 		testUser1.ID(): testUser1,
 	}
 
 	// correct token, user is ok.
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok1, nil))
+	h.mw.ServeHTTP(w, newRequest("Bearer "+tok1, nil))
 	assert.Equal(t, http.StatusOK, w.Code)
-	assertCalledWithUser(t, testUser1.ID(), check())
+	assertCalledWithUser(t, testUser1.ID(), h.check())
 
 	// correct session, user is ok.
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", cookies))
+	h.mw.ServeHTTP(w, newRequest("", cookies))
 	assert.Equal(t, http.StatusOK, w.Code)
-	assertCalledWithUser(t, testUser1.ID(), check())
+	assertCalledWithUser(t, testUser1.ID(), h.check())
 
 	// both token and session for same user.
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok1, cookies))
+	h.mw.ServeHTTP(w, newRequest("Bearer "+tok1, cookies))
 	assert.Equal(t, http.StatusOK, w.Code)
-	assertCalledWithUser(t, testUser1.ID(), check())
+	assertCalledWithUser(t, testUser1.ID(), h.check())
 
 	// token for token user, session for other user.
 	// token > session.
-	users.Users[testUser2.ID()] = testUser2
+	h.users.Users[testUser2.ID()] = testUser2
 	w = httptest.NewRecorder()
-	tok2 := kittehs.Must1(tokens.Create(testUser2))
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok2, cookies))
+	tok2 := kittehs.Must1(h.tokens.Create(testUser2))
+	h.mw.ServeHTTP(w, newRequest("Bearer "+tok2, cookies))
 	assert.Equal(t, http.StatusOK, w.Code)
-	assertCalledWithUser(t, testUser2.ID(), check())
+	assertCalledWithUser(t, testUser2.ID(), h.check())
 
 	// token for token user who is disabled, session for other user.
 	// token > session, and is rejected.
-	users.Users[testUser2.ID()] = testUser2.WithStatus(sdktypes.UserStatusDisabled)
+	h.users.Users[testUser2.ID()] = testUser2.WithStatus(sdktypes.UserStatusDisabled)
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok2, cookies))
+	h.mw.ServeHTTP(w, newRequest("Bearer "+tok2, cookies))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Nil(t, check())
+	assert.Nil(t, h.check())
 }
 
 func TestNewWithDefaultUser(t *testing.T) {
-	h, check := newOverallTestHandler(t)
-
-	sessions := kittehs.Must1(authsessions.New(authsessions.Configs.Dev))
-	tokens := kittehs.Must1(authjwttokens.New(authjwttokens.Configs.Dev))
-	users := &sdktest.TestUsers{
-		Users: map[sdktypes.UserID]sdktypes.User{
-			authusers.DefaultUser.ID(): authusers.DefaultUser,
-		},
-	}
-
-	mw := New(Deps{
-		Sessions: sessions,
-		Tokens:   tokens,
-		Users:    users,
-		Cfg:      &Config{UseDefaultUser: true},
-	})(h)
+	h := newTestHarness(t, true)
 
 	// no auth.
 	w := httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", nil))
+	h.mw.ServeHTTP(w, newRequest("", nil))
 	assert.Equal(t, http.StatusOK, w.Code)
-	assertCalledWithUser(t, authusers.DefaultUser.ID(), check())
+	assertCalledWithUser(t, authusers.DefaultUser.ID(), h.check())
 
 	// correct token, but no such user.
-	tok1 := kittehs.Must1(tokens.Create(testUser1))
+	tok1 := kittehs.Must1(h.tokens.Create(testUser1))
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok1, nil))
+	h.mw.ServeHTTP(w, newRequest("Bearer "+tok1, nil))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Nil(t, check())
+	assert.Nil(t, h.check())
 
 	// correct session, but no such user.
 	w = httptest.NewRecorder()
-	kittehs.Must0(sessions.Set(w, authsessions.NewSessionData(testUser1.ID())))
+	kittehs.Must0(h.sessions.Set(w, authsessions.NewSessionData(testUser1.ID())))
 	cookies := w.Result().Cookies()
 
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", cookies))
+	h.mw.ServeHTTP(w, newRequest("", cookies))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Nil(t, check())
+	assert.Nil(t, h.check())
 
 	// create a disabled user.
-	users.Users[testUser1.ID()] = testUser1.WithStatus(sdktypes.UserStatusDisabled)
+	h.users.Users[testUser1.ID()] = testUser1.WithStatus(sdktypes.UserStatusDisabled)
 
 	// correct token, user is disabled.
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok1, nil))
+	h.mw.ServeHTTP(w, newRequest("Bearer "+tok1, nil))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Nil(t, check())
+	assert.Nil(t, h.check())
 
 	// correct token, user is disabled.
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", cookies))
+	h.mw.ServeHTTP(w, newRequest("", cookies))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Nil(t, check())
+	assert.Nil(t, h.check())
 
 	// create an invited user.
-	users.Users[testUser1.ID()] = testUser1.WithStatus(sdktypes.UserStatusInvited)
+	h.users.Users[testUser1.ID()] = testUser1.WithStatus(sdktypes.UserStatusInvited)
 
 	// correct token, user is invited.
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok1, nil))
+	h.mw.ServeHTTP(w, newRequest("Bearer "+tok1, nil))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Nil(t, check())
+	assert.Nil(t, h.check())
 
 	// correct token, user is invited.
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", cookies))
+	h.mw.ServeHTTP(w, newRequest("", cookies))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Nil(t, check())
+	assert.Nil(t, h.check())
 
 	// enable the user.
-	users.Users = map[sdktypes.UserID]sdktypes.User{
+	h.users.Users = map[sdktypes.UserID]sdktypes.User{
 		testUser1.ID(): testUser1,
 	}
 
 	// correct token, user is ok.
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "Bearer "+tok1, nil))
+	h.mw.ServeHTTP(w, newRequest("Bearer "+tok1, nil))
 	assert.Equal(t, http.StatusOK, w.Code)
-	assertCalledWithUser(t, testUser1.ID(), check())
+	assertCalledWithUser(t, testUser1.ID(), h.check())
 
 	// correct session, user is ok.
 	w = httptest.NewRecorder()
-	mw.ServeHTTP(w, newRequest(sdktypes.InvalidUser, "", cookies))
+	h.mw.ServeHTTP(w, newRequest("", cookies))
 	assert.Equal(t, http.StatusOK, w.Code)
-	assertCalledWithUser(t, testUser1.ID(), check())
+	assertCalledWithUser(t, testUser1.ID(), h.check())
 }

--- a/internal/backend/auth/authhttpmiddleware/authmiddleware_test.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware_test.go
@@ -52,16 +52,6 @@ func assertCalledWithUser(t *testing.T, expected sdktypes.UserID, given *sdktype
 	}
 }
 
-func assertCalledWithoutAuthn(t *testing.T, given *sdktypes.UserID) {
-	if assert.NotNil(t, given) {
-		assert.False(t, given.IsValid())
-	}
-}
-
-func newOverallTestHandler(t *testing.T) (http.Handler, func() *sdktypes.UserID) {
-	return newTestHandler(t, authcontext.GetAuthnUserID)
-}
-
 func newRequest(authHeader string, cookies []*http.Cookie) *http.Request {
 	req := kittehs.Must1(http.NewRequest(http.MethodGet, "/", nil))
 
@@ -152,7 +142,7 @@ type harness struct {
 }
 
 func newTestHarness(t *testing.T, useDefaultUser bool) *harness {
-	h, check := newOverallTestHandler(t)
+	h, check := newTestHandler(t, authcontext.GetAuthnUserID)
 
 	sessions := kittehs.Must1(authsessions.New(authsessions.Configs.Dev))
 	tokens := kittehs.Must1(authjwttokens.New(authjwttokens.Configs.Dev))


### PR DESCRIPTION
instead of passing internal context, just explicitly pass the user id in the sub-middleware level.
this makes the code simpler and greatly simplifies testing.