### PR TITLE
fix: process nested json inputs in session.start

### DIFF
--- a/internal/backend/sessionsgrpcsvc/svc.go
+++ b/internal/backend/sessionsgrpcsvc/svc.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -43,26 +44,27 @@ func (s *server) Start(ctx context.Context, req *connect.Request[sessionsv1.Star
 	}
 
 	for k, v := range msg.JsonInputs {
-		d := json.NewDecoder(strings.NewReader(v))
-		d.UseNumber()
-
-		var x any
-		if err := d.Decode(&x); err != nil {
-			err = sdkerrors.NewInvalidArgumentError(`json_inputs["%s"]: %w`, k, err)
-			return nil, sdkerrors.AsConnectError(err)
+		decoded, err := decodeNestedJSON(v)
+		if err != nil {
+			if !json.Valid([]byte(v)) {
+				log.Printf("Failed to decode JSON for key %s: %v\nJSON content: %s", k, err, v)
+				decoded = v
+			} else {
+				return nil, sdkerrors.AsConnectError(err)
+			}
 		}
 
 		if msg.Session.Inputs == nil {
 			msg.Session.Inputs = make(map[string]*sdktypes.ValuePB)
 		}
 
-		v, err := sdktypes.WrapValue(x)
+		wrappedValue, err := sdktypes.WrapValue(decoded)
 		if err != nil {
 			err = sdkerrors.NewInvalidArgumentError(`json_inputs["%s"]: %w`, k, err)
 			return nil, sdkerrors.AsConnectError(fmt.Errorf(`json_inputs["%s"]: %w`, k, err))
 		}
 
-		msg.Session.Inputs[k] = v.ToProto()
+		msg.Session.Inputs[k] = wrappedValue.ToProto()
 	}
 
 	session, err := sdktypes.SessionFromProto(msg.Session)
@@ -76,6 +78,37 @@ func (s *server) Start(ctx context.Context, req *connect.Request[sessionsv1.Star
 	}
 
 	return connect.NewResponse(&sessionsv1.StartResponse{SessionId: uid.String()}), nil
+}
+
+func decodeNestedJSON(input string) (any, error) {
+	var result any
+	d := json.NewDecoder(strings.NewReader(input))
+	d.UseNumber()
+
+	if err := d.Decode(&result); err != nil {
+		return nil, err
+	}
+
+	switch v := result.(type) {
+	case map[string]any:
+		for key, value := range v {
+			if str, ok := value.(string); ok {
+				if decoded, err := decodeNestedJSON(str); err == nil {
+					v[key] = decoded
+				}
+			}
+		}
+	case []any:
+		for i, value := range v {
+			if str, ok := value.(string); ok {
+				if decoded, err := decodeNestedJSON(str); err == nil {
+					v[i] = decoded
+				}
+			}
+		}
+	}
+
+	return result, nil
 }
 
 func (s *server) Get(ctx context.Context, req *connect.Request[sessionsv1.GetRequest]) (*connect.Response[sessionsv1.GetResponse], error) {

--- a/internal/backend/sessionsgrpcsvc/svc.go
+++ b/internal/backend/sessionsgrpcsvc/svc.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -46,12 +45,8 @@ func (s *server) Start(ctx context.Context, req *connect.Request[sessionsv1.Star
 	for k, v := range msg.JsonInputs {
 		decoded, err := decodeNestedJSON(v)
 		if err != nil {
-			if !json.Valid([]byte(v)) {
-				log.Printf("Failed to decode JSON for key %s: %v\nJSON content: %s", k, err, v)
-				decoded = v
-			} else {
-				return nil, sdkerrors.AsConnectError(err)
-			}
+			err = sdkerrors.NewInvalidArgumentError(`json_inputs["%s"]: %w`, k, err)
+			return nil, sdkerrors.AsConnectError(err)
 		}
 
 		if msg.Session.Inputs == nil {


### PR DESCRIPTION
Given simple JSON (not nested), for example:
```
{
    "method": "Start",
    "input": "test",
    "retries": 4
}
```

We converted it on the frontend it to:
```
{
    "method": "\"Start"\",
    "input": "\"test"\",
    "retries": "4"
}
```

By adding apostrophes around the strings, it works because the format the backend  expected to get is: map[string]string
But if we had nested JSON, for example:

```
{
	"method": {
		"input": {
			"retries": 4
		}
	}
}
```

Then, in order to turn it into a string, I had to send this to the backend:
```
{
  "method": "\"{'input':{'retries':4}}\""
}
```

And which was supposed to first of all convert the JSON into this:
```
{
	"method": {
		"input":{'retries':4}
	}
}
```

Then, on the next iteration of the conversion to this:
```
{
	"method": {
		"input":{
			"retries":4
		}
	}
}
```

And since we ran the conversion only once, we had the first key, for example in this JSON:
```
{
	"body": {
		"form": null,
		"json": {
			"address": "abc",
			"application_form_url": "http://test.io",
			"city": "abc",
			"company": {
				"city": "abc",
				"company_name": "beyond oil",
				"contact_slug": [
					"123654asd"
				],
				"created_by": {
					"avatar": "https://webphoto.com/Users/IBA/photo?updatedonParam=123,logo_squre.jpg",
					"contact_number": "",
					"email": "test@autokitteh.com",
					"first_name": "Boris",
					"id": 25336,
					"last_name": "Kameronov",
					"status": "Active"
				}
			}
		},
		"headers": {
			"Content-Length": "15040",
			"Content-Type": "application/json",
			"User-Agent": "GuzzleHttp/7",
			"X-Amzn-Trace-Id": "Root=1-6790dd0f-3dece0f127e6866a5271bc70",
			"X-Forwarded-For": "54.246.54.62",
			"X-Forwarded-Port": "443",
			"X-Forwarded-Proto": "https"
		},
		"method": "POST",
		"raw_url": "/webhooks/01jj6xnyysev8ag26ty9f3g41h",
		"trailers": {},
		"url": {
			"fragment": "",
			"path": "/webhooks/01jj6xnyysev8ag26ty9f3g41h",
			"query": {},
			"raw_fragment": "",
			"raw_path": "",
			"raw_query": ""
		}
	}
}
```

We could get the first key in Python with this code:

```
import os
import json

def on_new_job(event):
    data = event 
    print("Ta-Da", data["body"])
    print("Not-Ta-Da", data["body"]["json"]["company"]["city"])
```

But since the value inside the body key was a string, we couldn't access the sub-keys, since they weren't parsed.

To solve it, we created a recursive function that takes the value of the key each time and tries to parse it to another level.