### PR TITLE
feat(slack): update mappings & TODOs of bot event handlers

### DIFF
--- a/integrations/slack/events/channel.go
+++ b/integrations/slack/events/channel.go
@@ -60,8 +60,12 @@ func (b *BoolOrInt) UnmarshalJSON(data []byte) error {
 }
 
 // https://api.slack.com/events/channel_archive
+// https://api.slack.com/events/channel_left
 // https://api.slack.com/events/channel_unarchive
 // https://api.slack.com/events/group_archive
+// https://api.slack.com/events/group_close
+// https://api.slack.com/events/group_deleted
+// https://api.slack.com/events/group_left
 // https://api.slack.com/events/group_open
 // https://api.slack.com/events/group_unarchive
 // https://api.slack.com/events/member_joined_channel
@@ -83,8 +87,12 @@ type channelGroupMemberContainer struct {
 }
 
 // https://api.slack.com/events/channel_archive
+// https://api.slack.com/events/channel_left
 // https://api.slack.com/events/channel_unarchive
 // https://api.slack.com/events/group_archive
+// https://api.slack.com/events/group_close
+// https://api.slack.com/events/group_deleted
+// https://api.slack.com/events/group_left
 // https://api.slack.com/events/group_open
 // https://api.slack.com/events/group_unarchive
 // https://api.slack.com/events/member_joined_channel

--- a/integrations/slack/webhooks/bot_events.go
+++ b/integrations/slack/webhooks/bot_events.go
@@ -23,20 +23,19 @@ var BotEventHandlers = map[string]BotEventHandler{
 	// TODO: app_rate_limit
 	// TODO: app_uninstalled
 
-	"channel_archive": events.ChannelGroupMemberHandler,
-	"channel_created": events.ChannelCreatedRenameHandler,
-	// TODO: channel_history_changed
-	// TODO: channel_id_changed
+	"channel_archive":   events.ChannelGroupMemberHandler,
+	"channel_created":   events.ChannelCreatedRenameHandler,
+	"channel_left":      events.ChannelGroupMemberHandler,
 	"channel_rename":    events.ChannelCreatedRenameHandler,
 	"channel_unarchive": events.ChannelGroupMemberHandler,
 
-	"group_archive": events.ChannelGroupMemberHandler,
-	// TODO: group_history_changed
+	"group_archive":   events.ChannelGroupMemberHandler,
+	"group_close":     events.ChannelGroupMemberHandler,
+	"group_deleted":   events.ChannelGroupMemberHandler,
+	"group_left":      events.ChannelGroupMemberHandler,
 	"group_open":      events.ChannelGroupMemberHandler,
 	"group_rename":    events.ChannelCreatedRenameHandler,
 	"group_unarchive": events.ChannelGroupMemberHandler,
-
-	// TODO: im_history_changed
 
 	"member_joined_channel": events.ChannelGroupMemberHandler,
 	"member_left_channel":   events.ChannelGroupMemberHandler,


### PR DESCRIPTION
Remove events that we don't plan to support at this time, and add events that don't require any new code.

Testing for events: manual triggering via Slack website (e.g. https://api.slack.com/methods/conversations.leave/test). Specifically note that some events refer to the bot itself, not users, so they required 1-2 manual API calls.

Refs: INT-94, INT-142