### PR TITLE
fix(cron): fix invalid expiration times by renewing watches

### DIFF
--- a/internal/backend/cron/google.go
+++ b/internal/backend/cron/google.go
@@ -184,7 +184,7 @@ func (cr *Cron) checkGmailEventWatch(ctx context.Context, cid sdktypes.Connectio
 		l.Warn("invalid Gmail event watch expiration time during renewal check",
 			zap.String("expiration", e), zap.Error(err),
 		)
-		return true // Old/invalid expiration time --> solve by renewing the watch.
+		return true // Invalid expiration time: don't ignore watch, solve by renewing it.
 	}
 
 	// Update this event watch only if it's about to expire in less than 3 days.
@@ -207,7 +207,7 @@ func (cr *Cron) checkGoogleCalendarEventWatch(ctx context.Context, cid sdktypes.
 		l.Warn("invalid Google Calendar event watch expiration timestamp",
 			zap.String("expiration", e), zap.Error(err),
 		)
-		return true // Old/invalid expiration time --> solve by renewing the watch.
+		return true // Invalid expiration time: don't ignore watch, solve by renewing it.
 	}
 
 	// Update this event watch only if it's about to expire in less than 3 days.
@@ -230,7 +230,7 @@ func (cr *Cron) checkGoogleDriveEventWatch(ctx context.Context, cid sdktypes.Con
 		l.Warn("invalid Google Drive event watch expiration timestamp",
 			zap.String("expiration", e), zap.Error(err),
 		)
-		return true // Old/invalid expiration time --> solve by renewing the watch.
+		return true // Invalid expiration time: don't ignore watch, solve by renewing it.
 	}
 
 	// Update this event watch only if it's about to expire in less than 3 days.
@@ -253,7 +253,7 @@ func (cr *Cron) checkGoogleFormsEventWatch(ctx context.Context, cid sdktypes.Con
 		l.Warn("invalid Google Forms event watch expiration time during renewal check",
 			zap.String("expiration", e), zap.Error(err),
 		)
-		return true // Old/invalid expiration time --> solve by renewing the watch.
+		return true // Invalid expiration time: don't ignore watch, solve by renewing it.
 	}
 
 	// Update this event watch only if it's about to expire in less than 3 days.

--- a/internal/backend/cron/google.go
+++ b/internal/backend/cron/google.go
@@ -184,7 +184,7 @@ func (cr *Cron) checkGmailEventWatch(ctx context.Context, cid sdktypes.Connectio
 		l.Warn("invalid Gmail event watch expiration time during renewal check",
 			zap.String("expiration", e), zap.Error(err),
 		)
-		return false
+		return true // Old/invalid expiration time --> solve by renewing the watch.
 	}
 
 	// Update this event watch only if it's about to expire in less than 3 days.
@@ -207,7 +207,7 @@ func (cr *Cron) checkGoogleCalendarEventWatch(ctx context.Context, cid sdktypes.
 		l.Warn("invalid Google Calendar event watch expiration timestamp",
 			zap.String("expiration", e), zap.Error(err),
 		)
-		return false
+		return true // Old/invalid expiration time --> solve by renewing the watch.
 	}
 
 	// Update this event watch only if it's about to expire in less than 3 days.
@@ -230,7 +230,7 @@ func (cr *Cron) checkGoogleDriveEventWatch(ctx context.Context, cid sdktypes.Con
 		l.Warn("invalid Google Drive event watch expiration timestamp",
 			zap.String("expiration", e), zap.Error(err),
 		)
-		return false
+		return true // Old/invalid expiration time --> solve by renewing the watch.
 	}
 
 	// Update this event watch only if it's about to expire in less than 3 days.
@@ -253,7 +253,7 @@ func (cr *Cron) checkGoogleFormsEventWatch(ctx context.Context, cid sdktypes.Con
 		l.Warn("invalid Google Forms event watch expiration time during renewal check",
 			zap.String("expiration", e), zap.Error(err),
 		)
-		return false
+		return true // Old/invalid expiration time --> solve by renewing the watch.
 	}
 
 	// Update this event watch only if it's about to expire in less than 3 days.

--- a/internal/backend/cron/jira.go
+++ b/internal/backend/cron/jira.go
@@ -87,7 +87,7 @@ func (cr *Cron) checkJiraEventWatch(ctx context.Context, cid sdktypes.Connection
 		l.Warn("invalid Jira event watch expiration time during renewal check",
 			zap.String("expiration", e), zap.Error(err),
 		)
-		return false
+		return true // Old/invalid expiration time --> solve by renewing the watch.
 	}
 
 	// Update this event watch only if it's about to expire in less than 2 weeks.

--- a/internal/backend/cron/jira.go
+++ b/internal/backend/cron/jira.go
@@ -87,7 +87,7 @@ func (cr *Cron) checkJiraEventWatch(ctx context.Context, cid sdktypes.Connection
 		l.Warn("invalid Jira event watch expiration time during renewal check",
 			zap.String("expiration", e), zap.Error(err),
 		)
-		return true // Old/invalid expiration time --> solve by renewing the watch.
+		return true // Invalid expiration time: don't ignore watch, solve by renewing it.
 	}
 
 	// Update this event watch only if it's about to expire in less than 2 weeks.


### PR DESCRIPTION
Oversight in the original implementation of Jira & Google workflows: if a watch has an old-style/invalid timestamp, this is a reason to renew it (to fix this problem), not to ignore it.

Specifically, this is what will facilitate a smooth transition for Jira connections between pre-renewal Go-style timestamp strings (e.g. `"2006-01-02 15:04:05.999999999 -0700 MST"`) and post-renewal RFC-3339 timestamp strings (e.g. `"2006-01-02T15:04:05Z07:00"`).