### PR TITLE
fix(google): more robust watch renewal

### DIFF
--- a/internal/backend/cron/jira.go
+++ b/internal/backend/cron/jira.go
@@ -118,9 +118,7 @@ func (cr *Cron) renewJiraEventWatchActivity(ctx context.Context, cid sdktypes.Co
 	if err != nil {
 		l.Warn("invalid Jira event watch ID for renewal", zap.String("watch_id", wid), zap.Error(err))
 		cr.deleteInvalidWatchID(ctx, cid, wid)
-		return temporal.NewNonRetryableApplicationError(
-			"invalid Jira event watch ID: "+err.Error(), "NumError", err, cid.String(), wid,
-		)
+		return nil // No need to retry.
 	}
 
 	// Update the Jira OAuth configuration, to get a fresh OAuth access token.


### PR DESCRIPTION
Follow-up to Jira in #1025:
1. Google Forms: if the watched form was deleted (ID not found), forget it and its watches
2. Google Calendar & Forms: watches are optional, don't try renew if there's no expiration time
3. Better logging

Also tweaked Jira: if a watch ID is invalid and gets removed, treating it as a successful activity makes more sense than a non-retryable error. In contrast, server errors still require "loud" failures.

Refs: INT-219