### PR TITLE
feat(integrations)!: add `file_remove` event type to google drive

### DIFF
--- a/integrations/google/drive/events.go
+++ b/integrations/google/drive/events.go
@@ -58,8 +58,13 @@ func constructSingleEvent(a api, change *drive.Change) (sdktypes.Event, error) {
 		return sdktypes.InvalidEvent, err
 	}
 
+	eventType := "file_change"
+	if change.Removed {
+		eventType = "file_remove"
+	}
+
 	akEvent, err := sdktypes.EventFromProto(&sdktypes.EventPB{
-		EventType: "change",
+		EventType: eventType,
 		Data:      kittehs.TransformMapValues(data, sdktypes.ToProto),
 	})
 	if err != nil {


### PR DESCRIPTION
Tested manually by creating documents using the Google Drive sample. Additionally, I added a function/trigger to listen for `file_remove` events and verified that both creation and deletion events were triggered correctly.