### PR TITLE
fix(pythonrt): better wrapping of unhandled type

### DIFF
--- a/runtimes/pythonrt/runner/main.py
+++ b/runtimes/pythonrt/runner/main.py
@@ -248,7 +248,7 @@ class Runner(pb.runner_rpc.RunnerService):
             result=pb.values.Value(
                 custom=pb.values.Custom(
                     data=data,
-                    value=safe_wrap(result.value),
+                    value=values.safe_wrap(result.value),
                 ),
             )
         )
@@ -325,8 +325,8 @@ class Runner(pb.runner_rpc.RunnerService):
             runner_id=self.id,
             call_info=pb.handler.CallInfo(
                 function=fn.__name__,  # AK rejects __qualname__ such as "json.loads"
-                args=[safe_wrap(a) for a in args],
-                kwargs={k: safe_wrap(v) for k, v in kw.items()},
+                args=[values.safe_wrap(a) for a in args],
+                kwargs={k: values.safe_wrap(v) for k, v in kw.items()},
             ),
         )
         log.info("activity: sending")
@@ -369,7 +369,7 @@ class Runner(pb.runner_rpc.RunnerService):
             try:
                 data = pickle.dumps(result)
                 req.result.custom.data = data
-                req.result.custom.value.CopyFrom(safe_wrap(result.value))
+                req.result.custom.value.CopyFrom(values.safe_wrap(result.value))
             except (TypeError, pickle.PickleError) as err:
                 req.error = f"can't pickle {result.value} - {err}"
 
@@ -399,13 +399,6 @@ class Runner(pb.runner_rpc.RunnerService):
                 log.error("grpc cancelled or unavailable, killing self")
                 self.server.stop(SERVER_GRACE_TIMEOUT)
             log.error("print: %s", err)
-
-
-def safe_wrap(v):
-    try:
-        return values.wrap(v)
-    except TypeError:
-        return pb.values.Value(string=pb.values.String(v=repr(v)))
 
 
 def is_valid_port(port):

--- a/runtimes/pythonrt/runner/tests/main_test.py
+++ b/runtimes/pythonrt/runner/tests/main_test.py
@@ -14,6 +14,7 @@ from subprocess import run
 from unittest.mock import MagicMock
 
 import main
+import values
 import pb.autokitteh.user_code.v1.runner_svc_pb2 as runner_pb
 import pb.autokitteh.user_code.v1.user_code_pb2 as user_code
 import pb.autokitteh.values.v1.values_pb2 as pb_values
@@ -83,7 +84,7 @@ def test_activity_reply():
             custom=pb_values.Custom(
                 executor_id=runner.id,
                 data=pickle.dumps(result),
-                value=main.safe_wrap(result.value),
+                value=values.safe_wrap(result.value),
             ),
         )
     )

--- a/runtimes/pythonrt/runner/tests/values_test.py
+++ b/runtimes/pythonrt/runner/tests/values_test.py
@@ -5,7 +5,9 @@ import google.protobuf.duration_pb2 as duration_pb2
 import google.protobuf.timestamp_pb2 as timestamp_pb2
 import pb.autokitteh.values.v1.values_pb2 as pb
 import pytest
-from values import unwrap, wrap
+from threading import Lock
+
+from values import unwrap, wrap, safe_wrap, wrap_unhandled
 
 
 def intv(n):
@@ -89,6 +91,7 @@ wrap_test_cases = [
 @pytest.mark.parametrize("u,v", wrap_test_cases)
 def test_wrap(u, v):
     assert wrap(u) == v
+    assert safe_wrap(u) == v
     assert unwrap(v) == u
 
 
@@ -140,3 +143,12 @@ def test_special_wraps():
     assert wrap(D()) == dv
 
     assert unwrap(dv) == namedtuple("D", ["a", "b"])(1, "meow")
+
+
+def test_safe_wrap():
+    v = Lock()
+    u = safe_wrap(v)
+    assert u == wrap_unhandled(v)
+    assert u.struct.ctor == wrap("unhandled_type")
+    assert u.struct.fields.keys() == {"type", "repr"}
+    assert u.struct.fields["type"] == wrap("<class '_thread.lock'>")

--- a/runtimes/pythonrt/runner/values.py
+++ b/runtimes/pythonrt/runner/values.py
@@ -25,7 +25,7 @@ def wrap_unhandled(v: Any) -> pb.Value:
 
 
 def safe_wrap(v):
-    """Same as wrap, but does raise TypeError if a type is not supported.
+    """Same as wrap, but does not raise TypeError if a type is not supported.
 
     Instead, it returns a struct with the type and the string representation of the value.
     """


### PR DESCRIPTION
- moved `safe_wrap` into `values.py`.
- now tries its best to wrap whatever it can, and what it cannot it wraps into an "unhandled" struct.

motivation: show python requests HTTP response objects.