### PR TITLE
feat(descope): expose project id

### DIFF
--- a/internal/backend/auth/authloginhttpsvc/config.go
+++ b/internal/backend/auth/authloginhttpsvc/config.go
@@ -23,9 +23,8 @@ func (c oauth2Config) cookieConfig() gologin.CookieConfig {
 }
 
 type descopeConfig struct {
-	Enabled       bool   `koanf:"enabled"`
-	ProjectID     string `koanf:"project_id"`
-	ManagementKey string `koanf:"management_key"`
+	Enabled   bool   `koanf:"enabled"`
+	ProjectID string `koanf:"project_id"`
 }
 
 type Config struct {

--- a/internal/backend/auth/authloginhttpsvc/descope.go
+++ b/internal/backend/auth/authloginhttpsvc/descope.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	descopeRootPath  = "/auth/descope"
-	descopeLoginPath = descopeRootPath + "/login"
+	descopeRootPath      = "/auth/descope"
+	descopeProjectIDPath = descopeRootPath + "/project_id"
+	descopeLoginPath     = descopeRootPath + "/login"
 )
 
 func registerDescopeRoutes(mux *http.ServeMux, cfg descopeConfig, onSuccess func(context.Context, *loginData) http.Handler) error {
@@ -27,7 +28,7 @@ func registerDescopeRoutes(mux *http.ServeMux, cfg descopeConfig, onSuccess func
 		return err
 	}
 
-	mux.HandleFunc(descopeRootPath+"/project_id", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(descopeLoginPath, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, "%q", cfg.ProjectID)
 	})

--- a/internal/backend/auth/authloginhttpsvc/descope.go
+++ b/internal/backend/auth/authloginhttpsvc/descope.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/descope/go-sdk/descope/client"
@@ -11,19 +12,27 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authloginhttpsvc/web"
 )
 
-const descopeLoginPath = "/auth/descope/login"
+const (
+	descopeRootPath  = "/auth/descope"
+	descopeLoginPath = descopeRootPath + "/login"
+)
 
 func registerDescopeRoutes(mux *http.ServeMux, cfg descopeConfig, onSuccess func(context.Context, *loginData) http.Handler) error {
 	if cfg.ProjectID == "" {
 		return errors.New("descope login is enabled, but missing DESCOPE_PROJECT_ID")
 	}
 
-	client, err := client.NewWithConfig(&client.Config{ProjectID: cfg.ProjectID, ManagementKey: cfg.ManagementKey})
+	client, err := client.NewWithConfig(&client.Config{ProjectID: cfg.ProjectID})
 	if err != nil {
 		return err
 	}
 
-	mux.Handle(descopeLoginPath, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(descopeRootPath+"/project_id", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, "%q", cfg.ProjectID)
+	})
+
+	mux.HandleFunc(descopeLoginPath, func(w http.ResponseWriter, r *http.Request) {
 		jwt := r.URL.Query().Get("jwt")
 
 		if jwt == "" {
@@ -64,7 +73,7 @@ func registerDescopeRoutes(mux *http.ServeMux, cfg descopeConfig, onSuccess func
 		}
 
 		onSuccess(ctx, &ld).ServeHTTP(w, r)
-	}))
+	})
 
 	return nil
 }


### PR DESCRIPTION
- allow a client to figure out the project id by accessing `<HOST>/auth/descope/project_id`.
- remove management key, unused.