### PR TITLE
fix(jira): more robust watch renewal

### DIFF
--- a/internal/backend/cron/cron.go
+++ b/internal/backend/cron/cron.go
@@ -174,6 +174,7 @@ func (cr *Cron) updateSchedule(ctx context.Context, handle client.ScheduleHandle
 func (cr *Cron) workflow(wctx workflow.Context) error {
 	// Start multiple child workflows in parallel.
 	cwfs := []workflow.ChildWorkflowFuture{}
+	cwfs = append(cwfs, workflow.ExecuteChildWorkflow(wctx, cr.renewGmailEventWatchesWorkflow))
 	cwfs = append(cwfs, workflow.ExecuteChildWorkflow(wctx, cr.renewGoogleCalendarEventWatchesWorkflow))
 	cwfs = append(cwfs, workflow.ExecuteChildWorkflow(wctx, cr.renewGoogleDriveEventWatchesWorkflow))
 	cwfs = append(cwfs, workflow.ExecuteChildWorkflow(wctx, cr.renewGoogleFormsEventWatchesWorkflow))

--- a/internal/backend/cron/jira.go
+++ b/internal/backend/cron/jira.go
@@ -161,13 +161,17 @@ func (cr *Cron) renewJiraEventWatchActivity(ctx context.Context, cid sdktypes.Co
 	u, err := jira.APIBaseURL()
 	if err != nil {
 		l.Error("invalid Atlassian base URL for Jira event watch renewal", zap.Error(err))
-		return err
+		return temporal.NewNonRetryableApplicationError(
+			"invalid Atlassian base URL: "+err.Error(), "URLParseError", err, cid.String(), wid,
+		)
 	}
 
 	u, err = url.JoinPath(u, "/ex/jira", accessID)
 	if err != nil {
 		l.Error("failed to construct Jira API URL for event watch renewal", zap.Error(err))
-		return err
+		return temporal.NewNonRetryableApplicationError(
+			"invalid Atlassian base URL: "+err.Error(), "URLParseError", err, cid.String(), wid,
+		)
 	}
 
 	newExp, ok := jira.ExtendWebhookLife(l, u, t.AccessToken, id)

--- a/internal/backend/cron/jira.go
+++ b/internal/backend/cron/jira.go
@@ -99,7 +99,7 @@ func (cr *Cron) checkJiraEventWatch(ctx context.Context, cid sdktypes.Connection
 
 func (cr *Cron) renewJiraEventWatchActivity(ctx context.Context, cid sdktypes.ConnectionID) error {
 	l := cr.logger.With(zap.String("connection_id", cid.String()))
-	l.Sugar().Debugf("renewing Jira event watch in: ", cid.String())
+	l.Debug("renewing Jira event watch in: " + cid.String())
 
 	ctx = authcontext.SetAuthnSystemUser(ctx)
 	vsid := sdktypes.NewVarScopeID(cid)
@@ -186,7 +186,7 @@ func (cr *Cron) renewJiraEventWatchActivity(ctx context.Context, cid sdktypes.Co
 		return err
 	}
 
-	l.Sugar().Debugf("finished renewing Jira event watch in: ", cid.String())
+	l.Debug("finished renewing Jira event watch in: " + cid.String())
 	return nil
 }
 

--- a/internal/backend/cron/jira.go
+++ b/internal/backend/cron/jira.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strconv"
 	"time"
 
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
@@ -98,32 +100,55 @@ func (cr *Cron) checkJiraEventWatch(ctx context.Context, cid sdktypes.Connection
 func (cr *Cron) renewJiraEventWatchActivity(ctx context.Context, cid sdktypes.ConnectionID) error {
 	l := cr.logger.With(zap.String("connection_id", cid.String()))
 	ctx = authcontext.SetAuthnSystemUser(ctx)
+	vsid := sdktypes.NewVarScopeID(cid)
 
 	// Load the Jira connection's webhook ID.
-	vs, err := cr.vars.Get(ctx, sdktypes.NewVarScopeID(cid))
+	vs, err := cr.vars.Get(ctx, vsid)
 	if err != nil {
 		l.Error("failed to get Jira connection vars for event watch renewal", zap.Error(err))
 		return err
 	}
 
-	id, err := strconv.Atoi(vs.GetValue(jira.WebhookID))
+	accessID := vs.GetValue(jira.AccessID)
+
+	wid := vs.GetValue(jira.WebhookID)
+	id, err := strconv.Atoi(wid)
 	if err != nil {
-		l.Error("invalid Jira event watch ID for renewal", zap.Error(err))
-		return err
+		l.Warn("invalid Jira event watch ID for renewal", zap.String("watch_id", wid), zap.Error(err))
+		cr.deleteInvalidWatchID(ctx, cid, wid)
+		return temporal.NewNonRetryableApplicationError(
+			"invalid Jira event watch ID: "+err.Error(), "NumError", err, cid.String(), wid,
+		)
 	}
 
-	// Load the Jira OAuth configuration, to get a fresh OAuth access token.
+	// Update the Jira OAuth configuration, to get a fresh OAuth access token.
 	cfg, _, err := cr.oauth.Get(ctx, "jira")
 	if err != nil {
 		l.Error("failed to get OAuth config for Jira event watch renewal", zap.Error(err))
 		return err
 	}
 
-	refreshToken := vs.GetValueByString("oauth_RefreshToken")
-	t, err := cfg.TokenSource(ctx, &oauth2.Token{RefreshToken: refreshToken}).Token()
+	t := &oauth2.Token{
+		AccessToken:  vs.GetValueByString("oauth_AccessToken"),
+		RefreshToken: vs.GetValueByString("oauth_RefreshToken"),
+		TokenType:    vs.GetValueByString("oauth_TokenType"),
+		Expiry:       parseTime(vs.GetValueByString("oauth_Expiry")),
+	}
+	t, err = cfg.TokenSource(ctx, t).Token()
 	if err != nil {
 		l.Error("failed to refresh OAuth token for Jira event watch renewal", zap.Error(err))
 		return err
+	}
+
+	vs = sdktypes.NewVars(
+		sdktypes.NewVar(sdktypes.NewSymbol("AccessToken")).SetValue(t.AccessToken),
+		sdktypes.NewVar(sdktypes.NewSymbol("RefreshToken")).SetValue(t.RefreshToken),
+		sdktypes.NewVar(sdktypes.NewSymbol("Expiry")).SetValue(t.Expiry.String()),
+	).WithPrefix("oauth_").WithScopeID(vsid)
+	if err = cr.vars.Set(ctx, vs...); err != nil {
+		l.Error("failed to update Jira connection vars after OAuth token refresh", zap.Error(err))
+		// We have a valid OAuth token, but we can't save it. This may cause problems
+		// down the line, but for now we can at least try to renew the event watch.
 	}
 
 	// Refresh the event watch (2 weeks --> 1 month).
@@ -133,7 +158,7 @@ func (cr *Cron) renewJiraEventWatchActivity(ctx context.Context, cid sdktypes.Co
 		return err
 	}
 
-	u, err = url.JoinPath(u, "/ex/jira", vs.GetValue(jira.AccessID))
+	u, err = url.JoinPath(u, "/ex/jira", accessID)
 	if err != nil {
 		l.Error("failed to construct Jira API URL for event watch renewal", zap.Error(err))
 		return err
@@ -145,15 +170,38 @@ func (cr *Cron) renewJiraEventWatchActivity(ctx context.Context, cid sdktypes.Co
 		return fmt.Errorf("failed to renew Jira event watch: %s", cid.String())
 	}
 
-	// Update the connection vars.
-	vs.Set(sdktypes.NewSymbol("oauth_AccessToken"), t.AccessToken, true)
-	vs.Set(sdktypes.NewSymbol("oauth_Expiry"), t.Expiry.String(), false)
-	vs.Set(sdktypes.NewSymbol("oauth_RefreshToken"), t.RefreshToken, true)
-	vs.Set(sdktypes.NewSymbol("WebhookExpiration"), newExp.Format(time.RFC3339), false)
-	if err := cr.vars.Set(ctx, vs...); err != nil {
-		l.Error("failed to update Jira connection vars after event watch renewal", zap.Error(err))
+	v := sdktypes.NewVar(jira.WebhookExpiration).SetValue(newExp.Format(time.RFC3339))
+	if err := cr.vars.Set(ctx, v.WithScopeID(vsid)); err != nil {
+		l.Error("failed to update Jira connection var after event watch renewal", zap.Error(err))
 		return err
 	}
 
 	return nil
+}
+
+func (cr *Cron) deleteInvalidWatchID(ctx context.Context, cid sdktypes.ConnectionID, watchID string) {
+	err := cr.vars.Delete(ctx, sdktypes.NewVarScopeID(cid), jira.WebhookID)
+	if err != nil {
+		cr.logger.Error("failed to delete invalid Jira event watch ID during renewal",
+			zap.String("connection_id", cid.String()),
+			zap.String("watch_id", watchID),
+			zap.Error(err),
+		)
+	}
+}
+
+func parseTime(s string) time.Time {
+	// Remove unnecessary suffixes, e.g. "PST m=+3759.281638293".
+	s = regexp.MustCompile("[A-Z].*").ReplaceAllString(s, "")
+
+	// Go time string formats.
+	if t, err := time.Parse("2006-01-02 15:04:05.999999999 -0700", s); err == nil {
+		return t
+	}
+
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t
+	}
+
+	return time.Now() // Fallback if we don't know the format.
 }

--- a/internal/backend/cron/jira.go
+++ b/internal/backend/cron/jira.go
@@ -99,6 +99,8 @@ func (cr *Cron) checkJiraEventWatch(ctx context.Context, cid sdktypes.Connection
 
 func (cr *Cron) renewJiraEventWatchActivity(ctx context.Context, cid sdktypes.ConnectionID) error {
 	l := cr.logger.With(zap.String("connection_id", cid.String()))
+	l.Sugar().Debugf("renewing Jira event watch in: ", cid.String())
+
 	ctx = authcontext.SetAuthnSystemUser(ctx)
 	vsid := sdktypes.NewVarScopeID(cid)
 
@@ -180,6 +182,7 @@ func (cr *Cron) renewJiraEventWatchActivity(ctx context.Context, cid sdktypes.Co
 		return err
 	}
 
+	l.Sugar().Debugf("finished renewing Jira event watch in: ", cid.String())
 	return nil
 }
 

--- a/internal/backend/cron/jira.go
+++ b/internal/backend/cron/jira.go
@@ -145,11 +145,10 @@ func (cr *Cron) renewJiraEventWatchActivity(ctx context.Context, cid sdktypes.Co
 		}
 
 		vs = sdktypes.NewVars(
-			sdktypes.NewVar(sdktypes.NewSymbol("AccessToken")).SetValue(t.AccessToken),
-			sdktypes.NewVar(sdktypes.NewSymbol("RefreshToken")).SetValue(t.RefreshToken),
-			sdktypes.NewVar(sdktypes.NewSymbol("Expiry")).SetValue(t.Expiry.String()),
-		).WithPrefix("oauth_").WithScopeID(vsid)
-
+			vs.Get(sdktypes.NewSymbol("oauth_AccessToken")).SetValue(t.AccessToken),
+			vs.Get(sdktypes.NewSymbol("oauth_RefreshToken")).SetValue(t.RefreshToken),
+			vs.Get(sdktypes.NewSymbol("oauth_Expiry")).SetValue(t.Expiry.String()),
+		)
 		if err = cr.vars.Set(ctx, vs...); err != nil {
 			l.Error("failed to update Jira connection vars after OAuth token refresh", zap.Error(err))
 			// We have a valid OAuth token, but we can't save it. This may cause problems


### PR DESCRIPTION
1. Save OAuth token updates as soon as possible, in case the renewal fails
2. If the watch ID is an invalid number, don't retry the activity

Refs: INT-217