### PR TITLE
fix: github and slack custom oauth save - handling GET request

### DIFF
--- a/integrations/github/save.go
+++ b/integrations/github/save.go
@@ -19,26 +19,32 @@ import (
 func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 	c, l := sdkintegrations.NewConnectionInit(h.logger, w, r, desc)
 
-	// Check "Content-Type" header.
-	contentType := r.Header.Get(headerContentType)
-	if !strings.HasPrefix(contentType, contentTypeForm) {
-		c.AbortBadRequest("unexpected content type")
-		return
+	var form url.Values
+	if r.Method == "GET" {
+		form = r.URL.Query()
+	} else {
+		// Check "Content-Type" header.
+		contentType := r.Header.Get(headerContentType)
+		if !strings.HasPrefix(contentType, contentTypeForm) {
+			c.AbortBadRequest("unexpected content type")
+			return
+		}
+
+		// Read and parse POST request body.
+		if err := r.ParseForm(); err != nil {
+			l.Warn("Failed to parse incoming HTTP request", zap.Error(err))
+			c.AbortBadRequest("failed to parse form data")
+			return
+		}
+		form = r.Form
 	}
 
-	// Read and parse POST request body.
-	if err := r.ParseForm(); err != nil {
-		l.Warn("Failed to parse incoming HTTP request", zap.Error(err))
-		c.AbortBadRequest("failed to parse form data")
-		return
-	}
-
-	if r.Form.Get("client_id") == "" || r.Form.Get("client_secret") == "" {
+	if form.Get("client_id") == "" || form.Get("client_secret") == "" {
 		c.AbortBadRequest("missing client ID or client secret")
 		return
 	}
 
-	if err := h.saveClientIDAndSecret(r.Context(), c, r.Form); err != nil {
+	if err := h.saveClientIDAndSecret(r.Context(), c, form); err != nil {
 		l.Warn("Failed to save client ID and secret", zap.Error(err))
 		c.AbortBadRequest("failed to save client ID and secret")
 		return

--- a/integrations/github/save.go
+++ b/integrations/github/save.go
@@ -19,32 +19,26 @@ import (
 func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 	c, l := sdkintegrations.NewConnectionInit(h.logger, w, r, desc)
 
-	var form url.Values
-	if r.Method == "GET" {
-		form = r.URL.Query()
-	} else {
-		// Check "Content-Type" header.
-		contentType := r.Header.Get(headerContentType)
-		if !strings.HasPrefix(contentType, contentTypeForm) {
-			c.AbortBadRequest("unexpected content type")
-			return
-		}
-
-		// Read and parse POST request body.
-		if err := r.ParseForm(); err != nil {
-			l.Warn("Failed to parse incoming HTTP request", zap.Error(err))
-			c.AbortBadRequest("failed to parse form data")
-			return
-		}
-		form = r.Form
+	// Check "Content-Type" header.
+	contentType := r.Header.Get(headerContentType)
+	if !strings.HasPrefix(contentType, contentTypeForm) {
+		c.AbortBadRequest("unexpected content type")
+		return
 	}
 
-	if form.Get("client_id") == "" || form.Get("client_secret") == "" {
+	// Read and parse POST request body.
+	if err := r.ParseForm(); err != nil {
+		l.Warn("Failed to parse incoming HTTP request", zap.Error(err))
+		c.AbortBadRequest("failed to parse form data")
+		return
+	}
+
+	if r.Form.Get("client_id") == "" || r.Form.Get("client_secret") == "" {
 		c.AbortBadRequest("missing client ID or client secret")
 		return
 	}
 
-	if err := h.saveClientIDAndSecret(r.Context(), c, form); err != nil {
+	if err := h.saveClientIDAndSecret(r.Context(), c, r.Form); err != nil {
 		l.Warn("Failed to save client ID and secret", zap.Error(err))
 		c.AbortBadRequest("failed to save client ID and secret")
 		return

--- a/integrations/github/save.go
+++ b/integrations/github/save.go
@@ -21,7 +21,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 
 	// Check "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
-	if !strings.HasPrefix(contentType, contentTypeForm) {
+	if r.Method == http.MethodPost && !strings.HasPrefix(contentType, contentTypeForm) {
 		c.AbortBadRequest("unexpected content type")
 		return
 	}

--- a/integrations/slack/save.go
+++ b/integrations/slack/save.go
@@ -25,7 +25,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 
 	// Check "Content-Type" header.
 	contentType := r.Header.Get(headerContentType)
-	if !strings.HasPrefix(contentType, contentTypeForm) {
+	if r.Method == http.MethodPost && !strings.HasPrefix(contentType, contentTypeForm) {
 		c.AbortBadRequest("unexpected content type")
 		return
 	}


### PR DESCRIPTION
Inside the [server "router"](https://github.com/autokitteh/autokitteh/blob/98169778d174b826fd2729a22029aff2668f6bae/integrations/github/server.go#L42C1-L43C1) we allow starting the GitHub custom OAuth flow with POST method for the internal connections UI and with GET method for the WebUI.

Inside the Custom OAuth Save Handler we are taking care only of the POST method, and this is what I fixed here, added a proper treatment for the GET method (for the WebUI).