### PR TITLE
feat: Block organization delete if it has projects

### DIFF
--- a/internal/backend/db/db.go
+++ b/internal/backend/db/db.go
@@ -57,6 +57,8 @@ type DB interface {
 
 	ListProjects(context.Context, sdktypes.OrgID) ([]sdktypes.Project, error)
 
+	CountProjects(context.Context, sdktypes.OrgID) (int, error)
+
 	// Returns nill, nil if no resources are set.
 	GetProjectResources(context.Context, sdktypes.ProjectID) (map[string][]byte, error)
 

--- a/internal/backend/db/dbgorm/orgs.go
+++ b/internal/backend/db/dbgorm/orgs.go
@@ -44,6 +44,14 @@ func (gdb *gormdb) DeleteOrg(ctx context.Context, oid sdktypes.OrgID) error {
 		return sdkerrors.NewInvalidArgumentError("missing id")
 	}
 
+	projectCount, err := gdb.CountProjects(ctx, oid)
+	if err != nil {
+		return translateError(err)
+	}
+	if projectCount > 0 {
+		return errors.New("cannot delete an organization with projects")
+	}
+
 	return translateError(gdb.transaction(ctx, func(tx *tx) error {
 		err := tx.db.Where("org_id = ?", oid.UUIDValue()).Delete(&scheme.OrgMember{}).Error
 		if err != nil {

--- a/internal/backend/db/dbgorm/projects.go
+++ b/internal/backend/db/dbgorm/projects.go
@@ -147,6 +147,20 @@ func (gdb *gormdb) listProjects(ctx context.Context, oid sdktypes.OrgID) ([]sche
 	return ps, nil
 }
 
+func (db *gormdb) CountProjects(ctx context.Context, oid sdktypes.OrgID) (int, error) {
+	q := db.db.WithContext(ctx)
+
+	if oid.IsValid() {
+		q = q.Where("org_id = ?", oid.UUIDValue())
+	}
+
+	var count int64
+	if err := q.Model(&scheme.Project{}).Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return int(count), nil
+}
+
 func (db *gormdb) CreateProject(ctx context.Context, p sdktypes.Project) error {
 	if err := p.Strict(); err != nil {
 		return err

--- a/internal/backend/orgs/orgs.go
+++ b/internal/backend/orgs/orgs.go
@@ -2,7 +2,6 @@ package orgs
 
 import (
 	"context"
-	"errors"
 	"strings"
 
 	"go.uber.org/zap"
@@ -95,14 +94,6 @@ func (o *orgs) GetByName(ctx context.Context, n sdktypes.Symbol) (sdktypes.Org, 
 func (o *orgs) Delete(ctx context.Context, id sdktypes.OrgID) error {
 	if err := authz.CheckContext(ctx, id, "delete:delete", authz.WithConvertForbiddenToNotFound); err != nil {
 		return err
-	}
-
-	projects, err := o.db.ListProjects(ctx, id)
-	if err != nil {
-		return err
-	}
-	if len(projects) > 0 {
-		return errors.New("cannot delete an organization with projects")
 	}
 
 	return o.db.DeleteOrg(ctx, id)

--- a/internal/backend/orgs/orgs.go
+++ b/internal/backend/orgs/orgs.go
@@ -2,6 +2,7 @@ package orgs
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"go.uber.org/zap"
@@ -94,6 +95,14 @@ func (o *orgs) GetByName(ctx context.Context, n sdktypes.Symbol) (sdktypes.Org, 
 func (o *orgs) Delete(ctx context.Context, id sdktypes.OrgID) error {
 	if err := authz.CheckContext(ctx, id, "delete:delete", authz.WithConvertForbiddenToNotFound); err != nil {
 		return err
+	}
+
+	projects, err := o.db.ListProjects(ctx, id)
+	if err != nil {
+		return err
+	}
+	if len(projects) > 0 {
+		return errors.New("cannot delete an organization with projects")
 	}
 
 	return o.db.DeleteOrg(ctx, id)


### PR DESCRIPTION
Prevent organization deletion if it has any projects (active or inactive).
Used db.ListProjects() to check for existing projects. If there's a more optimized approach, please advise.

Tested it locally using Descope to log in.