### PR TITLE
feat(integrations): add google drive events

### DIFF
--- a/integrations/google/creds.go
+++ b/integrations/google/creds.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/integrations/google/calendar"
+	"go.autokitteh.dev/autokitteh/integrations/google/drive"
 	"go.autokitteh.dev/autokitteh/integrations/google/forms"
 	"go.autokitteh.dev/autokitteh/integrations/google/gmail"
 	"go.autokitteh.dev/autokitteh/integrations/google/internal/vars"
@@ -155,6 +156,12 @@ func (h handler) finalize(ctx context.Context, c sdkintegrations.ConnectionInit,
 	if err := calendar.UpdateWatches(ctx, h.vars, cid); err != nil {
 		l.Error("Google Calendar watches creation error", zap.Error(err))
 		c.AbortServerError("calendar watches creation error")
+		return
+	}
+
+	if err := drive.UpdateWatches(ctx, h.vars, cid); err != nil {
+		l.Error("Google Drive watches creation error", zap.Error(err))
+		c.AbortServerError("drive watches creation error")
 		return
 	}
 

--- a/integrations/google/drive/client.go
+++ b/integrations/google/drive/client.go
@@ -1,7 +1,21 @@
 package drive
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/googleapi"
+	googleoauth2 "google.golang.org/api/oauth2/v2"
+	"google.golang.org/api/option"
+
 	"go.autokitteh.dev/autokitteh/integrations/google/connections"
+	"go.autokitteh.dev/autokitteh/integrations/google/internal/vars"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
@@ -9,10 +23,16 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-var integrationID = sdktypes.NewIntegrationIDFromName("googledrive")
+var IntegrationID = sdktypes.NewIntegrationIDFromName("googledrive")
+
+type api struct {
+	logger *zap.Logger
+	vars   sdkservices.Vars
+	cid    sdktypes.ConnectionID
+}
 
 var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: integrationID.String(),
+	IntegrationId: IntegrationID.String(),
 	UniqueName:    "googledrive",
 	DisplayName:   "Google Drive",
 	Description:   "Google Drive is a file-hosting service and synchronization service developed by Google.",
@@ -36,4 +56,262 @@ func New(cvars sdkservices.Vars) sdkservices.Integration {
 		connections.ConnTest(cvars),
 		sdkintegrations.WithConnectionConfigFromVars(cvars),
 	)
+}
+
+func (a api) driveClient(ctx context.Context) (*drive.Service, error) {
+	data, err := a.connectionData(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var src oauth2.TokenSource
+	if data.OAuthData != "" {
+		src, err = oauthTokenSource(ctx, data.OAuthData)
+	} // else {
+	// 	src, err = jwtTokenSource(ctx, data.JSON)
+	// }
+	if err != nil {
+		return nil, err
+	}
+
+	svc, err := drive.NewService(ctx, option.WithTokenSource(src))
+	if err != nil {
+		return nil, err
+	}
+	return svc, nil
+}
+
+func oauthTokenSource(ctx context.Context, data string) (oauth2.TokenSource, error) {
+	d, err := sdkintegrations.DecodeOAuthData(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return oauthConfig().TokenSource(ctx, d.Token), nil
+}
+
+func oauthConfig() *oauth2.Config {
+	addr := os.Getenv("WEBHOOK_ADDRESS")
+	return &oauth2.Config{
+		ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
+		ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
+		Endpoint:     google.Endpoint,
+		RedirectURL:  fmt.Sprintf("https://%s/oauth/redirect/google", addr),
+		// https://developers.google.com/drive/api/guides/api-specific-auth
+		Scopes: []string{
+			// Non-sensitive.
+			googleoauth2.OpenIDScope,
+			googleoauth2.UserinfoEmailScope,
+			googleoauth2.UserinfoProfileScope,
+			// Sensitive.
+			drive.DriveFileScope,
+			// drive.DriveScope, // See ENG-1701
+		},
+	}
+}
+
+func (a api) connectionData(ctx context.Context) (*vars.Vars, error) {
+	cid, err := sdkmodule.FunctionConnectionIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if !cid.IsValid() {
+		cid = a.cid // Fallback during authentication flows.
+	}
+
+	vs, err := a.vars.Get(ctx, sdktypes.NewVarScopeID(cid))
+	if err != nil {
+		return nil, err
+	}
+
+	var decoded vars.Vars
+	vs.Decode(&decoded)
+	return &decoded, nil
+}
+
+// https://developers.google.com/drive/api/guides/push
+// https://developers.google.com/drive/api/reference/rest/v3/changes/watch
+func (a api) watchEvents(ctx context.Context, connID sdktypes.ConnectionID, userEmail string) (*drive.Channel, error) {
+	client, err := a.driveClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	startToken, err := client.Changes.GetStartPageToken().Do()
+	if err != nil {
+		return nil, err
+	}
+
+	// Save the start page token for the next request.
+	v := sdktypes.NewVar(vars.DriveChangesStartPageToken).SetValue(startToken.StartPageToken)
+	if err = a.vars.Set(ctx, v.WithScopeID(sdktypes.NewVarScopeID(a.cid))); err != nil {
+		return nil, err
+	}
+
+	addr := os.Getenv("WEBHOOK_ADDRESS")
+	req := client.Changes.Watch(startToken.StartPageToken, &drive.Channel{
+		Id:         connID.String() + "/events",
+		Token:      userEmail + "/events",
+		Address:    fmt.Sprintf("https://%s/googledrive/notif", addr),
+		Type:       "web_hook",
+		Expiration: time.Now().Add(time.Hour*24*7).Unix() * 1000,
+	})
+
+	resp, err := req.Do()
+	if err == nil {
+		return resp, nil
+	}
+
+	gerr, ok := err.(*googleapi.Error)
+	a.logger.Warn("Google Drive watch channel creation error", zap.Any("googleApiError", gerr))
+	if !ok || gerr.Code != 400 || len(gerr.Errors) != 1 {
+		return nil, err
+	}
+	if gerr.Errors[0].Reason != "channelIdNotUnique" {
+		return nil, err
+	}
+
+	// If the channel already exists, stop and recreate it.
+	a.logger.Info("Google Drive watch channel already exists - stopping and recreating")
+	if err := a.stopWatch(ctx, connID); err != nil {
+		return nil, fmt.Errorf("stop existing watch channel: %w", err)
+	}
+
+	resp, err = req.Do()
+	if err != nil {
+		return nil, fmt.Errorf("recreate watch channel: %w", err)
+	}
+	return resp, nil
+}
+
+// https://developers.google.com/drive/api/reference/rest/v3/channels/stop
+func (a api) stopWatch(ctx context.Context, cid sdktypes.ConnectionID) error {
+	client, err := a.driveClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	vs, err := a.vars.Get(ctx, sdktypes.NewVarScopeID(cid), vars.DriveEventsWatchResID)
+	if err != nil {
+		return err
+	}
+
+	err = client.Channels.Stop(&drive.Channel{
+		Id:         cid.String() + "/events",
+		ResourceId: vs.Get(vars.DriveEventsWatchResID).Value(),
+	}).Do()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a api) createChangeListRequest(client *drive.Service, pageToken string) *drive.ChangesListCall {
+	return client.Changes.List(pageToken).
+		IncludeItemsFromAllDrives(true).
+		SupportsAllDrives(true).
+		IncludeCorpusRemovals(true)
+}
+
+func (a api) initializeChangeTracking(ctx context.Context) error {
+	client, err := a.driveClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	vs, err := a.vars.Get(ctx, sdktypes.NewVarScopeID(a.cid))
+	if err != nil {
+		return err
+	}
+	startPageToken := vs.Get(vars.DriveChangesStartPageToken).Value()
+
+	// Initial request
+	resp, err := a.createChangeListRequest(client, startPageToken).Do()
+	if err != nil {
+		return err
+	}
+
+	// Handle pagination
+	for resp.NextPageToken != "" {
+		a.logger.Debug("Requesting next page of Google Drive changes",
+			zap.String("pageToken", resp.NextPageToken),
+		)
+
+		resp, err = a.createChangeListRequest(client, resp.NextPageToken).Do()
+		if err != nil {
+			return err
+		}
+	}
+
+	// After processing all pages, save the newStartPageToken for future change requests
+	if resp.NewStartPageToken != "" {
+		v := sdktypes.NewVar(vars.DriveChangesStartPageToken).SetValue(resp.NewStartPageToken)
+		if err = a.vars.Set(ctx, v.WithScopeID(sdktypes.NewVarScopeID(a.cid))); err != nil {
+			return err
+		}
+		a.logger.Debug("Updated Google Drive changes start page token",
+			zap.String("cid", a.cid.String()),
+			zap.String("newStartPageToken", resp.NewStartPageToken),
+		)
+	}
+
+	return nil
+}
+
+func (a api) listChanges(ctx context.Context) ([]*drive.Change, error) {
+	client, err := a.driveClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	vs, err := a.vars.Get(ctx, sdktypes.NewVarScopeID(a.cid))
+	if err != nil {
+		return nil, err
+	}
+
+	startPageToken := vs.Get(vars.DriveChangesStartPageToken).Value()
+	a.logger.Debug("Google Drive connection's existing start page token",
+		zap.String("cid", a.cid.String()),
+		zap.String("startPageToken", startPageToken),
+	)
+
+	var changes []*drive.Change
+
+	// Initial request with the stored page token
+	req := a.createChangeListRequest(client, startPageToken)
+	resp, err := req.Do()
+	if err != nil {
+		return nil, err
+	}
+	changes = append(changes, resp.Changes...)
+
+	// Handle pagination
+	for resp.NextPageToken != "" {
+		a.logger.Debug("Requesting next page of Google Drive changes",
+			zap.String("pageToken", resp.NextPageToken),
+		)
+
+		req = a.createChangeListRequest(client, resp.NextPageToken)
+		resp, err = req.Do()
+		if err != nil {
+			return nil, err
+		}
+
+		changes = append(changes, resp.Changes...)
+	}
+
+	// Save the new start page token for future requests
+	// TODO: helper function for saving NewStartPageToken?
+	if resp.NewStartPageToken != "" {
+		v := sdktypes.NewVar(vars.DriveChangesStartPageToken).SetValue(resp.NewStartPageToken)
+		if err := a.vars.Set(ctx, v.WithScopeID(sdktypes.NewVarScopeID(a.cid))); err != nil {
+			return nil, err
+		}
+		a.logger.Debug("Updated Google Drive changes start page token",
+			zap.String("cid", a.cid.String()),
+			zap.String("newStartPageToken", resp.NewStartPageToken),
+		)
+	}
+	return changes, nil
 }

--- a/integrations/google/drive/client.go
+++ b/integrations/google/drive/client.go
@@ -67,9 +67,9 @@ func (a api) driveClient(ctx context.Context) (*drive.Service, error) {
 	var src oauth2.TokenSource
 	if data.OAuthData != "" {
 		src, err = oauthTokenSource(ctx, data.OAuthData)
-	} // else {
-	// 	src, err = jwtTokenSource(ctx, data.JSON)
-	// }
+	} else {
+		src, err = jwtTokenSource(ctx, data.JSON)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -88,6 +88,17 @@ func oauthTokenSource(ctx context.Context, data string) (oauth2.TokenSource, err
 	}
 
 	return oauthConfig().TokenSource(ctx, d.Token), nil
+}
+
+func jwtTokenSource(ctx context.Context, data string) (oauth2.TokenSource, error) {
+	scopes := oauthConfig().Scopes
+
+	cfg, err := google.JWTConfigFromJSON([]byte(data), scopes...)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg.TokenSource(ctx), nil
 }
 
 func oauthConfig() *oauth2.Config {

--- a/integrations/google/drive/events.go
+++ b/integrations/google/drive/events.go
@@ -26,10 +26,6 @@ func ConstructEvents(ctx context.Context, vars sdkservices.Vars, cids []sdktypes
 		return nil, err
 	}
 
-	if len(changes) == 0 {
-		return nil, nil
-	}
-
 	var events []sdktypes.Event
 	for _, change := range changes {
 		event, err := constructSingleEvent(a, change)

--- a/integrations/google/drive/events.go
+++ b/integrations/google/drive/events.go
@@ -22,7 +22,7 @@ func ConstructEvents(ctx context.Context, vars sdkservices.Vars, cids []sdktypes
 	a := api{logger: l, vars: vars, cid: cids[0]}
 	changes, err := a.listChanges(ctx)
 	if err != nil {
-		l.Error("Failed to list events", zap.Error(err))
+		l.Error("Failed to list Google Drive events", zap.Error(err))
 		return nil, err
 	}
 

--- a/integrations/google/drive/events.go
+++ b/integrations/google/drive/events.go
@@ -1,0 +1,75 @@
+package drive
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	"google.golang.org/api/drive/v3"
+
+	"go.autokitteh.dev/autokitteh/integrations/internal/extrazap"
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+// ConstructEvents returns all events from a single notification
+func ConstructEvents(ctx context.Context, vars sdkservices.Vars, cids []sdktypes.ConnectionID) ([]sdktypes.Event, error) {
+	l := extrazap.ExtractLoggerFromContext(ctx)
+	if len(cids) == 0 {
+		return nil, nil
+	}
+
+	a := api{logger: l, vars: vars, cid: cids[0]}
+	changes, err := a.listChanges(ctx)
+	if err != nil {
+		l.Error("Failed to list events", zap.Error(err))
+		return nil, err
+	}
+
+	if len(changes) == 0 {
+		return nil, nil
+	}
+
+	var events []sdktypes.Event
+	for _, change := range changes {
+		event, err := constructSingleEvent(a, change)
+		if err != nil {
+			l.Error("Failed to construct event", zap.Error(err))
+			continue
+		}
+		if event.IsValid() {
+			events = append(events, event)
+		}
+	}
+
+	return events, nil
+}
+
+// constructSingleEvent handles a single change event
+func constructSingleEvent(a api, change *drive.Change) (sdktypes.Event, error) {
+	l := a.logger
+
+	// Convert the raw data to an AutoKitteh event
+	wrapped, err := sdktypes.WrapValue(change)
+	if err != nil {
+		l.Error("Failed to wrap Google Drive event", zap.Error(err))
+		return sdktypes.InvalidEvent, err
+	}
+
+	data, err := wrapped.ToStringValuesMap()
+	if err != nil {
+		l.Error("Failed to convert wrapped Google Drive event", zap.Error(err))
+		return sdktypes.InvalidEvent, err
+	}
+
+	akEvent, err := sdktypes.EventFromProto(&sdktypes.EventPB{
+		EventType: "change",
+		Data:      kittehs.TransformMapValues(data, sdktypes.ToProto),
+	})
+	if err != nil {
+		l.Error("Failed to convert protocol buffer to SDK event", zap.Error(err))
+		return sdktypes.InvalidEvent, err
+	}
+
+	return akEvent, nil
+}

--- a/integrations/google/drive/watches.go
+++ b/integrations/google/drive/watches.go
@@ -1,0 +1,88 @@
+package drive
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"go.uber.org/zap"
+	"google.golang.org/api/drive/v3"
+
+	"go.autokitteh.dev/autokitteh/integrations/google/internal/vars"
+	"go.autokitteh.dev/autokitteh/integrations/internal/extrazap"
+	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+// UpdateWatches creates or renews watches for a specific Google Drive
+// or shared drive, if an ID was specified during initialization.
+func UpdateWatches(ctx context.Context, v sdkservices.Vars, connID sdktypes.ConnectionID) error {
+	l := extrazap.ExtractLoggerFromContext(ctx)
+
+	// Not a Google Drive user? Nothing to do.
+	if !gotDriveScope(ctx, v, connID) {
+		l.Debug("No Google Drive scope, skipping Google Drive watches")
+		return nil
+	}
+
+	a := api{logger: l, vars: v, cid: connID}
+	// TODO(INT-22): allow users to specify both fileID and driveID
+
+	// Get the user's email address.
+	vs, err := v.Get(ctx, sdktypes.NewVarScopeID(connID), vars.UserEmail)
+	if err != nil {
+		return err
+	}
+	userEmail := vs.Get(vars.UserEmail).Value()
+
+	// Create or renew the events watch channel.
+	extrazap.AttachLoggerToContext(l, ctx)
+	watchChannel, err := a.watchEvents(ctx, connID, userEmail)
+	if err != nil {
+		return err
+	}
+
+	// Save all of its IDs.
+	err = a.saveWatchChannel(ctx, connID, watchChannel)
+	if err != nil {
+		return err
+	}
+
+	err = a.initializeChangeTracking(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func gotDriveScope(ctx context.Context, v sdkservices.Vars, cid sdktypes.ConnectionID) bool {
+	l := extrazap.ExtractLoggerFromContext(ctx)
+
+	vs, err := v.Get(ctx, sdktypes.NewVarScopeID(cid), vars.UserScope)
+	if err != nil {
+		l.Error("Failed to get Google OAuth scopes", zap.Error(err))
+		return false
+	}
+
+	return strings.Contains(vs.GetValue(vars.UserScope), "https://www.googleapis.com/auth/drive")
+}
+
+func (a api) saveWatchChannel(ctx context.Context, cid sdktypes.ConnectionID, wc *drive.Channel) error {
+	expirationSecs := wc.Expiration / 1000
+	expiration := strconv.FormatInt(expirationSecs, 10)
+	sid := sdktypes.NewVarScopeID(cid)
+
+	vs := sdktypes.NewVars().
+		Set(vars.DriveEventsWatchID, wc.Id, false).
+		Set(vars.DriveEventsWatchResID, wc.ResourceId, false).
+		Set(vars.DriveEventsWatchExp, expiration, false)
+
+	for _, v := range vs {
+		if err := a.vars.Set(ctx, v.WithScopeID(sid)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/integrations/google/internal/vars/vars.go
+++ b/integrations/google/internal/vars/vars.go
@@ -27,6 +27,11 @@ var (
 	CalendarEventsWatchExp   = sdktypes.NewSymbol("CalendarEventsWatchExp")
 	CalendarEventsSyncToken  = sdktypes.NewSymbol("CalendarEventsSyncToken")
 
+	DriveChangesStartPageToken = sdktypes.NewSymbol("DriveChangesStartPageToken")
+	DriveEventsWatchExp        = sdktypes.NewSymbol("DriveEventsWatchExp")
+	DriveEventsWatchID         = sdktypes.NewSymbol("DriveEventsWatchID")
+	DriveEventsWatchResID      = sdktypes.NewSymbol("DriveEventsWatchResID")
+
 	FormID               = sdktypes.NewSymbol("FormID")
 	FormResponsesWatchID = sdktypes.NewSymbol("FormResponsesWatchID")
 	FormSchemaWatchID    = sdktypes.NewSymbol("FormSchemaWatchID")

--- a/integrations/google/notifs.go
+++ b/integrations/google/notifs.go
@@ -17,6 +17,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/integrations/google/calendar"
+	"go.autokitteh.dev/autokitteh/integrations/google/drive"
 	"go.autokitteh.dev/autokitteh/integrations/google/forms"
 	"go.autokitteh.dev/autokitteh/integrations/google/gmail"
 	"go.autokitteh.dev/autokitteh/integrations/google/internal/vars"
@@ -64,6 +65,55 @@ func (h handler) handleCalNotification(w http.ResponseWriter, r *http.Request) {
 	if err := h.dispatchAsyncEventsToConnections(ctx, cids, akEvent); err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
+	}
+
+	// Returning immediately without an error = acknowledgement of receipt.
+}
+
+// handleDriveNotification receives and dispatches asynchronous Google Drive
+// notifications.
+func (h handler) handleDriveNotification(w http.ResponseWriter, r *http.Request) {
+	// Parse event details from the request headers
+	channelID := r.Header.Get("X-Goog-Channel-Id")
+	resState := r.Header.Get("X-Goog-Resource-State")
+
+	l := h.logger.With(
+		zap.String("urlPath", r.URL.Path),
+		zap.String("channelID", channelID),
+		zap.String("channelToken", r.Header.Get("X-Goog-Channel-Token")),
+		zap.String("resourceID", r.Header.Get("X-Goog-Resource-Id")),
+		zap.String("resourceState", resState),
+		zap.String("messageNumber", r.Header.Get("X-Goog-Message-Number")),
+	)
+
+	if resState == "sync" {
+		l.Info("Ignoring Google Drive watch creation notification")
+		return
+	}
+	l.Info("Received Google Drive notification")
+
+	// Find all the connection IDs associated with the watch ID.
+	ctx := extrazap.AttachLoggerToContext(l, r.Context())
+	name := vars.DriveEventsWatchID
+	cids, err := h.vars.FindConnectionIDs(ctx, drive.IntegrationID, name, channelID)
+	if err != nil {
+		l.Error("Failed to find connection IDs", zap.Error(err))
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	events, err := drive.ConstructEvents(ctx, h.vars, cids)
+	l.Warn("Constructed events", zap.Int("events", len(events)))
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	for _, event := range events {
+		if err := h.dispatchAsyncEventsToConnections(ctx, cids, event); err != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	// Returning immediately without an error = acknowledgement of receipt.

--- a/integrations/google/oauth.go
+++ b/integrations/google/oauth.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/api/option"
 
 	"go.autokitteh.dev/autokitteh/integrations/google/calendar"
+	"go.autokitteh.dev/autokitteh/integrations/google/drive"
 	"go.autokitteh.dev/autokitteh/integrations/google/forms"
 	"go.autokitteh.dev/autokitteh/integrations/google/gmail"
 	"go.autokitteh.dev/autokitteh/integrations/google/internal/vars"
@@ -95,6 +96,12 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 	if err := calendar.UpdateWatches(ctx, h.vars, cid); err != nil {
 		l.Error("Google Calendar watches creation error", zap.Error(err))
 		c.AbortServerError("calendar watches creation error")
+		return
+	}
+
+	if err := drive.UpdateWatches(ctx, h.vars, cid); err != nil {
+		l.Error("Google Drive watches creation error", zap.Error(err))
+		c.AbortServerError("drive watches creation error")
 		return
 	}
 

--- a/integrations/google/server.go
+++ b/integrations/google/server.go
@@ -21,6 +21,8 @@ const (
 
 	// calWebhookPath is the URL path to receive incoming Google Calendar push notifications.
 	calWebhookPath = "/googlecalendar/notif"
+	// driveWebhookPath is the URL path to receive incoming Google Drive push notifications.
+	driveWebhookPath = "/googledrive/notif"
 	// formsWebhookPath is the URL path to receive incoming Google Forms push notifications.
 	formsWebhookPath = "/googleforms/notif"
 	// gmailWebhookPath is the URL path to receive incoming Gmail push notifications.
@@ -64,6 +66,7 @@ func Start(l *zap.Logger, muxes *muxes.Muxes, v sdkservices.Vars, o sdkservices.
 
 	// Event webhooks (unauthenticated by definition).
 	muxes.NoAuth.HandleFunc("POST "+calWebhookPath, h.handleCalNotification)
+	muxes.NoAuth.HandleFunc("POST "+driveWebhookPath, h.handleDriveNotification)
 	muxes.NoAuth.HandleFunc("POST "+formsWebhookPath, h.handleFormsNotification)
 	muxes.NoAuth.HandleFunc("POST "+gmailWebhookPath, h.handleGmailNotification)
 }


### PR DESCRIPTION
### **Changes**:
1. **Drive Changes API Integration**:
   - Changes from the Google Drive API are parsed and passed directly to users. No additional calls to the File API are made, as users can query further details as needed.
   - Notifications include events like file creation, modification, and deletion.

2. **Testing & Observations**:
   - Successfully tested by creating, modifying, and deleting files in Drive. Notifications were received and processed correctly.
   - File creation triggers two non-duplicate notifications, and currently, there is no clear way to filter these. This behavior might be a nuisance in workflows.
   - Changes are scoped to the authenticated connection (file-level scope for now).

---

### **Limitations**:
1. **Notification Volume**: Google Drive sends notifications for a variety of file operations, including opening files. These may be considered noise in certain workflows.
2. **Watch Expiration**: The watch expiration is limited to Google's maximum duration of one week. As a result, users will need to reauthenticate after a week unless the watch is manually renewed. This limitation will be addressed after the merge of **INT-156**, which adds watch renewal support.

---

### **Next Steps**:
1. **Enhancements**:
   - Implement watch renewal after **INT-156** merges.
   - Explore strategies for filtering noisy notifications.
   - Consider adding support for querying file metadata from the File API.