### PR TITLE
fix: high performance sqlite

### DIFF
--- a/internal/backend/db/db.go
+++ b/internal/backend/db/db.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/google/uuid"
-	"go.uber.org/zap"
 	"gorm.io/gorm"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/health/healthreporter"
@@ -12,20 +11,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
-
-type Transaction interface {
-	DB
-	Commit() error
-
-	// Does nothing if already committed.
-	Rollback() error
-}
-
-func LoggedRollback(z *zap.Logger, tx Transaction) {
-	if err := tx.Rollback(); err != nil {
-		z.Error("rollback error", zap.Error(err))
-	}
-}
 
 type DB interface {
 	Connect(context.Context) error
@@ -36,10 +21,7 @@ type DB interface {
 
 	healthreporter.HealthReporter
 
-	GormDB() *gorm.DB
-
-	// Begina a transaction.
-	Begin(context.Context) (Transaction, error)
+	GormDB() (r, w *gorm.DB)
 
 	Transaction(context.Context, func(tx DB) error) error
 

--- a/internal/backend/db/dbgorm/builds.go
+++ b/internal/backend/db/dbgorm/builds.go
@@ -13,19 +13,19 @@ import (
 )
 
 func (gdb *gormdb) saveBuild(ctx context.Context, build *scheme.Build) error {
-	return gdb.db.WithContext(ctx).Create(build).Error
+	return gdb.wdb.WithContext(ctx).Create(build).Error
 }
 
 func (gdb *gormdb) deleteBuild(ctx context.Context, buildID uuid.UUID) error {
-	return gdb.db.WithContext(ctx).Delete(&scheme.Build{BuildID: buildID}).Error
+	return gdb.wdb.WithContext(ctx).Delete(&scheme.Build{BuildID: buildID}).Error
 }
 
 func (gdb *gormdb) getBuild(ctx context.Context, buildID uuid.UUID) (*scheme.Build, error) {
-	return getOne[scheme.Build](gdb.db.WithContext(ctx), "build_id = ?", buildID)
+	return getOne[scheme.Build](gdb.rdb.WithContext(ctx), "build_id = ?", buildID)
 }
 
 func (gdb *gormdb) listBuilds(ctx context.Context, filter sdkservices.ListBuildsFilter) ([]scheme.Build, error) {
-	q := gdb.db.WithContext(ctx).Order("created_at desc")
+	q := gdb.rdb.WithContext(ctx).Order("created_at desc")
 
 	q = withProjectID(q, "", filter.ProjectID)
 

--- a/internal/backend/db/dbgorm/builds.go
+++ b/internal/backend/db/dbgorm/builds.go
@@ -13,19 +13,19 @@ import (
 )
 
 func (gdb *gormdb) saveBuild(ctx context.Context, build *scheme.Build) error {
-	return gdb.wdb.WithContext(ctx).Create(build).Error
+	return gdb.writer.WithContext(ctx).Create(build).Error
 }
 
 func (gdb *gormdb) deleteBuild(ctx context.Context, buildID uuid.UUID) error {
-	return gdb.wdb.WithContext(ctx).Delete(&scheme.Build{BuildID: buildID}).Error
+	return gdb.writer.WithContext(ctx).Delete(&scheme.Build{BuildID: buildID}).Error
 }
 
 func (gdb *gormdb) getBuild(ctx context.Context, buildID uuid.UUID) (*scheme.Build, error) {
-	return getOne[scheme.Build](gdb.rdb.WithContext(ctx), "build_id = ?", buildID)
+	return getOne[scheme.Build](gdb.reader.WithContext(ctx), "build_id = ?", buildID)
 }
 
 func (gdb *gormdb) listBuilds(ctx context.Context, filter sdkservices.ListBuildsFilter) ([]scheme.Build, error) {
-	q := gdb.rdb.WithContext(ctx).Order("created_at desc")
+	q := gdb.reader.WithContext(ctx).Order("created_at desc")
 
 	q = withProjectID(q, "", filter.ProjectID)
 

--- a/internal/backend/db/dbgorm/connections.go
+++ b/internal/backend/db/dbgorm/connections.go
@@ -17,10 +17,10 @@ import (
 )
 
 func (gdb *gormdb) createConnection(ctx context.Context, conn *scheme.Connection) error {
-	return gdb.transaction(ctx, func(tx *gormdb) error {
+	return gdb.writeTransaction(ctx, func(tx *gormdb) error {
 		// ensure there is no connection with the same name for the same project
 		var count int64
-		if err := tx.wdb.
+		if err := tx.writer.
 			Model(&scheme.Connection{}).
 			Where("name = ?", conn.Name).Where("project_id = ?", conn.ProjectID).Count(&count).Error; err != nil {
 			return err
@@ -28,7 +28,7 @@ func (gdb *gormdb) createConnection(ctx context.Context, conn *scheme.Connection
 		if count > 0 {
 			return gorm.ErrDuplicatedKey // active/non-deleted connection was found.
 		}
-		return tx.wdb.Create(conn).Error
+		return tx.writer.Create(conn).Error
 	})
 }
 
@@ -45,7 +45,7 @@ func (gdb *gormdb) deleteConnectionsAndVars(ctx context.Context, what string, id
 	}
 
 	var ids []uuid.UUID
-	q := gdb.wdb.WithContext(ctx).Model(&scheme.Connection{})
+	q := gdb.writer.WithContext(ctx).Model(&scheme.Connection{})
 	q = q.Clauses(clause.Returning{Columns: []clause.Column{{Name: "connection_id"}}})
 	if err := q.Delete(&ids, what+" = ?", id).Error; err != nil {
 		return err
@@ -53,7 +53,7 @@ func (gdb *gormdb) deleteConnectionsAndVars(ctx context.Context, what string, id
 	}
 
 	if len(ids) > 0 {
-		return gdb.wdb.Where("var_id IN (?)", ids).Delete(&scheme.Var{}).Error
+		return gdb.writer.Where("var_id IN (?)", ids).Delete(&scheme.Var{}).Error
 	}
 
 	return nil
@@ -61,7 +61,7 @@ func (gdb *gormdb) deleteConnectionsAndVars(ctx context.Context, what string, id
 
 func (gdb *gormdb) doesConnectionHaveTriggers(ctx context.Context, connID uuid.UUID) (bool, error) {
 	var exists bool
-	q := gdb.db.WithContext(ctx)
+	q := gdb.reader.WithContext(ctx)
 
 	q = q.Model(&scheme.Trigger{}).
 		Select("1").
@@ -81,11 +81,11 @@ func (gdb *gormdb) deleteConnection(ctx context.Context, id uuid.UUID) error {
 }
 
 func (gdb *gormdb) updateConnection(ctx context.Context, id uuid.UUID, data map[string]any) error {
-	return gdb.wdb.WithContext(ctx).Model(&scheme.Connection{ConnectionID: id}).Updates(data).Error
+	return gdb.writer.WithContext(ctx).Model(&scheme.Connection{ConnectionID: id}).Updates(data).Error
 }
 
 func (gdb *gormdb) getConnection(ctx context.Context, id uuid.UUID) (*scheme.Connection, error) {
-	return getOne[scheme.Connection](gdb.rdb.WithContext(ctx), "connection_id = ?", id)
+	return getOne[scheme.Connection](gdb.reader.WithContext(ctx), "connection_id = ?", id)
 }
 
 func findConnections(query *gorm.DB) ([]scheme.Connection, error) {
@@ -97,12 +97,12 @@ func findConnections(query *gorm.DB) ([]scheme.Connection, error) {
 }
 
 func (gdb *gormdb) getConnections(ctx context.Context, ids ...uuid.UUID) ([]scheme.Connection, error) {
-	q := gdb.rdb.WithContext(ctx).Where("connection_id IN (?)", ids)
+	q := gdb.reader.WithContext(ctx).Where("connection_id IN (?)", ids)
 	return findConnections(q)
 }
 
 func (gdb *gormdb) listConnections(ctx context.Context, filter sdkservices.ListConnectionsFilter, idsOnly bool) ([]scheme.Connection, error) {
-	q := gdb.rdb.WithContext(ctx)
+	q := gdb.reader.WithContext(ctx)
 
 	q = withProjectID(q, "", filter.ProjectID)
 

--- a/internal/backend/db/dbgorm/dbgorm.go
+++ b/internal/backend/db/dbgorm/dbgorm.go
@@ -5,7 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"sync"
+	"runtime"
+	"strings"
 
 	_ "ariga.io/atlas-provider-gorm/gormschema"
 	"github.com/pressly/goose/v3"
@@ -23,15 +24,9 @@ type Config = gormkitteh.Config
 
 type gormdb struct {
 	z   *zap.Logger
-	db  *gorm.DB
 	cfg *Config
 
-	// See https://github.com/mattn/go-sqlite3/issues/274.
-	// Used only for protecting writes when using sqlite.
-	//
-	// TODO(ENG-190): This is not... ideal. Really find a better
-	//                solution. Everything else I tried didn't work.
-	mu *sync.Mutex
+	wdb, rdb *gorm.DB
 }
 
 var _ db.DB = (*gormdb)(nil)
@@ -46,51 +41,59 @@ func New(z *zap.Logger, cfg *Config) (db.DB, error) {
 		return nil, err
 	}
 
-	db := &gormdb{z: z, cfg: cfg}
-
-	if cfg.Type == "sqlite" {
-		db.mu = new(sync.Mutex)
-	}
-
-	return db, nil
+	return &gormdb{z: z, cfg: cfg}, nil
 }
 
-func (db *gormdb) GormDB() *gorm.DB { return db.db }
+func (db *gormdb) GormDB() (r, w *gorm.DB) { return db.rdb, db.wdb }
 
-func connect(_ context.Context, z *zap.Logger, cfg *Config) (*gorm.DB, error) {
-	client, err := gormkitteh.OpenZ(z, cfg, func(cfg *gorm.Config) {
-		cfg.SkipDefaultTransaction = true
-	})
+func connect(_ context.Context, z *zap.Logger, cfg *Config) (r *gorm.DB, w *gorm.DB, err error) {
+	gormCfgFn := func(cfg *gorm.Config) { cfg.SkipDefaultTransaction = true }
+
+	r, err = gormkitteh.OpenZ(z, cfg, gormCfgFn)
 	if err != nil {
-		return nil, fmt.Errorf("opendb: %w", err)
+		err = fmt.Errorf("opendb: %w", err)
+		return
 	}
-	sqlDB, err := client.DB()
+
+	var sqlDB *sql.DB
+	if sqlDB, err = r.DB(); err != nil {
+		return
+	}
+
+	n := cfg.MaxOpenConns
+	if n == 0 {
+		n = max(4, runtime.NumCPU())
+	}
+
+	sqlDB.SetMaxOpenConns(n)
+
+	// in memory db doesn't need any separation between writing and reading.
+	if cfg.Type != "sqlite" || strings.HasPrefix(cfg.DSN, ":memory:") {
+		w = r
+		return
+	}
+
+	// For SQlite we need to open a separate connection for writes.
+	// See https://kerkour.com/sqlite-for-servers.
+
+	w, err = gormkitteh.OpenZ(z, cfg, gormCfgFn)
 	if err != nil {
-		return nil, err
+		err = fmt.Errorf("opendb: %w", err)
+		return
 	}
 
-	if cfg.MaxOpenConns > 0 {
-		sqlDB.SetMaxOpenConns(cfg.MaxOpenConns)
-	}
-	if cfg.MaxIdleConns > 0 {
-		sqlDB.SetMaxIdleConns(cfg.MaxIdleConns)
+	if sqlDB, err = w.DB(); err != nil {
+		return
 	}
 
-	return client, nil
-}
+	sqlDB.SetMaxOpenConns(1)
 
-func (db *gormdb) Connect(ctx context.Context) (err error) {
-	db.db, err = connect(ctx, db.z.Named("gorm"), db.cfg)
 	return
 }
 
-func (db *gormdb) locked(f func(db *gormdb) error) error {
-	if db.mu != nil {
-		db.mu.Lock()
-		defer db.mu.Unlock()
-	}
-
-	return f(db)
+func (db *gormdb) Connect(ctx context.Context) (err error) {
+	db.rdb, db.wdb, err = connect(ctx, db.z.Named("gorm"), db.cfg)
+	return
 }
 
 func translateError(err error) error {
@@ -130,12 +133,23 @@ var fkStmtByDB = map[string]map[bool]string{
 	},
 }
 
-func foreignKeys(gormdb *gormdb, enable bool) {
+func foreignKeys(gormdb *gormdb, enable bool) error {
 	if _, found := fkStmtByDB[gormdb.cfg.Type]; !found {
 		panic(fmt.Errorf("unknown DB type: %s", gormdb.cfg.Type))
 	}
 	stmt := fkStmtByDB[gormdb.cfg.Type][enable]
-	gormdb.db.Exec(stmt)
+
+	if err := gormdb.rdb.Exec(stmt).Error; err != nil {
+		return fmt.Errorf("exec %q failed on rdb: %w", stmt, err)
+	}
+
+	if gormdb.wdb != gormdb.rdb {
+		if err := gormdb.wdb.Exec(stmt).Error; err != nil {
+			return fmt.Errorf("exec %q failed on wdb: %w", stmt, err)
+		}
+	}
+
+	return nil
 }
 
 func initGoose(client *sql.DB, dialect string) (ver int64, err error) {
@@ -155,7 +169,7 @@ func initGoose(client *sql.DB, dialect string) (ver int64, err error) {
 func (db *gormdb) Migrate(ctx context.Context) error {
 	db.z.Info("migrating")
 
-	client := db.client(true)
+	_, client := db.client(true)
 
 	_, err := initGoose(client, db.cfg.Type)
 	if err != nil {
@@ -171,7 +185,7 @@ func (db *gormdb) Migrate(ctx context.Context) error {
 }
 
 func (db *gormdb) MigrationRequired(ctx context.Context) (bool, int64, error) {
-	client := db.client(false)
+	_, client := db.client(false)
 	dbversion, err := initGoose(client, db.cfg.Type)
 	if err != nil {
 		return false, 0, err
@@ -213,7 +227,7 @@ func (db *gormdb) seed(ctx context.Context) error {
 
 	db.z.Info("seeding")
 
-	cmd := db.db.WithContext(ctx).Debug().Exec(db.cfg.SeedCommands)
+	cmd := db.wdb.WithContext(ctx).Debug().Exec(db.cfg.SeedCommands)
 
 	db.z.Info("done seeding", zap.Int64("rows_affected", cmd.RowsAffected))
 
@@ -223,8 +237,15 @@ func (db *gormdb) seed(ctx context.Context) error {
 func (db *gormdb) Setup(ctx context.Context) error {
 	isSqlite := db.cfg.Type == "sqlite"
 	if isSqlite {
-		foreignKeys(db, false)
-		defer foreignKeys(db, true)
+		if err := foreignKeys(db, false); err != nil {
+			return err
+		}
+
+		defer func() {
+			if err := foreignKeys(db, true); err != nil {
+				db.z.Error("failed to re-enable foreign keys", zap.Error(err))
+			}
+		}()
 	}
 
 	if err := db.migrate(ctx); err != nil {
@@ -241,8 +262,9 @@ func (db *gormdb) Setup(ctx context.Context) error {
 // TODO: not sure this will work with the connect method
 func (db *gormdb) Debug() db.DB {
 	return &gormdb{
-		z:  db.z,
-		db: db.db.Debug(),
+		z:   db.z,
+		rdb: db.rdb.Debug(),
+		wdb: db.wdb.Debug(),
 	}
 }
 
@@ -278,11 +300,20 @@ func delete[T any](db *gorm.DB, ctx context.Context, where string, args ...any) 
 	return nil
 }
 
-func (db *gormdb) client(debug bool) *sql.DB {
-	q := db.db
+func (db *gormdb) client(debug bool) (r, w *sql.DB) {
+	q := db.rdb
 	if debug {
 		q = q.Debug()
 	}
 
-	return kittehs.Must1(q.DB())
+	r = kittehs.Must1(q.DB())
+
+	q = db.wdb
+	if debug {
+		q = q.Debug()
+	}
+
+	w = kittehs.Must1(q.DB())
+
+	return
 }

--- a/internal/backend/db/dbgorm/deployments.go
+++ b/internal/backend/db/dbgorm/deployments.go
@@ -15,11 +15,11 @@ import (
 )
 
 func (gdb *gormdb) createDeployment(ctx context.Context, d *scheme.Deployment) error {
-	return gormErrNotFoundToForeignKey(gdb.wdb.WithContext(ctx).Create(d).Error)
+	return gormErrNotFoundToForeignKey(gdb.writer.WithContext(ctx).Create(d).Error)
 }
 
 func (gdb *gormdb) deleteDeployment(ctx context.Context, deploymentID uuid.UUID) error {
-	return gdb.transaction(ctx, func(tx *gormdb) error {
+	return gdb.writeTransaction(ctx, func(tx *gormdb) error {
 		return tx.deleteDeploymentsAndDependents(ctx, []uuid.UUID{deploymentID})
 	})
 }
@@ -31,7 +31,7 @@ func (gdb *gormdb) deleteDeploymentsAndDependents(ctx context.Context, depIDs []
 	if len(depIDs) == 0 {
 		return nil
 	}
-	db := gdb.wdb.WithContext(ctx)
+	db := gdb.writer.WithContext(ctx)
 
 	if err := db.Delete(&scheme.Session{}, "deployment_id IN ?", depIDs).Error; err != nil {
 		return err
@@ -62,15 +62,15 @@ func (gdb *gormdb) updateDeploymentState(
 	d := scheme.Deployment{DeploymentID: deploymentID}
 	var oldState int32 = 0
 
-	if err := gdb.transaction(ctx, func(tx *gormdb) error {
-		if err := tx.wdb.Model(&d).Select("state").First(&oldState).Error; err != nil {
+	if err := gdb.writeTransaction(ctx, func(tx *gormdb) error {
+		if err := tx.writer.Model(&d).Select("state").First(&oldState).Error; err != nil {
 			return err
 		}
 
 		data := updatedBaseColumns(ctx)
 		data["state"] = int32(state.ToProto())
 
-		if err := tx.wdb.Model(&d).UpdateColumns(data).Error; err != nil {
+		if err := tx.writer.Model(&d).UpdateColumns(data).Error; err != nil {
 			return err
 		}
 		return nil
@@ -82,11 +82,11 @@ func (gdb *gormdb) updateDeploymentState(
 }
 
 func (gdb *gormdb) getDeployment(ctx context.Context, deploymentID uuid.UUID) (*scheme.Deployment, error) {
-	return getOne[scheme.Deployment](gdb.rdb.WithContext(ctx), "deployment_id = ?", deploymentID)
+	return getOne[scheme.Deployment](gdb.reader.WithContext(ctx), "deployment_id = ?", deploymentID)
 }
 
 func (gdb *gormdb) listDeploymentsCommonQuery(ctx context.Context, filter sdkservices.ListDeploymentsFilter) *gorm.DB {
-	q := gdb.rdb.WithContext(ctx)
+	q := gdb.reader.WithContext(ctx)
 
 	q = withProjectID(q, "deployments", filter.ProjectID)
 
@@ -221,7 +221,7 @@ func (db *gormdb) DeploymentHasActiveSessions(ctx context.Context, id sdktypes.D
 var finalSessionStateTypes = kittehs.Transform(sdktypes.FinalSessionStateTypes, func(s sdktypes.SessionStateType) int { return s.ToInt() })
 
 func (db *gormdb) DeactivateAllDrainedDeployments(ctx context.Context) (int, error) {
-	q := db.wdb.WithContext(ctx).Exec(`UPDATE deployments
+	q := db.writer.WithContext(ctx).Exec(`UPDATE deployments
 SET state = ?
 WHERE state = ?
 AND NOT EXISTS (
@@ -240,7 +240,7 @@ AND NOT EXISTS (
 }
 
 func (db *gormdb) DeactivateDrainedDeployment(ctx context.Context, did sdktypes.DeploymentID) (bool, error) {
-	q := db.wdb.WithContext(ctx).Exec(`UPDATE deployments
+	q := db.writer.WithContext(ctx).Exec(`UPDATE deployments
 SET state = ?
 WHERE state = ? AND deployment_id = ?
 AND NOT EXISTS (

--- a/internal/backend/db/dbgorm/deployments.go
+++ b/internal/backend/db/dbgorm/deployments.go
@@ -15,11 +15,11 @@ import (
 )
 
 func (gdb *gormdb) createDeployment(ctx context.Context, d *scheme.Deployment) error {
-	return gormErrNotFoundToForeignKey(gdb.db.WithContext(ctx).Create(d).Error)
+	return gormErrNotFoundToForeignKey(gdb.wdb.WithContext(ctx).Create(d).Error)
 }
 
 func (gdb *gormdb) deleteDeployment(ctx context.Context, deploymentID uuid.UUID) error {
-	return gdb.transaction(ctx, func(tx *tx) error {
+	return gdb.transaction(ctx, func(tx *gormdb) error {
 		return tx.deleteDeploymentsAndDependents(ctx, []uuid.UUID{deploymentID})
 	})
 }
@@ -31,7 +31,7 @@ func (gdb *gormdb) deleteDeploymentsAndDependents(ctx context.Context, depIDs []
 	if len(depIDs) == 0 {
 		return nil
 	}
-	db := gdb.db.WithContext(ctx)
+	db := gdb.wdb.WithContext(ctx)
 
 	if err := db.Delete(&scheme.Session{}, "deployment_id IN ?", depIDs).Error; err != nil {
 		return err
@@ -62,15 +62,15 @@ func (gdb *gormdb) updateDeploymentState(
 	d := scheme.Deployment{DeploymentID: deploymentID}
 	var oldState int32 = 0
 
-	if err := gdb.transaction(ctx, func(tx *tx) error {
-		if err := tx.db.Model(&d).Select("state").First(&oldState).Error; err != nil {
+	if err := gdb.transaction(ctx, func(tx *gormdb) error {
+		if err := tx.wdb.Model(&d).Select("state").First(&oldState).Error; err != nil {
 			return err
 		}
 
 		data := updatedBaseColumns(ctx)
 		data["state"] = int32(state.ToProto())
 
-		if err := tx.db.Model(&d).UpdateColumns(data).Error; err != nil {
+		if err := tx.wdb.Model(&d).UpdateColumns(data).Error; err != nil {
 			return err
 		}
 		return nil
@@ -82,11 +82,11 @@ func (gdb *gormdb) updateDeploymentState(
 }
 
 func (gdb *gormdb) getDeployment(ctx context.Context, deploymentID uuid.UUID) (*scheme.Deployment, error) {
-	return getOne[scheme.Deployment](gdb.db.WithContext(ctx), "deployment_id = ?", deploymentID)
+	return getOne[scheme.Deployment](gdb.rdb.WithContext(ctx), "deployment_id = ?", deploymentID)
 }
 
 func (gdb *gormdb) listDeploymentsCommonQuery(ctx context.Context, filter sdkservices.ListDeploymentsFilter) *gorm.DB {
-	q := gdb.db.WithContext(ctx)
+	q := gdb.rdb.WithContext(ctx)
 
 	q = withProjectID(q, "deployments", filter.ProjectID)
 
@@ -221,7 +221,7 @@ func (db *gormdb) DeploymentHasActiveSessions(ctx context.Context, id sdktypes.D
 var finalSessionStateTypes = kittehs.Transform(sdktypes.FinalSessionStateTypes, func(s sdktypes.SessionStateType) int { return s.ToInt() })
 
 func (db *gormdb) DeactivateAllDrainedDeployments(ctx context.Context) (int, error) {
-	q := db.db.WithContext(ctx).Exec(`UPDATE deployments
+	q := db.wdb.WithContext(ctx).Exec(`UPDATE deployments
 SET state = ?
 WHERE state = ?
 AND NOT EXISTS (
@@ -240,7 +240,7 @@ AND NOT EXISTS (
 }
 
 func (db *gormdb) DeactivateDrainedDeployment(ctx context.Context, did sdktypes.DeploymentID) (bool, error) {
-	q := db.db.WithContext(ctx).Exec(`UPDATE deployments
+	q := db.wdb.WithContext(ctx).Exec(`UPDATE deployments
 SET state = ?
 WHERE state = ? AND deployment_id = ?
 AND NOT EXISTS (

--- a/internal/backend/db/dbgorm/events.go
+++ b/internal/backend/db/dbgorm/events.go
@@ -15,19 +15,19 @@ import (
 )
 
 func (gdb *gormdb) saveEvent(ctx context.Context, event *scheme.Event) error {
-	return gdb.wdb.WithContext(ctx).Create(event).Error
+	return gdb.writer.WithContext(ctx).Create(event).Error
 }
 
 func (gdb *gormdb) deleteEvent(ctx context.Context, eventID uuid.UUID) error {
-	return gdb.wdb.WithContext(ctx).Delete(&scheme.Event{}, "event_id = ?", eventID).Error // NOTE: eventID isn't a primary key
+	return gdb.writer.WithContext(ctx).Delete(&scheme.Event{}, "event_id = ?", eventID).Error // NOTE: eventID isn't a primary key
 }
 
 func (gdb *gormdb) getEvent(ctx context.Context, eventID uuid.UUID) (*scheme.Event, error) {
-	return getOne[scheme.Event](gdb.rdb.WithContext(ctx), "event_id = ?", eventID)
+	return getOne[scheme.Event](gdb.reader.WithContext(ctx), "event_id = ?", eventID)
 }
 
 func (gdb *gormdb) listEvents(ctx context.Context, filter sdkservices.ListEventsFilter) ([]scheme.Event, error) {
-	q := gdb.rdb.WithContext(ctx)
+	q := gdb.reader.WithContext(ctx)
 
 	q = withProjectOrgID(q, filter.OrgID, "events")
 
@@ -126,7 +126,7 @@ func (db *gormdb) ListEvents(ctx context.Context, filter sdkservices.ListEventsF
 func (db *gormdb) GetLatestEventSequence(ctx context.Context) (uint64, error) {
 	// NOTE: called from workflow, not protected by user context
 	var s scheme.Event
-	if err := db.rdb.WithContext(ctx).Last(&s).Error; err != nil {
+	if err := db.reader.WithContext(ctx).Last(&s).Error; err != nil {
 		return 0, translateError(err)
 	}
 	return s.Seq, nil

--- a/internal/backend/db/dbgorm/gorm_test.go
+++ b/internal/backend/db/dbgorm/gorm_test.go
@@ -57,7 +57,7 @@ func TestMain(m *testing.M) {
 	cfg, _ = cfg.Explicit()
 	db := setupDB(cfg)
 	z := kittehs.Must1(zap.NewDevelopment())
-	gormDB = gormdb{db: db, cfg: cfg, mu: nil, z: z}
+	gormDB = gormdb{rdb: db, wdb: db, cfg: cfg, z: z}
 
 	ctx := context.Background()
 	if err := gormDB.Setup(ctx); err != nil { // ensure migration/schemas
@@ -169,9 +169,11 @@ func setupDB(config *gormkitteh.Config) *gorm.DB {
 func TeardownDB(gormdb *gormdb, ctx context.Context) error {
 	isSqlite := gormdb.cfg.Type == "sqlite"
 	if isSqlite {
-		foreignKeys(gormdb, false)
+		if err := foreignKeys(gormdb, false); err != nil {
+			return err
+		}
 	}
-	db := gormdb.db.WithContext(ctx).Scopes(NoDebug())
+	db := gormdb.wdb.WithContext(ctx).Scopes(NoDebug())
 	if err := db.Migrator().DropTable(scheme.Tables...); err != nil {
 		return fmt.Errorf("droptable: %w", err)
 	}
@@ -179,16 +181,21 @@ func TeardownDB(gormdb *gormdb, ctx context.Context) error {
 		return fmt.Errorf("failed to drop migraiton table (goose_db_version) : %w", err)
 	}
 	if isSqlite {
-		foreignKeys(gormdb, true)
+		if err := foreignKeys(gormdb, true); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
 func CleanupDB(gormdb *gormdb, ctx context.Context) error {
-	foreignKeys(gormdb, false) // disable foreign keys
+	// disable foreign keys
+	if err := foreignKeys(gormdb, false); err != nil {
+		return err
+	}
 
-	db := gormdb.db.WithContext(ctx).Unscoped().Session(&gorm.Session{AllowGlobalUpdate: true})
+	db := gormdb.wdb.WithContext(ctx).Unscoped().Session(&gorm.Session{AllowGlobalUpdate: true})
 	for _, model := range scheme.Tables {
 		modelType := reflect.TypeOf(model)
 		model := reflect.New(modelType).Interface()
@@ -199,7 +206,11 @@ func CleanupDB(gormdb *gormdb, ctx context.Context) error {
 		}
 	}
 
-	foreignKeys(gormdb, true) // re-enable foreign keys
+	// re-enable foreign keys
+	if err := foreignKeys(gormdb, true); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -209,20 +220,25 @@ func newDBFixture() *dbFixture {
 		log.Fatalf("Failed to cleanup gormdb: %v", err)
 	}
 	gormdb := gormDB
-	f := dbFixture{db: gormdb.db, gormdb: &gormdb, ctx: ctx}
+	f := dbFixture{db: gormdb.wdb, gormdb: &gormdb, ctx: ctx}
 	return &f
 }
 
 func (f *dbFixture) WithForeignKeysDisabled(fn func()) {
-	foreignKeys(f.gormdb, false) // disable
+	if err := foreignKeys(f.gormdb, false); err != nil {
+		panic(err)
+	}
 	fn()
-	foreignKeys(f.gormdb, true) // enable
+	if err := foreignKeys(f.gormdb, true); err != nil {
+		panic(err)
+	}
 }
 
 // enable SQL logging
 func (f *dbFixture) WithDebug() *dbFixture {
 	f.db = f.db.Debug()
-	f.gormdb.db = f.db
+	f.gormdb.wdb = f.db
+	f.gormdb.rdb = f.db
 	return f
 }
 
@@ -237,7 +253,7 @@ func NoDebug() func(*gorm.DB) *gorm.DB {
 
 func findAndAssertCount[T any](t *testing.T, f *dbFixture, expected int, where string, args ...any) []T {
 	var objs []T
-	res := f.gormdb.db.Where(where, args...).Find(&objs)
+	res := f.gormdb.rdb.Where(where, args...).Find(&objs)
 	require.NoError(t, res.Error)
 	require.Equal(t, expected, len(objs))
 	require.Equal(t, int64(expected), res.RowsAffected)

--- a/internal/backend/db/dbgorm/health.go
+++ b/internal/backend/db/dbgorm/health.go
@@ -1,6 +1,25 @@
 package dbgorm
 
+import "fmt"
+
 func (db *gormdb) Report() error {
-	s, _ := db.db.DB()
-	return s.Ping()
+	w, err := db.wdb.DB()
+	if err != nil {
+		return fmt.Errorf("write db: %w", err)
+	}
+
+	if err := w.Ping(); err != nil {
+		return fmt.Errorf("write db ping: %w", err)
+	}
+
+	r, err := db.wdb.DB()
+	if err != nil {
+		return fmt.Errorf("read db: %w", err)
+	}
+
+	if err := r.Ping(); err != nil {
+		return fmt.Errorf("read db ping: %w", err)
+	}
+
+	return nil
 }

--- a/internal/backend/db/dbgorm/health.go
+++ b/internal/backend/db/dbgorm/health.go
@@ -3,7 +3,7 @@ package dbgorm
 import "fmt"
 
 func (db *gormdb) Report() error {
-	w, err := db.wdb.DB()
+	w, err := db.writer.DB()
 	if err != nil {
 		return fmt.Errorf("write db: %w", err)
 	}
@@ -12,7 +12,7 @@ func (db *gormdb) Report() error {
 		return fmt.Errorf("write db ping: %w", err)
 	}
 
-	r, err := db.wdb.DB()
+	r, err := db.writer.DB()
 	if err != nil {
 		return fmt.Errorf("read db: %w", err)
 	}

--- a/internal/backend/db/dbgorm/orgs.go
+++ b/internal/backend/db/dbgorm/orgs.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (gdb *gormdb) GetOrg(ctx context.Context, oid sdktypes.OrgID, n sdktypes.Symbol) (sdktypes.Org, error) {
-	q := gdb.db.WithContext(ctx)
+	q := gdb.rdb.WithContext(ctx)
 
 	if !oid.IsValid() && !n.IsValid() {
 		return sdktypes.InvalidOrg, sdkerrors.NewInvalidArgumentError("missing id or name")
@@ -44,13 +44,13 @@ func (gdb *gormdb) DeleteOrg(ctx context.Context, oid sdktypes.OrgID) error {
 		return sdkerrors.NewInvalidArgumentError("missing id")
 	}
 
-	return translateError(gdb.transaction(ctx, func(tx *tx) error {
-		err := tx.db.Where("org_id = ?", oid.UUIDValue()).Delete(&scheme.OrgMember{}).Error
+	return translateError(gdb.transaction(ctx, func(tx *gormdb) error {
+		err := tx.wdb.Where("org_id = ?", oid.UUIDValue()).Delete(&scheme.OrgMember{}).Error
 		if err != nil {
 			return translateError(err)
 		}
 
-		return tx.db.Where("org_id = ?", oid.UUIDValue()).Delete(&scheme.Org{}).Error
+		return tx.wdb.Where("org_id = ?", oid.UUIDValue()).Delete(&scheme.Org{}).Error
 	}))
 }
 
@@ -61,7 +61,7 @@ func (gdb *gormdb) CreateOrg(ctx context.Context, o sdktypes.Org) (sdktypes.OrgI
 		oid = sdktypes.NewOrgID()
 	}
 
-	err := gdb.transaction(ctx, func(tx *tx) error {
+	err := gdb.transaction(ctx, func(tx *gormdb) error {
 		org := scheme.Org{
 			Base: based(ctx),
 
@@ -71,14 +71,14 @@ func (gdb *gormdb) CreateOrg(ctx context.Context, o sdktypes.Org) (sdktypes.OrgI
 		}
 
 		if org.Name != "" {
-			if err := tx.db.Where("name = ?", org.Name).First(&scheme.Org{}).Error; err == nil {
+			if err := tx.wdb.Where("name = ?", org.Name).First(&scheme.Org{}).Error; err == nil {
 				return sdkerrors.ErrAlreadyExists
 			} else if !errors.Is(err, gorm.ErrRecordNotFound) {
 				return err
 			}
 		}
 
-		return tx.db.Create(&org).Error
+		return tx.wdb.Create(&org).Error
 	})
 	if err != nil {
 		return sdktypes.InvalidOrgID, translateError(err)
@@ -93,16 +93,16 @@ func (gdb *gormdb) UpdateOrg(ctx context.Context, o sdktypes.Org, fm *sdktypes.F
 		return err
 	}
 
-	err = gdb.transaction(ctx, func(tx *tx) error {
+	err = gdb.transaction(ctx, func(tx *gormdb) error {
 		if name, ok := data["name"]; ok && name != "" {
-			if err := tx.db.Where("name = ?", name).First(&scheme.Org{}).Error; err == nil {
+			if err := tx.wdb.Where("name = ?", name).First(&scheme.Org{}).Error; err == nil {
 				return sdkerrors.ErrAlreadyExists
 			} else if !errors.Is(err, gorm.ErrRecordNotFound) {
 				return err
 			}
 		}
 
-		return tx.db.
+		return tx.wdb.
 			Model(&scheme.Org{}).
 			Where("org_id = ?", o.ID().UUIDValue()).
 			Updates(data).
@@ -114,7 +114,7 @@ func (gdb *gormdb) UpdateOrg(ctx context.Context, o sdktypes.Org, fm *sdktypes.F
 
 func (gdb *gormdb) ListOrgMembers(ctx context.Context, oid sdktypes.OrgID, includeUsers bool) ([]sdktypes.OrgMember, []sdktypes.User, error) {
 	var mrs []scheme.OrgMember
-	err := gdb.db.WithContext(ctx).
+	err := gdb.rdb.WithContext(ctx).
 		Where("org_id = ?", oid.UUIDValue()).
 		Order("created_at ASC").Find(&mrs).
 		Error
@@ -125,7 +125,7 @@ func (gdb *gormdb) ListOrgMembers(ctx context.Context, oid sdktypes.OrgID, inclu
 	var urs []scheme.User
 
 	if includeUsers {
-		err = gdb.db.WithContext(ctx).
+		err = gdb.rdb.WithContext(ctx).
 			Where("user_id in ?", kittehs.Transform(mrs, func(r scheme.OrgMember) uuid.UUID { return r.UserID })).
 			Find(&urs).
 			Error
@@ -160,7 +160,7 @@ func (gdb *gormdb) AddOrgMember(ctx context.Context, m sdktypes.OrgMember) error
 		Roles:  roles,
 	}
 
-	return translateError(gdb.db.WithContext(ctx).Create(&ou).Error)
+	return translateError(gdb.wdb.WithContext(ctx).Create(&ou).Error)
 }
 
 func (gdb *gormdb) UpdateOrgMember(ctx context.Context, m sdktypes.OrgMember, fm *sdktypes.FieldMask) error {
@@ -176,7 +176,7 @@ func (gdb *gormdb) UpdateOrgMember(ctx context.Context, m sdktypes.OrgMember, fm
 	}
 
 	return translateError(
-		gdb.db.WithContext(ctx).
+		gdb.wdb.WithContext(ctx).
 			Model(&scheme.OrgMember{}).
 			Where("org_id = ? AND user_id = ?", m.OrgID().UUIDValue(), m.UserID().UUIDValue()).
 			Updates(data).
@@ -186,7 +186,7 @@ func (gdb *gormdb) UpdateOrgMember(ctx context.Context, m sdktypes.OrgMember, fm
 
 func (gdb *gormdb) RemoveOrgMember(ctx context.Context, oid sdktypes.OrgID, uid sdktypes.UserID) error {
 	return translateError(
-		gdb.db.WithContext(ctx).
+		gdb.wdb.WithContext(ctx).
 			Where("org_id = ? AND user_id = ?", oid.UUIDValue(), uid.UUIDValue()).
 			Delete(&scheme.OrgMember{}).
 			Error,
@@ -196,7 +196,7 @@ func (gdb *gormdb) RemoveOrgMember(ctx context.Context, oid sdktypes.OrgID, uid 
 func (gdb *gormdb) GetOrgMember(ctx context.Context, oid sdktypes.OrgID, uid sdktypes.UserID) (sdktypes.OrgMember, error) {
 	var om scheme.OrgMember
 
-	err := gdb.db.WithContext(ctx).
+	err := gdb.rdb.WithContext(ctx).
 		Model(&scheme.OrgMember{}).
 		Where("org_id = ? AND user_id = ?", oid.UUIDValue(), uid.UUIDValue()).
 		First(&om).
@@ -215,7 +215,7 @@ func (gdb *gormdb) GetOrgMember(ctx context.Context, oid sdktypes.OrgID, uid sdk
 
 func (gdb *gormdb) GetOrgsForUser(ctx context.Context, uid sdktypes.UserID, includeOrgs bool) ([]sdktypes.OrgMember, []sdktypes.Org, error) {
 	var rms []scheme.OrgMember
-	err := gdb.db.WithContext(ctx).
+	err := gdb.rdb.WithContext(ctx).
 		Where("user_id = ?", uid.UUIDValue()).
 		Order("created_at ASC").
 		Find(&rms).
@@ -227,7 +227,7 @@ func (gdb *gormdb) GetOrgsForUser(ctx context.Context, uid sdktypes.UserID, incl
 	var ors []scheme.Org
 
 	if includeOrgs {
-		err = gdb.db.WithContext(ctx).
+		err = gdb.rdb.WithContext(ctx).
 			Where("org_id in ?", kittehs.Transform(rms, func(r scheme.OrgMember) uuid.UUID { return r.OrgID })).
 			Find(&ors).
 			Error

--- a/internal/backend/db/dbgorm/owner_org.go
+++ b/internal/backend/db/dbgorm/owner_org.go
@@ -18,7 +18,7 @@ type (
 func (gdb *gormdb) getProjectOrg(ctx context.Context, id uuidValuer) (sdktypes.OrgID, error) {
 	var p scheme.Project
 
-	err := gdb.db.WithContext(ctx).
+	err := gdb.rdb.WithContext(ctx).
 		Where("project_id = ?", id.UUIDValue()).
 		Select("org_id").
 		First(&p).
@@ -40,7 +40,7 @@ func (gdb *gormdb) getRecordProjectOwner(
 		Project   scheme.Project `gorm:"foreignKey:project_id"`
 	}
 
-	err := gdb.db.WithContext(ctx).
+	err := gdb.rdb.WithContext(ctx).
 		Model(m).
 		Where(m.IDFieldName()+" = ?", id.UUIDValue()).
 		Preload("Project").
@@ -109,7 +109,7 @@ func (gdb *gormdb) GetProjectIDOf(ctx context.Context, id sdktypes.ID) (sdktypes
 		Project   scheme.Project `gorm:"foreignKey:project_id"`
 	}
 
-	err := gdb.db.WithContext(ctx).
+	err := gdb.rdb.WithContext(ctx).
 		Model(m).
 		Where(m.IDFieldName()+" = ?", id.UUIDValue()).
 		Select("project_id").

--- a/internal/backend/db/dbgorm/owner_org.go
+++ b/internal/backend/db/dbgorm/owner_org.go
@@ -18,7 +18,7 @@ type (
 func (gdb *gormdb) getProjectOrg(ctx context.Context, id uuidValuer) (sdktypes.OrgID, error) {
 	var p scheme.Project
 
-	err := gdb.rdb.WithContext(ctx).
+	err := gdb.reader.WithContext(ctx).
 		Where("project_id = ?", id.UUIDValue()).
 		Select("org_id").
 		First(&p).
@@ -40,7 +40,7 @@ func (gdb *gormdb) getRecordProjectOwner(
 		Project   scheme.Project `gorm:"foreignKey:project_id"`
 	}
 
-	err := gdb.rdb.WithContext(ctx).
+	err := gdb.reader.WithContext(ctx).
 		Model(m).
 		Where(m.IDFieldName()+" = ?", id.UUIDValue()).
 		Preload("Project").
@@ -109,7 +109,7 @@ func (gdb *gormdb) GetProjectIDOf(ctx context.Context, id sdktypes.ID) (sdktypes
 		Project   scheme.Project `gorm:"foreignKey:project_id"`
 	}
 
-	err := gdb.rdb.WithContext(ctx).
+	err := gdb.reader.WithContext(ctx).
 		Model(m).
 		Where(m.IDFieldName()+" = ?", id.UUIDValue()).
 		Select("project_id").

--- a/internal/backend/db/dbgorm/projects.go
+++ b/internal/backend/db/dbgorm/projects.go
@@ -16,10 +16,10 @@ import (
 )
 
 func (gdb *gormdb) createProject(ctx context.Context, project *scheme.Project) error {
-	return gdb.transaction(ctx, func(tx *tx) error {
+	return gdb.transaction(ctx, func(tx *gormdb) error {
 		// ensure there is no active project with the same name (but allow deleted ones)
 		var count int64
-		if err := tx.db.
+		if err := tx.wdb.
 			// probably EXISTS is a bit more efficient, but it's not naturally supported by gorm
 			// and we are using joins as well. First maybe a good option too, but there should be only
 			// one active user project with the same name, so COUNT is also OK
@@ -30,19 +30,17 @@ func (gdb *gormdb) createProject(ctx context.Context, project *scheme.Project) e
 		if count > 0 {
 			return gorm.ErrDuplicatedKey // active/non-deleted project was found.
 		}
-		return tx.db.Create(project).Error
+		return tx.wdb.Create(project).Error
 	})
 }
 
 func (gdb *gormdb) deleteProject(ctx context.Context, projectID uuid.UUID) error {
-	return gdb.transaction(ctx, func(tx *tx) error {
-		return tx.deleteProjectAndDependents(tx.ctx, projectID)
-	})
+	return gdb.transaction(ctx, func(tx *gormdb) error { return tx.deleteProjectAndDependents(ctx, projectID) })
 }
 
 func (gdb *gormdb) deleteProjectVars(ctx context.Context, id uuid.UUID) error {
 	// NOTE: should be transactional
-	db := gdb.db.WithContext(ctx)
+	db := gdb.wdb.WithContext(ctx)
 
 	var count int64
 	db.Model(&scheme.Deployment{}).Where("deleted_at is NULL and project_id = ?", id).Count(&count)
@@ -81,18 +79,18 @@ func (gdb *gormdb) deleteProjectAndDependents(ctx context.Context, projectID uui
 
 	// Connection is referenced by signals and triggers, so delete them first.
 	// NOTE that signals, triggers and connections are hard-deleted now
-	if err = gdb.db.Delete(&scheme.Trigger{}, "project_id = ?", projectID).Error; err != nil {
+	if err = gdb.wdb.Delete(&scheme.Trigger{}, "project_id = ?", projectID).Error; err != nil {
 		return err
 	}
 
 	var signalIDs []string
-	if err := gdb.db.Model(&scheme.Signal{}).
+	if err := gdb.wdb.Model(&scheme.Signal{}).
 		Joins("join connections on connections.connection_id = signals.connection_id").
 		Where("connections.project_id = ?", projectID).
 		Pluck("signals.signal_id", &signalIDs).Error; err != nil {
 		return err
 	}
-	if err = gdb.db.Delete(&scheme.Signal{}, "signal_id IN ?", signalIDs).Error; err != nil {
+	if err = gdb.wdb.Delete(&scheme.Signal{}, "signal_id IN ?", signalIDs).Error; err != nil {
 		return err
 	}
 
@@ -105,20 +103,20 @@ func (gdb *gormdb) deleteProjectAndDependents(ctx context.Context, projectID uui
 		return err
 	}
 
-	return gdb.db.Delete(&scheme.Project{ProjectID: projectID}).Error
+	return gdb.wdb.Delete(&scheme.Project{ProjectID: projectID}).Error
 }
 
 func (gdb *gormdb) updateProject(ctx context.Context, p *scheme.Project) error {
-	return gdb.transaction(ctx, func(tx *tx) error {
+	return gdb.transaction(ctx, func(tx *gormdb) error {
 		data := updatedBaseColumns(ctx)
 		data["name"] = p.Name
 		data["root_url"] = p.RootURL
-		return tx.db.Model(&scheme.Project{ProjectID: p.ProjectID}).Updates(data).Error
+		return tx.wdb.Model(&scheme.Project{ProjectID: p.ProjectID}).Updates(data).Error
 	})
 }
 
 func (gdb *gormdb) getProject(ctx context.Context, projectID uuid.UUID) (*scheme.Project, error) {
-	return getOne[scheme.Project](gdb.db.WithContext(ctx), "project_id = ?", projectID)
+	return getOne[scheme.Project](gdb.rdb.WithContext(ctx), "project_id = ?", projectID)
 }
 
 func (gdb *gormdb) getProjectByName(ctx context.Context, oid sdktypes.OrgID, projectName string) (*scheme.Project, error) {
@@ -130,11 +128,11 @@ func (gdb *gormdb) getProjectByName(ctx context.Context, oid sdktypes.OrgID, pro
 		qargs = append(qargs, oid.UUIDValue())
 	}
 
-	return getOne[scheme.Project](gdb.db.WithContext(ctx), q, qargs...)
+	return getOne[scheme.Project](gdb.rdb.WithContext(ctx), q, qargs...)
 }
 
 func (gdb *gormdb) listProjects(ctx context.Context, oid sdktypes.OrgID) ([]scheme.Project, error) {
-	q := gdb.db.WithContext(ctx)
+	q := gdb.rdb.WithContext(ctx)
 
 	if oid.IsValid() {
 		q = q.Where("org_id = ?", oid.UUIDValue())
@@ -211,12 +209,12 @@ type DeploymentState struct {
 
 func (db *gormdb) getProjectDeploymentsStates(ctx context.Context, pid uuid.UUID) ([]DeploymentState, error) {
 	var pds []DeploymentState
-	res := db.db.WithContext(ctx).Model(&scheme.Deployment{}).Where("project_id = ?", pid).Find(&pds)
+	res := db.rdb.WithContext(ctx).Model(&scheme.Deployment{}).Where("project_id = ?", pid).Find(&pds)
 	return pds, res.Error
 }
 
 func (db *gormdb) GetProjectResources(ctx context.Context, pid sdktypes.ProjectID) (map[string][]byte, error) {
-	res := db.db.WithContext(ctx).Model(&scheme.Project{}).Where("project_id = ?", pid.UUIDValue()).Select("resources").Row()
+	res := db.rdb.WithContext(ctx).Model(&scheme.Project{}).Where("project_id = ?", pid.UUIDValue()).Select("resources").Row()
 	var resources []byte
 	if err := res.Scan(&resources); err != nil {
 		return nil, translateError(err)
@@ -244,7 +242,7 @@ func (db *gormdb) SetProjectResources(ctx context.Context, pid sdktypes.ProjectI
 		return err
 	}
 
-	res := db.db.WithContext(ctx).Model(&scheme.Project{}).Where("project_id = ?", pid.UUIDValue()).Update("resources", resourcesBytes)
+	res := db.wdb.WithContext(ctx).Model(&scheme.Project{}).Where("project_id = ?", pid.UUIDValue()).Update("resources", resourcesBytes)
 	if res.Error != nil {
 		return translateError(res.Error)
 	}

--- a/internal/backend/db/dbgorm/projects.go
+++ b/internal/backend/db/dbgorm/projects.go
@@ -16,10 +16,10 @@ import (
 )
 
 func (gdb *gormdb) createProject(ctx context.Context, project *scheme.Project) error {
-	return gdb.transaction(ctx, func(tx *gormdb) error {
+	return gdb.writeTransaction(ctx, func(tx *gormdb) error {
 		// ensure there is no active project with the same name (but allow deleted ones)
 		var count int64
-		if err := tx.wdb.
+		if err := tx.writer.
 			// probably EXISTS is a bit more efficient, but it's not naturally supported by gorm
 			// and we are using joins as well. First maybe a good option too, but there should be only
 			// one active user project with the same name, so COUNT is also OK
@@ -30,17 +30,17 @@ func (gdb *gormdb) createProject(ctx context.Context, project *scheme.Project) e
 		if count > 0 {
 			return gorm.ErrDuplicatedKey // active/non-deleted project was found.
 		}
-		return tx.wdb.Create(project).Error
+		return tx.writer.Create(project).Error
 	})
 }
 
 func (gdb *gormdb) deleteProject(ctx context.Context, projectID uuid.UUID) error {
-	return gdb.transaction(ctx, func(tx *gormdb) error { return tx.deleteProjectAndDependents(ctx, projectID) })
+	return gdb.writeTransaction(ctx, func(tx *gormdb) error { return tx.deleteProjectAndDependents(ctx, projectID) })
 }
 
 func (gdb *gormdb) deleteProjectVars(ctx context.Context, id uuid.UUID) error {
 	// NOTE: should be transactional
-	db := gdb.wdb.WithContext(ctx)
+	db := gdb.writer.WithContext(ctx)
 
 	var count int64
 	db.Model(&scheme.Deployment{}).Where("deleted_at is NULL and project_id = ?", id).Count(&count)
@@ -79,18 +79,18 @@ func (gdb *gormdb) deleteProjectAndDependents(ctx context.Context, projectID uui
 
 	// Connection is referenced by signals and triggers, so delete them first.
 	// NOTE that signals, triggers and connections are hard-deleted now
-	if err = gdb.wdb.Delete(&scheme.Trigger{}, "project_id = ?", projectID).Error; err != nil {
+	if err = gdb.writer.Delete(&scheme.Trigger{}, "project_id = ?", projectID).Error; err != nil {
 		return err
 	}
 
 	var signalIDs []string
-	if err := gdb.wdb.Model(&scheme.Signal{}).
+	if err := gdb.writer.Model(&scheme.Signal{}).
 		Joins("join connections on connections.connection_id = signals.connection_id").
 		Where("connections.project_id = ?", projectID).
 		Pluck("signals.signal_id", &signalIDs).Error; err != nil {
 		return err
 	}
-	if err = gdb.wdb.Delete(&scheme.Signal{}, "signal_id IN ?", signalIDs).Error; err != nil {
+	if err = gdb.writer.Delete(&scheme.Signal{}, "signal_id IN ?", signalIDs).Error; err != nil {
 		return err
 	}
 
@@ -103,20 +103,20 @@ func (gdb *gormdb) deleteProjectAndDependents(ctx context.Context, projectID uui
 		return err
 	}
 
-	return gdb.wdb.Delete(&scheme.Project{ProjectID: projectID}).Error
+	return gdb.writer.Delete(&scheme.Project{ProjectID: projectID}).Error
 }
 
 func (gdb *gormdb) updateProject(ctx context.Context, p *scheme.Project) error {
-	return gdb.transaction(ctx, func(tx *gormdb) error {
+	return gdb.writeTransaction(ctx, func(tx *gormdb) error {
 		data := updatedBaseColumns(ctx)
 		data["name"] = p.Name
 		data["root_url"] = p.RootURL
-		return tx.wdb.Model(&scheme.Project{ProjectID: p.ProjectID}).Updates(data).Error
+		return tx.writer.Model(&scheme.Project{ProjectID: p.ProjectID}).Updates(data).Error
 	})
 }
 
 func (gdb *gormdb) getProject(ctx context.Context, projectID uuid.UUID) (*scheme.Project, error) {
-	return getOne[scheme.Project](gdb.rdb.WithContext(ctx), "project_id = ?", projectID)
+	return getOne[scheme.Project](gdb.reader.WithContext(ctx), "project_id = ?", projectID)
 }
 
 func (gdb *gormdb) getProjectByName(ctx context.Context, oid sdktypes.OrgID, projectName string) (*scheme.Project, error) {
@@ -128,11 +128,11 @@ func (gdb *gormdb) getProjectByName(ctx context.Context, oid sdktypes.OrgID, pro
 		qargs = append(qargs, oid.UUIDValue())
 	}
 
-	return getOne[scheme.Project](gdb.rdb.WithContext(ctx), q, qargs...)
+	return getOne[scheme.Project](gdb.reader.WithContext(ctx), q, qargs...)
 }
 
 func (gdb *gormdb) listProjects(ctx context.Context, oid sdktypes.OrgID) ([]scheme.Project, error) {
-	q := gdb.rdb.WithContext(ctx)
+	q := gdb.reader.WithContext(ctx)
 
 	if oid.IsValid() {
 		q = q.Where("org_id = ?", oid.UUIDValue())
@@ -209,12 +209,12 @@ type DeploymentState struct {
 
 func (db *gormdb) getProjectDeploymentsStates(ctx context.Context, pid uuid.UUID) ([]DeploymentState, error) {
 	var pds []DeploymentState
-	res := db.rdb.WithContext(ctx).Model(&scheme.Deployment{}).Where("project_id = ?", pid).Find(&pds)
+	res := db.reader.WithContext(ctx).Model(&scheme.Deployment{}).Where("project_id = ?", pid).Find(&pds)
 	return pds, res.Error
 }
 
 func (db *gormdb) GetProjectResources(ctx context.Context, pid sdktypes.ProjectID) (map[string][]byte, error) {
-	res := db.rdb.WithContext(ctx).Model(&scheme.Project{}).Where("project_id = ?", pid.UUIDValue()).Select("resources").Row()
+	res := db.reader.WithContext(ctx).Model(&scheme.Project{}).Where("project_id = ?", pid.UUIDValue()).Select("resources").Row()
 	var resources []byte
 	if err := res.Scan(&resources); err != nil {
 		return nil, translateError(err)
@@ -242,7 +242,7 @@ func (db *gormdb) SetProjectResources(ctx context.Context, pid sdktypes.ProjectI
 		return err
 	}
 
-	res := db.wdb.WithContext(ctx).Model(&scheme.Project{}).Where("project_id = ?", pid.UUIDValue()).Update("resources", resourcesBytes)
+	res := db.writer.WithContext(ctx).Model(&scheme.Project{}).Where("project_id = ?", pid.UUIDValue()).Update("resources", resourcesBytes)
 	if res.Error != nil {
 		return translateError(res.Error)
 	}

--- a/internal/backend/db/dbgorm/secrets.go
+++ b/internal/backend/db/dbgorm/secrets.go
@@ -10,12 +10,12 @@ import (
 
 func (db *gormdb) SetSecret(ctx context.Context, key string, value string) error {
 	secret := scheme.Secret{Key: key, Value: value}
-	return translateError(db.db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(secret).Error)
+	return translateError(db.wdb.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(secret).Error)
 }
 
 func (db *gormdb) GetSecret(ctx context.Context, key string) (string, error) {
 	var secret scheme.Secret
-	if err := db.db.WithContext(ctx).Where("key = ?", key).Find(&secret).Error; err != nil {
+	if err := db.rdb.WithContext(ctx).Where("key = ?", key).Find(&secret).Error; err != nil {
 		return "", translateError(err)
 	}
 
@@ -23,5 +23,5 @@ func (db *gormdb) GetSecret(ctx context.Context, key string) (string, error) {
 }
 
 func (db *gormdb) DeleteSecret(ctx context.Context, key string) error {
-	return delete[scheme.Secret](db.db, ctx, "key = ?", key)
+	return delete[scheme.Secret](db.wdb, ctx, "key = ?", key)
 }

--- a/internal/backend/db/dbgorm/secrets.go
+++ b/internal/backend/db/dbgorm/secrets.go
@@ -10,12 +10,12 @@ import (
 
 func (db *gormdb) SetSecret(ctx context.Context, key string, value string) error {
 	secret := scheme.Secret{Key: key, Value: value}
-	return translateError(db.wdb.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(secret).Error)
+	return translateError(db.writer.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(secret).Error)
 }
 
 func (db *gormdb) GetSecret(ctx context.Context, key string) (string, error) {
 	var secret scheme.Secret
-	if err := db.rdb.WithContext(ctx).Where("key = ?", key).Find(&secret).Error; err != nil {
+	if err := db.reader.WithContext(ctx).Where("key = ?", key).Find(&secret).Error; err != nil {
 		return "", translateError(err)
 	}
 
@@ -23,5 +23,5 @@ func (db *gormdb) GetSecret(ctx context.Context, key string) (string, error) {
 }
 
 func (db *gormdb) DeleteSecret(ctx context.Context, key string) error {
-	return delete[scheme.Secret](db.wdb, ctx, "key = ?", key)
+	return delete[scheme.Secret](db.writer, ctx, "key = ?", key)
 }

--- a/internal/backend/db/dbgorm/sessions.go
+++ b/internal/backend/db/dbgorm/sessions.go
@@ -35,16 +35,16 @@ func (gdb *gormdb) createSession(ctx context.Context, session *scheme.Session) e
 		return err
 	}
 
-	return translateError(gdb.transaction(ctx, func(tx *gormdb) error {
-		if err := tx.wdb.Create(session).Error; err != nil {
+	return translateError(gdb.writeTransaction(ctx, func(tx *gormdb) error {
+		if err := tx.writer.Create(session).Error; err != nil {
 			return err
 		}
-		return createLogRecord(tx.wdb, ctx, logr, stateSessionLogRecordType)
+		return createLogRecord(tx.writer, ctx, logr, stateSessionLogRecordType)
 	}))
 }
 
 func (gdb *gormdb) deleteSession(ctx context.Context, sessionID uuid.UUID) error {
-	return gdb.wdb.WithContext(ctx).Delete(&scheme.Session{SessionID: sessionID}).Error
+	return gdb.writer.WithContext(ctx).Delete(&scheme.Session{SessionID: sessionID}).Error
 }
 
 func (gdb *gormdb) updateSessionState(ctx context.Context, sessionID uuid.UUID, state sdktypes.SessionState) error {
@@ -54,20 +54,20 @@ func (gdb *gormdb) updateSessionState(ctx context.Context, sessionID uuid.UUID, 
 		return err
 	}
 
-	return gdb.transaction(ctx, func(tx *gormdb) error {
-		if err := tx.wdb.Model(&scheme.Session{SessionID: sessionID}).Updates(sessionStateUpdate).Error; err != nil {
+	return gdb.writeTransaction(ctx, func(tx *gormdb) error {
+		if err := tx.writer.Model(&scheme.Session{SessionID: sessionID}).Updates(sessionStateUpdate).Error; err != nil {
 			return err
 		}
-		return createLogRecord(tx.wdb, ctx, logr, stateSessionLogRecordType)
+		return createLogRecord(tx.writer, ctx, logr, stateSessionLogRecordType)
 	})
 }
 
 func (gdb *gormdb) getSession(ctx context.Context, sessionID uuid.UUID) (*scheme.Session, error) {
-	return getOne[scheme.Session](gdb.rdb.WithContext(ctx), "session_id = ?", sessionID)
+	return getOne[scheme.Session](gdb.reader.WithContext(ctx), "session_id = ?", sessionID)
 }
 
 func (gdb *gormdb) listSessions(ctx context.Context, f sdkservices.ListSessionsFilter) ([]scheme.Session, int64, error) {
-	q := gdb.rdb.WithContext(ctx)
+	q := gdb.reader.WithContext(ctx)
 
 	q = withProjectID(q, "", f.ProjectID)
 
@@ -130,14 +130,14 @@ func createLogRecord(db *gorm.DB, ctx context.Context, logr *scheme.SessionLogRe
 }
 
 func (gdb *gormdb) addSessionLogRecord(ctx context.Context, logr *scheme.SessionLogRecord, typ string) error {
-	return createLogRecord(gdb.wdb, ctx, logr, typ)
+	return createLogRecord(gdb.writer, ctx, logr, typ)
 }
 
 func (gdb *gormdb) getSessionLogRecords(ctx context.Context, filter sdkservices.SessionLogRecordsFilter) (logs []scheme.SessionLogRecord, n int64, err error) {
 	sessionID := filter.SessionID.UUIDValue()
 
-	if err := gdb.transaction(ctx, func(tx *gormdb) error {
-		q := tx.rdb.Where("session_id = ?", sessionID)
+	if err := gdb.writeTransaction(ctx, func(tx *gormdb) error {
+		q := tx.reader.Where("session_id = ?", sessionID)
 
 		if err := q.Model(&scheme.SessionLogRecord{}).Count(&n).Error; err != nil {
 			return err
@@ -205,17 +205,17 @@ func (gdb *gormdb) createSessionCall(ctx context.Context, sessionID uuid.UUID, s
 		Data:      jsonSpec,
 	}
 
-	return gdb.transaction(ctx, func(tx *gormdb) error {
-		if err := tx.wdb.Create(&callSpec).Error; err != nil {
+	return gdb.writeTransaction(ctx, func(tx *gormdb) error {
+		if err := tx.writer.Create(&callSpec).Error; err != nil {
 			return err
 		}
-		return createLogRecord(tx.wdb, ctx, logr, callSpecSessionLogRecordType)
+		return createLogRecord(tx.writer, ctx, logr, callSpecSessionLogRecordType)
 	})
 }
 
 func (gdb *gormdb) getSessionCallSpec(ctx context.Context, sessionID uuid.UUID, seq uint32) (*scheme.SessionCallSpec, error) {
 	var r scheme.SessionCallSpec
-	if err := gdb.rdb.WithContext(ctx).Where("session_id = ?", sessionID).Where("seq = ?", seq).First(&r).Error; err != nil {
+	if err := gdb.reader.WithContext(ctx).Where("session_id = ?", sessionID).Where("seq = ?", seq).First(&r).Error; err != nil {
 		return nil, err
 	}
 	return &r, nil
@@ -232,8 +232,8 @@ func countCallAttempts(db *gorm.DB, sessionID uuid.UUID, seq uint32) (uint32, er
 }
 
 func (gdb *gormdb) startSessionCallAttempt(ctx context.Context, sessionID uuid.UUID, seq uint32) (attempt uint32, err error) {
-	err = gdb.transaction(ctx, func(tx *gormdb) error {
-		if attempt, err = countCallAttempts(tx.wdb, sessionID, seq); err != nil {
+	err = gdb.writeTransaction(ctx, func(tx *gormdb) error {
+		if attempt, err = countCallAttempts(tx.writer, sessionID, seq); err != nil {
 			return err
 		}
 
@@ -257,11 +257,11 @@ func (gdb *gormdb) startSessionCallAttempt(ctx context.Context, sessionID uuid.U
 			Start:     callAttemptStartJson,
 		}
 
-		if err := tx.wdb.Create(&callAttempt).Error; err != nil {
+		if err := tx.writer.Create(&callAttempt).Error; err != nil {
 			return err
 		}
 
-		return createLogRecord(tx.wdb, ctx, logr, callAttemptStartSessionLogRecordType)
+		return createLogRecord(tx.writer, ctx, logr, callAttemptStartSessionLogRecordType)
 	})
 	return
 }
@@ -278,13 +278,13 @@ func (gdb *gormdb) completeSessionCallAttempt(ctx context.Context, sessionID uui
 	}
 	r := scheme.SessionCallAttempt{Complete: json}
 
-	return gdb.transaction(ctx, func(tx *gormdb) error {
-		if res := tx.wdb.Model(&r).Where("session_id = ? AND seq = ? AND attempt = ?", sessionID, seq, attempt).Updates(r); res.Error != nil {
+	return gdb.writeTransaction(ctx, func(tx *gormdb) error {
+		if res := tx.writer.Model(&r).Where("session_id = ? AND seq = ? AND attempt = ?", sessionID, seq, attempt).Updates(r); res.Error != nil {
 			return res.Error
 		} else if res.RowsAffected == 0 {
 			return sdkerrors.ErrNotFound
 		}
-		return createLogRecord(tx.wdb, ctx, logr, callAttemptCompleteSessionLogRecordType)
+		return createLogRecord(tx.writer, ctx, logr, callAttemptCompleteSessionLogRecordType)
 	})
 }
 
@@ -292,8 +292,8 @@ func (gdb *gormdb) completeSessionCallAttempt(ctx context.Context, sessionID uui
 func (gdb *gormdb) getSessionCallAttemptResult(ctx context.Context, sessionID uuid.UUID, seq uint32, attempt int64) (*scheme.SessionCallAttempt, error) {
 	var r scheme.SessionCallAttempt
 
-	if err := gdb.rtransaction(ctx, func(tx *gormdb) error {
-		q := tx.rdb.Where("session_id = ? AND seq = ?", sessionID, seq)
+	if err := gdb.readTransaction(ctx, func(tx *gormdb) error {
+		q := tx.reader.Where("session_id = ? AND seq = ?", sessionID, seq)
 
 		switch {
 		case attempt == -1:

--- a/internal/backend/db/dbgorm/signals.go
+++ b/internal/backend/db/dbgorm/signals.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (db *gormdb) saveSignal(ctx context.Context, signal *scheme.Signal) error {
-	return db.db.WithContext(ctx).Create(signal).Error
+	return db.wdb.WithContext(ctx).Create(signal).Error
 }
 
 func (db *gormdb) SaveSignal(ctx context.Context, signal *types.Signal) error {
@@ -30,7 +30,7 @@ func (db *gormdb) SaveSignal(ctx context.Context, signal *types.Signal) error {
 
 func (db *gormdb) ListWaitingSignals(ctx context.Context, dstID sdktypes.EventDestinationID) ([]*types.Signal, error) {
 	var rs []*scheme.Signal
-	q := db.db.WithContext(ctx).Where("destination_id = ?", dstID.UUIDValue())
+	q := db.rdb.WithContext(ctx).Where("destination_id = ?", dstID.UUIDValue())
 	if err := q.Find(&rs).Error; err != nil {
 		return nil, translateError(err)
 	}
@@ -38,13 +38,13 @@ func (db *gormdb) ListWaitingSignals(ctx context.Context, dstID sdktypes.EventDe
 }
 
 func (db *gormdb) RemoveSignal(ctx context.Context, signalID uuid.UUID) error {
-	return translateError(db.db.WithContext(ctx).Delete(&scheme.Signal{SignalID: signalID}).Error)
+	return translateError(db.wdb.WithContext(ctx).Delete(&scheme.Signal{SignalID: signalID}).Error)
 }
 
 func (db *gormdb) GetSignal(ctx context.Context, signalID uuid.UUID) (*types.Signal, error) {
 	var signal scheme.Signal
 
-	q := db.db.
+	q := db.rdb.
 		WithContext(ctx).
 		Where("signal_id = ?", signalID).
 		Preload("Connection").

--- a/internal/backend/db/dbgorm/signals.go
+++ b/internal/backend/db/dbgorm/signals.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (db *gormdb) saveSignal(ctx context.Context, signal *scheme.Signal) error {
-	return db.wdb.WithContext(ctx).Create(signal).Error
+	return db.writer.WithContext(ctx).Create(signal).Error
 }
 
 func (db *gormdb) SaveSignal(ctx context.Context, signal *types.Signal) error {
@@ -30,7 +30,7 @@ func (db *gormdb) SaveSignal(ctx context.Context, signal *types.Signal) error {
 
 func (db *gormdb) ListWaitingSignals(ctx context.Context, dstID sdktypes.EventDestinationID) ([]*types.Signal, error) {
 	var rs []*scheme.Signal
-	q := db.rdb.WithContext(ctx).Where("destination_id = ?", dstID.UUIDValue())
+	q := db.reader.WithContext(ctx).Where("destination_id = ?", dstID.UUIDValue())
 	if err := q.Find(&rs).Error; err != nil {
 		return nil, translateError(err)
 	}
@@ -38,13 +38,13 @@ func (db *gormdb) ListWaitingSignals(ctx context.Context, dstID sdktypes.EventDe
 }
 
 func (db *gormdb) RemoveSignal(ctx context.Context, signalID uuid.UUID) error {
-	return translateError(db.wdb.WithContext(ctx).Delete(&scheme.Signal{SignalID: signalID}).Error)
+	return translateError(db.writer.WithContext(ctx).Delete(&scheme.Signal{SignalID: signalID}).Error)
 }
 
 func (db *gormdb) GetSignal(ctx context.Context, signalID uuid.UUID) (*types.Signal, error) {
 	var signal scheme.Signal
 
-	q := db.rdb.
+	q := db.reader.
 		WithContext(ctx).
 		Where("signal_id = ?", signalID).
 		Preload("Connection").

--- a/internal/backend/db/dbgorm/signals_test.go
+++ b/internal/backend/db/dbgorm/signals_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/db/dbgorm/scheme"
@@ -31,7 +32,7 @@ func preSignalTest(t *testing.T) *dbFixture {
 
 func TestSaveSignal(t *testing.T) {
 	f := preSignalTest(t)
-	foreignKeys(f.gormdb, false) // no foreign keys
+	require.NoError(t, foreignKeys(f.gormdb, false)) // no foreign keys
 
 	sig := f.newSignal()
 	// test createSignal
@@ -65,7 +66,7 @@ func TestSaveSignelForeignKeys(t *testing.T) {
 
 func TestDeleteSignal(t *testing.T) {
 	f := preSignalTest(t)
-	foreignKeys(f.gormdb, false) // no foreign keys
+	require.NoError(t, foreignKeys(f.gormdb, false)) // no foreign keys
 
 	sig := f.newSignal()
 	f.saveSignalsAndAssert(t, sig)

--- a/internal/backend/db/dbgorm/triggers.go
+++ b/internal/backend/db/dbgorm/triggers.go
@@ -14,24 +14,24 @@ import (
 )
 
 func (gdb *gormdb) createTrigger(ctx context.Context, trigger *scheme.Trigger) error {
-	return gormErrNotFoundToForeignKey(gdb.wdb.WithContext(ctx).Create(trigger).Error)
+	return gormErrNotFoundToForeignKey(gdb.writer.WithContext(ctx).Create(trigger).Error)
 }
 
 func (gdb *gormdb) deleteTrigger(ctx context.Context, triggerID uuid.UUID) error {
 	// NOTE: we allow delettion of triggers referenced by events. see ENG-1535
-	return gdb.wdb.WithContext(ctx).Delete(&scheme.Trigger{TriggerID: triggerID}).Error
+	return gdb.writer.WithContext(ctx).Delete(&scheme.Trigger{TriggerID: triggerID}).Error
 }
 
 func (gdb *gormdb) updateTrigger(ctx context.Context, trigger *scheme.Trigger) error {
-	return gdb.wdb.WithContext(ctx).Model(&scheme.Trigger{TriggerID: trigger.TriggerID}).Updates(trigger).Error
+	return gdb.writer.WithContext(ctx).Model(&scheme.Trigger{TriggerID: trigger.TriggerID}).Updates(trigger).Error
 }
 
 func (gdb *gormdb) getTriggerByID(ctx context.Context, triggerID uuid.UUID) (*scheme.Trigger, error) {
-	return getOne[scheme.Trigger](gdb.rdb.WithContext(ctx), "trigger_id = ?", triggerID)
+	return getOne[scheme.Trigger](gdb.reader.WithContext(ctx), "trigger_id = ?", triggerID)
 }
 
 func (gdb *gormdb) listTriggers(ctx context.Context, filter sdkservices.ListTriggersFilter) ([]scheme.Trigger, error) {
-	q := gdb.rdb.WithContext(ctx)
+	q := gdb.reader.WithContext(ctx)
 
 	if filter.ProjectID.IsValid() {
 		q = q.Where("triggers.project_id = ?", filter.ProjectID.UUIDValue())
@@ -129,7 +129,7 @@ func (db *gormdb) ListTriggers(ctx context.Context, filter sdkservices.ListTrigg
 }
 
 func (db *gormdb) GetTriggerByWebhookSlug(ctx context.Context, slug string) (sdktypes.Trigger, error) {
-	r, err := getOne[scheme.Trigger](db.rdb.WithContext(ctx), "webhook_slug = ?", slug)
+	r, err := getOne[scheme.Trigger](db.reader.WithContext(ctx), "webhook_slug = ?", slug)
 	if err != nil {
 		return sdktypes.InvalidTrigger, translateError(err)
 	}

--- a/internal/backend/db/dbgorm/tx.go
+++ b/internal/backend/db/dbgorm/tx.go
@@ -10,59 +10,32 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/backend/db"
 )
 
-type tx struct {
-	gormdb
-	ctx  context.Context
-	done bool
-}
-
-func (db *gormdb) Begin(ctx context.Context) (db.Transaction, error) {
-	db.db.Error = nil
-	tx1 := db.db.WithContext(ctx).Begin()
-	if err := tx1.Error; err != nil {
-		return nil, err
-	}
-
-	return &tx{
-		gormdb: gormdb{
-			z:  db.z.With(zap.String("txid", uuid.NewString())),
-			db: tx1,
-		},
-	}, nil
-}
-
-func (tx *tx) Commit() error {
-	tx.done = true
-	return tx.db.Commit().Error
-}
-
-func (tx *tx) Rollback() error {
-	if tx.done {
-		return nil
-	}
-
-	return tx.db.Rollback().Error
-}
-
 func (db *gormdb) Transaction(ctx context.Context, f func(db db.DB) error) error {
-	return db.transaction(ctx, func(tx *tx) error {
-		return f(tx)
+	return db.transaction(ctx, func(tx *gormdb) error { return f(tx) })
+}
+
+func (db *gormdb) transaction(ctx context.Context, f func(tx *gormdb) error) error {
+	return db.wdb.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return f(
+			&gormdb{
+				z:   db.z.With(zap.String("txid", uuid.NewString())),
+				wdb: tx,
+				rdb: tx,
+				cfg: db.cfg,
+			},
+		)
 	})
 }
 
-func (db *gormdb) transaction(ctx context.Context, f func(tx *tx) error) error {
-	return db.locked(func(db *gormdb) error {
-		return db.db.WithContext(ctx).Transaction(func(txdb *gorm.DB) error {
-			return f(
-				&tx{
-					gormdb: gormdb{
-						z:   db.z.With(zap.String("txid", uuid.NewString())),
-						db:  txdb,
-						cfg: db.cfg,
-					},
-					ctx: ctx,
-				},
-			)
-		})
+func (db *gormdb) rtransaction(ctx context.Context, f func(tx *gormdb) error) error {
+	return db.rdb.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return f(
+			&gormdb{
+				z:   db.z.With(zap.String("txid", uuid.NewString())),
+				wdb: nil, // panic on writes.
+				rdb: tx,
+				cfg: db.cfg,
+			},
+		)
 	})
 }

--- a/internal/backend/db/dbgorm/tx.go
+++ b/internal/backend/db/dbgorm/tx.go
@@ -11,30 +11,30 @@ import (
 )
 
 func (db *gormdb) Transaction(ctx context.Context, f func(db db.DB) error) error {
-	return db.transaction(ctx, func(tx *gormdb) error { return f(tx) })
+	return db.writeTransaction(ctx, func(tx *gormdb) error { return f(tx) })
 }
 
-func (db *gormdb) transaction(ctx context.Context, f func(tx *gormdb) error) error {
-	return db.wdb.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+func (db *gormdb) writeTransaction(ctx context.Context, f func(tx *gormdb) error) error {
+	return db.writer.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		return f(
 			&gormdb{
-				z:   db.z.With(zap.String("txid", uuid.NewString())),
-				wdb: tx,
-				rdb: tx,
-				cfg: db.cfg,
+				z:      db.z.With(zap.String("txid", uuid.NewString())),
+				writer: tx,
+				reader: tx,
+				cfg:    db.cfg,
 			},
 		)
 	})
 }
 
-func (db *gormdb) rtransaction(ctx context.Context, f func(tx *gormdb) error) error {
-	return db.rdb.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+func (db *gormdb) readTransaction(ctx context.Context, f func(tx *gormdb) error) error {
+	return db.reader.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		return f(
 			&gormdb{
-				z:   db.z.With(zap.String("txid", uuid.NewString())),
-				wdb: nil, // panic on writes.
-				rdb: tx,
-				cfg: db.cfg,
+				z:      db.z.With(zap.String("txid", uuid.NewString())),
+				writer: nil, // panic on writes.
+				reader: tx,
+				cfg:    db.cfg,
 			},
 		)
 	})

--- a/internal/backend/db/dbgorm/users.go
+++ b/internal/backend/db/dbgorm/users.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (gdb *gormdb) GetUser(ctx context.Context, id sdktypes.UserID, email string) (sdktypes.User, error) {
-	q := gdb.db.WithContext(ctx)
+	q := gdb.rdb.WithContext(ctx)
 
 	if !id.IsValid() && email == "" {
 		return sdktypes.InvalidUser, sdkerrors.NewInvalidArgumentError("missing id or email")
@@ -55,7 +55,7 @@ func (gdb *gormdb) CreateUser(ctx context.Context, u sdktypes.User) (sdktypes.Us
 		Status:       int32(u.Status().ToProto()),
 	}
 
-	err := gdb.db.WithContext(ctx).Create(&user).Error
+	err := gdb.wdb.WithContext(ctx).Create(&user).Error
 	if err != nil {
 		return sdktypes.InvalidUserID, translateError(err)
 	}
@@ -78,7 +78,7 @@ func (gdb *gormdb) UpdateUser(ctx context.Context, u sdktypes.User, fm *sdktypes
 	}
 
 	return translateError(
-		gdb.db.WithContext(ctx).
+		gdb.wdb.WithContext(ctx).
 			Model(&scheme.User{}).
 			Where("user_id = ?", u.ID().UUIDValue()).
 			Updates(data).

--- a/internal/backend/db/dbgorm/users.go
+++ b/internal/backend/db/dbgorm/users.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (gdb *gormdb) GetUser(ctx context.Context, id sdktypes.UserID, email string) (sdktypes.User, error) {
-	q := gdb.rdb.WithContext(ctx)
+	q := gdb.reader.WithContext(ctx)
 
 	if !id.IsValid() && email == "" {
 		return sdktypes.InvalidUser, sdkerrors.NewInvalidArgumentError("missing id or email")
@@ -55,7 +55,7 @@ func (gdb *gormdb) CreateUser(ctx context.Context, u sdktypes.User) (sdktypes.Us
 		Status:       int32(u.Status().ToProto()),
 	}
 
-	err := gdb.wdb.WithContext(ctx).Create(&user).Error
+	err := gdb.writer.WithContext(ctx).Create(&user).Error
 	if err != nil {
 		return sdktypes.InvalidUserID, translateError(err)
 	}
@@ -78,7 +78,7 @@ func (gdb *gormdb) UpdateUser(ctx context.Context, u sdktypes.User, fm *sdktypes
 	}
 
 	return translateError(
-		gdb.wdb.WithContext(ctx).
+		gdb.writer.WithContext(ctx).
 			Model(&scheme.User{}).
 			Where("user_id = ?", u.ID().UUIDValue()).
 			Updates(data).

--- a/internal/backend/db/dbgorm/values.go
+++ b/internal/backend/db/dbgorm/values.go
@@ -22,13 +22,13 @@ func (db *gormdb) SetValue(ctx context.Context, pid sdktypes.ProjectID, key stri
 		return sdkerrors.NewInvalidArgumentError("value too large > %d bytes", maxValueSize)
 	}
 
-	return translateError(db.transaction(ctx, func(tx *tx) error {
+	return translateError(db.transaction(ctx, func(tx *gormdb) error {
 		bs, err := proto.Marshal(v.ToProto())
 		if err != nil {
 			return err
 		}
 
-		return tx.db.Save(&scheme.Value{
+		return tx.wdb.Save(&scheme.Value{
 			// This does not take into account if value was also previously set,
 			// so `created_by` and `updated_by` would always point to the last user
 			// that updated the user.
@@ -43,7 +43,7 @@ func (db *gormdb) SetValue(ctx context.Context, pid sdktypes.ProjectID, key stri
 }
 
 func (db *gormdb) GetValue(ctx context.Context, pid sdktypes.ProjectID, key string) (sdktypes.Value, error) {
-	r, err := getOne[scheme.Value](db.db.WithContext(ctx), "project_id = ? AND key = ?", pid.UUIDValue(), key)
+	r, err := getOne[scheme.Value](db.rdb.WithContext(ctx), "project_id = ? AND key = ?", pid.UUIDValue(), key)
 	if err != nil {
 		return sdktypes.InvalidValue, translateError(err)
 	}
@@ -59,7 +59,7 @@ func (db *gormdb) GetValue(ctx context.Context, pid sdktypes.ProjectID, key stri
 
 func (db *gormdb) ListValues(ctx context.Context, pid sdktypes.ProjectID) (map[string]sdktypes.Value, error) {
 	var rs []*scheme.Value
-	if err := db.db.WithContext(ctx).Where("project_id = ?", pid.UUIDValue()).Find(&rs).Error; err != nil {
+	if err := db.rdb.WithContext(ctx).Where("project_id = ?", pid.UUIDValue()).Find(&rs).Error; err != nil {
 		return nil, translateError(err)
 	}
 

--- a/internal/backend/db/dbgorm/values.go
+++ b/internal/backend/db/dbgorm/values.go
@@ -22,13 +22,13 @@ func (db *gormdb) SetValue(ctx context.Context, pid sdktypes.ProjectID, key stri
 		return sdkerrors.NewInvalidArgumentError("value too large > %d bytes", maxValueSize)
 	}
 
-	return translateError(db.transaction(ctx, func(tx *gormdb) error {
+	return translateError(db.writeTransaction(ctx, func(tx *gormdb) error {
 		bs, err := proto.Marshal(v.ToProto())
 		if err != nil {
 			return err
 		}
 
-		return tx.wdb.Save(&scheme.Value{
+		return tx.writer.Save(&scheme.Value{
 			// This does not take into account if value was also previously set,
 			// so `created_by` and `updated_by` would always point to the last user
 			// that updated the user.
@@ -43,7 +43,7 @@ func (db *gormdb) SetValue(ctx context.Context, pid sdktypes.ProjectID, key stri
 }
 
 func (db *gormdb) GetValue(ctx context.Context, pid sdktypes.ProjectID, key string) (sdktypes.Value, error) {
-	r, err := getOne[scheme.Value](db.rdb.WithContext(ctx), "project_id = ? AND key = ?", pid.UUIDValue(), key)
+	r, err := getOne[scheme.Value](db.reader.WithContext(ctx), "project_id = ? AND key = ?", pid.UUIDValue(), key)
 	if err != nil {
 		return sdktypes.InvalidValue, translateError(err)
 	}
@@ -59,7 +59,7 @@ func (db *gormdb) GetValue(ctx context.Context, pid sdktypes.ProjectID, key stri
 
 func (db *gormdb) ListValues(ctx context.Context, pid sdktypes.ProjectID) (map[string]sdktypes.Value, error) {
 	var rs []*scheme.Value
-	if err := db.rdb.WithContext(ctx).Where("project_id = ?", pid.UUIDValue()).Find(&rs).Error; err != nil {
+	if err := db.reader.WithContext(ctx).Where("project_id = ?", pid.UUIDValue()).Find(&rs).Error; err != nil {
 		return nil, translateError(err)
 	}
 

--- a/internal/backend/db/dbgorm/vars.go
+++ b/internal/backend/db/dbgorm/vars.go
@@ -19,8 +19,8 @@ func (gdb *gormdb) setVar(ctx context.Context, vr *scheme.Var) error {
 
 	// TODO: Check that connection or trigger were not deleted.
 
-	return gdb.transaction(ctx, func(tx *gormdb) error {
-		db := tx.wdb
+	return gdb.writeTransaction(ctx, func(tx *gormdb) error {
+		db := tx.writer
 
 		var (
 			tableName, idField string
@@ -55,11 +55,11 @@ func varsCommonQuery(db *gorm.DB, scopeID uuid.UUID, names []string) *gorm.DB {
 }
 
 func (gdb *gormdb) deleteVars(ctx context.Context, scopeID uuid.UUID, names ...string) error {
-	return varsCommonQuery(gdb.wdb.WithContext(ctx), scopeID, names).Delete(&scheme.Var{}).Error
+	return varsCommonQuery(gdb.writer.WithContext(ctx), scopeID, names).Delete(&scheme.Var{}).Error
 }
 
 func (gdb *gormdb) listVars(ctx context.Context, scopeID uuid.UUID, names ...string) ([]scheme.Var, error) {
-	db := varsCommonQuery(gdb.rdb.WithContext(ctx), scopeID, names) // skip not user owned vars
+	db := varsCommonQuery(gdb.reader.WithContext(ctx), scopeID, names) // skip not user owned vars
 
 	// Note: we are not checking if scope (env/connection) is deleted, since scope deletion will cascade deletion of relevant vars
 	// e.g. vars present only for valid and active scope
@@ -74,7 +74,7 @@ func (gdb *gormdb) listVars(ctx context.Context, scopeID uuid.UUID, names ...str
 }
 
 func (gdb *gormdb) findConnectionIDsByVar(ctx context.Context, integrationID uuid.UUID, name string, v string) ([]uuid.UUID, error) {
-	db := gdb.rdb.WithContext(ctx).Where("integration_id = ? AND name = ?", integrationID, name)
+	db := gdb.reader.WithContext(ctx).Where("integration_id = ? AND name = ?", integrationID, name)
 	if v != "" {
 		db = db.Where("value = ? AND is_secret is false", v)
 	}
@@ -149,7 +149,7 @@ func (db *gormdb) DeleteVars(ctx context.Context, sid sdktypes.VarScopeID, names
 }
 
 func (gdb *gormdb) CountVars(ctx context.Context, sid sdktypes.VarScopeID) (int, error) {
-	q := varsCommonQuery(gdb.rdb.WithContext(ctx), sid.UUIDValue(), nil)
+	q := varsCommonQuery(gdb.reader.WithContext(ctx), sid.UUIDValue(), nil)
 
 	var n int64
 	if err := q.Model(&scheme.Var{}).Count(&n).Error; err != nil {

--- a/internal/backend/gormkitteh/gormkitteh.go
+++ b/internal/backend/gormkitteh/gormkitteh.go
@@ -49,11 +49,5 @@ func Open(cfg *Config, f func(*gorm.Config)) (*gorm.DB, error) {
 		db = db.Debug()
 	}
 
-	if cfg.Type == "sqlite" {
-		if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
-			return nil, fmt.Errorf("sqlite error, failed setting foreign keys on: %w", err)
-		}
-	}
-
 	return db, nil
 }

--- a/internal/backend/webtools/db.go
+++ b/internal/backend/webtools/db.go
@@ -28,7 +28,8 @@ func (db *terminalDB) Setup(ctx context.Context) error {
 }
 
 func (db *terminalDB) db(ctx context.Context) *gorm.DB {
-	return db.DB.GormDB().WithContext(ctx)
+	_, w := db.DB.GormDB()
+	return w.WithContext(ctx)
 }
 
 func (db *terminalDB) GetMessages(ctx context.Context, addr string) ([]Message, error) {


### PR DESCRIPTION
the instructions given in https://kerkour.com/sqlite-for-servers seem to be working. tested under load, not a single BUSY was seen.

this essentially separates db connections into write and read connections, limiting writes to a single connection. also add a bunch of pragmas. for non-sqlite, there is no separation.

get rid of the sqlite lock.

also get rid of some unused functions.

Ref: ENG-190, ENG-648