### PR TITLE
fix(ENG-1977): lint request project id param parsing

### DIFF
--- a/internal/backend/projectsgrpcsvc/svc.go
+++ b/internal/backend/projectsgrpcsvc/svc.go
@@ -272,7 +272,16 @@ func (s *Server) Export(ctx context.Context, req *connect.Request[projectsv1.Exp
 
 func (s *Server) Lint(ctx context.Context, req *connect.Request[projectsv1.LintRequest]) (*connect.Response[projectsv1.LintResponse], error) {
 	// TODO: Need to work with our without project
-	vs, err := s.projects.Lint(ctx, sdktypes.InvalidProjectID, req.Msg.Resources, req.Msg.ManifestFile)
+
+	pid, err := sdktypes.ParseProjectID(req.Msg.ProjectId)
+	if err != nil {
+		return nil, sdkerrors.AsConnectError(err)
+	}
+
+	if !pid.IsValid() {
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("project_id: %w", err))
+	}
+	vs, err := s.projects.Lint(ctx, pid, req.Msg.Resources, req.Msg.ManifestFile)
 	if err != nil {
 		return nil, sdkerrors.AsConnectError(err)
 	}


### PR DESCRIPTION
Currently on main, when we sending request to lint a project, we don't get it ProjectID because we aren't parsing and passing it in the svc.go file:
https://github.com/autokitteh/autokitteh/blob/efc48f56d7356718a7df8d2ca86c112c5dc6d1cf/internal/backend/projectsgrpcsvc/svc.go#L275