### PR TITLE
feat(microsoft): support more auth types + MS Teams fixes

### DIFF
--- a/integrations/auth.go
+++ b/integrations/auth.go
@@ -5,9 +5,10 @@ package integrations
 const (
 	APIKey       = "apiKey"
 	APIToken     = "apiToken"
-	Init         = "initialized" // integrations with 1 auth method
+	DaemonApp    = "daemonApp"   // Microsoft integrations only
+	Init         = "initialized" // Integrations with only 1 type by definition
 	JSONKey      = "jsonKey"     // Google integrations only
-	OAuth        = "oauth"       // Deprecate?
+	OAuth        = "oauth"       // Deprecate in the future, use "OAuthDefault"
 	OAuthDefault = "oauthDefault"
 	OAuthPrivate = "oauthPrivate"
 	PAT          = "pat"

--- a/integrations/microsoft/connection/checks.go
+++ b/integrations/microsoft/connection/checks.go
@@ -5,9 +5,12 @@ package connection
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"golang.org/x/oauth2"
 
@@ -39,6 +42,8 @@ func Status(v sdkservices.Vars) sdkintegrations.OptFn {
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
+		case integrations.DaemonApp:
+			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using daemon app"), nil
 		default:
 			return sdktypes.NewStatus(sdktypes.StatusCodeError, "Bad auth type"), nil
 		}
@@ -63,14 +68,15 @@ func Test(v sdkservices.Vars, o sdkservices.OAuth) sdkintegrations.OptFn {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
-			// Don't return, continue to do the check below.
+			if _, err = GetUserInfo(ctx, oauthToken(ctx, vs, o)); err != nil {
+				return sdktypes.NewStatus(sdktypes.StatusCodeError, err.Error()), nil
+			}
+		case integrations.DaemonApp:
+			if err = GetDaemonToken(ctx, vs); err != nil {
+				return sdktypes.NewStatus(sdktypes.StatusCodeError, err.Error()), nil
+			}
 		default:
 			return sdktypes.NewStatus(sdktypes.StatusCodeError, "Bad auth type"), nil
-		}
-
-		// Load and attempt to use the OAuth token.
-		if _, err = GetUserInfo(ctx, oauthToken(ctx, vs, o)); err != nil {
-			return sdktypes.NewStatus(sdktypes.StatusCodeError, err.Error()), nil
 		}
 
 		return sdktypes.NewStatus(sdktypes.StatusCodeOK, ""), nil
@@ -118,8 +124,8 @@ type UserInfo struct {
 // GetUserInfo returns the authenticated user's profile from Microsoft
 // Graph (based on: https://learn.microsoft.com/en-us/graph/api/user-get).
 func GetUserInfo(ctx context.Context, t *oauth2.Token) (*UserInfo, error) {
-	url := "https://graph.microsoft.com/v1.0/me"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	u := "https://graph.microsoft.com/v1.0/me"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
@@ -131,13 +137,13 @@ func GetUserInfo(ctx context.Context, t *oauth2.Token) (*UserInfo, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("request for user info failed: %s", resp.Status)
-	}
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read user info response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request for user info failed: %s (%s)", resp.Status, body)
 	}
 
 	var user UserInfo
@@ -146,4 +152,48 @@ func GetUserInfo(ctx context.Context, t *oauth2.Token) (*UserInfo, error) {
 	}
 
 	return &user, nil
+}
+
+// GetDaemonToken checks whether a Microsoft Graph daemon app is configured correctly
+// (based on: https://learn.microsoft.com/en-us/entra/identity-platform/scenario-daemon-acquire-token).
+func GetDaemonToken(ctx context.Context, vs sdktypes.Vars) error {
+	tenantID := vs.GetValueByString("private_tenant_id")
+	if tenantID == "" {
+		// https://learn.microsoft.com/en-us/answers/questions/1853467/aadsts7000229-the-client-application-is-missing-se
+		return errors.New("missing tenant ID")
+	}
+	u := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantID)
+
+	data := url.Values{}
+	data.Set("grant_type", "client_credentials")
+	data.Set("client_id", vs.GetValueByString("private_client_id"))
+	data.Set("client_secret", vs.GetValueByString("private_client_secret"))
+	data.Set("scope", "https://graph.microsoft.com/.default")
+
+	if data.Get("client_id") == "" || data.Get("client_secret") == "" {
+		return errors.New("missing required connection variables")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, strings.NewReader(data.Encode()))
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request for token failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read token response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("request for token failed: %s (%s)", resp.Status, body)
+	}
+
+	return nil
 }

--- a/integrations/microsoft/connection/checks.go
+++ b/integrations/microsoft/connection/checks.go
@@ -164,6 +164,7 @@ func GetDaemonToken(ctx context.Context, vs sdktypes.Vars) error {
 	}
 	u := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantID)
 
+	// TODO(INT-227): Add support for certificate-based authentication.
 	data := url.Values{}
 	data.Set("grant_type", "client_credentials")
 	data.Set("client_id", vs.GetValueByString("private_client_id"))

--- a/integrations/microsoft/connection/vars.go
+++ b/integrations/microsoft/connection/vars.go
@@ -1,0 +1,60 @@
+package connection
+
+import (
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+var (
+	AuthTypeVar = sdktypes.NewSymbol("auth_type")
+
+	oauthAccessTokenVar  = sdktypes.NewSymbol("oauth_access_token")
+	oauthRefreshTokenVar = sdktypes.NewSymbol("oauth_refresh_token")
+	oauthTokenTypeVar    = sdktypes.NewSymbol("oauth_token_type")
+
+	privateClientIDVar     = sdktypes.NewSymbol("private_client_id")
+	privateClientSecretVar = sdktypes.NewSymbol("private_client_secret")
+	privateTenantIDVar     = sdktypes.NewSymbol("private_tenant_id")
+)
+
+// OauthData contains OAuth 2.0 token details.
+type OAuthData struct {
+	AccessToken  string `var:"oauth_access_token,secret"`
+	Expiry       string `var:"oauth_expiry"`
+	RefreshToken string `var:"oauth_refresh_token,secret"`
+	TokenType    string `var:"oauth_token_type"`
+}
+
+func NewOAuthData(t *oauth2.Token) OAuthData {
+	return OAuthData{
+		AccessToken:  t.AccessToken,
+		Expiry:       t.Expiry.Format(time.RFC3339),
+		RefreshToken: t.RefreshToken,
+		TokenType:    t.TokenType,
+	}
+}
+
+// PrivateAppConfig contains the user-provided details
+// of a private Microsoft OAuth 2.0 app or daemon app.
+type PrivateAppConfig struct {
+	ClientID     string `var:"private_client_id"`
+	ClientSecret string `var:"private_client_secret,secret"`
+	Certificate  string `var:"private_certificate,secret"`
+	TenantID     string `var:"private_tenant_id"`
+}
+
+// UserInfo contains user profile details from Microsoft Graph
+// (based on: https://learn.microsoft.com/en-us/graph/api/user-get).
+type UserInfo struct {
+	PrincipalName string `json:"userPrincipalName" var:"user_principal_name"`
+	ID            string `json:"id" var:"user_id"`
+	DisplayName   string `json:"displayName" var:"user_display_name"`
+	Surname       string `json:"surname" var:"user_surname"`
+	GivenName     string `json:"givenName" var:"user_given_name"`
+	Language      string `json:"preferredLanguage" var:"user_language"`
+	Mail          string `json:"mail" var:"user_mail"`
+	MobilePhone   string `json:"mobilePhone" var:"user_mobile_phone"`
+}

--- a/integrations/microsoft/save.go
+++ b/integrations/microsoft/save.go
@@ -61,7 +61,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 	// First save the user-provided details of a private Microsoft OAuth 2.0 app,
 	// and only then redirect to the 3-legged OAuth 2.0 flow's starting point.
 	case integrations.OAuthPrivate:
-		if err := h.saveOAuthAppConfig(r, vsid); err != nil {
+		if err := h.savePrivateAppConfig(r, vsid); err != nil {
 			l.Error("save connection: " + err.Error())
 			c.AbortServerError(err.Error())
 			return
@@ -71,7 +71,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 	// Same as a private OAuth 2.0 app, but without the OAuth 2.0 flow
 	// (it uses application permissions instead of user-delegated ones).
 	case integrations.DaemonApp:
-		if err := h.saveOAuthAppConfig(r, vsid); err != nil {
+		if err := h.savePrivateAppConfig(r, vsid); err != nil {
 			l.Error("save connection: " + err.Error())
 			c.AbortServerError(err.Error())
 			return
@@ -100,33 +100,26 @@ func (h handler) saveAuthType(ctx context.Context, vsid sdktypes.VarScopeID, aut
 	return authType
 }
 
-// OAuthAppConfig contains the user-provided details of a private Microsoft OAuth 2.0 app.
-type OAuthAppConfig struct {
-	ClientID     string `var:"client_id"`
-	ClientSecret string `var:"client_secret,secret"`
-	TenantID     string `var:"tenant_id"`
-}
-
-// saveOAuthAppConfig saves the user-provided details of a
-// private Microsoft OAuth 2.0 app as connection variables.
-func (h handler) saveOAuthAppConfig(r *http.Request, vsid sdktypes.VarScopeID) error {
+// savePrivateAppConfig saves the user-provided details of
+// a private Microsoft OAuth 2.0 app as connection variables.
+func (h handler) savePrivateAppConfig(r *http.Request, vsid sdktypes.VarScopeID) error {
 	tenantID := r.FormValue("tenant_id")
 	if tenantID == "" {
 		tenantID = "common"
 	}
 
-	app := OAuthAppConfig{
+	app := connection.PrivateAppConfig{
 		ClientID:     r.FormValue("client_id"),
 		ClientSecret: r.FormValue("client_secret"),
 		TenantID:     tenantID,
 	}
 
 	// Sanity check: all the required details were provided.
-	if app.ClientID == "" || app.ClientSecret == "" {
-		return errors.New("missing OAuth 2.0 app details")
+	if app.ClientID == "" || (app.ClientSecret == "" && app.Certificate == "") {
+		return errors.New("missing private app details")
 	}
 
-	return h.vars.Set(r.Context(), sdktypes.EncodeVars(app).WithPrefix("private_").WithScopeID(vsid)...)
+	return h.vars.Set(r.Context(), sdktypes.EncodeVars(app).WithScopeID(vsid)...)
 }
 
 // startOAuth redirects the user to the AutoKitteh server's

--- a/runtimes/pythonrt/py-sdk/autokitteh/microsoft.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/microsoft.py
@@ -3,48 +3,83 @@
 from datetime import datetime, timedelta, UTC
 import os
 
-from azure.core.credentials import AccessToken
-from azure.core.credentials import TokenCredential
+from azure.core import credentials
+from azure import identity
 from msgraph import GraphServiceClient
 
 from .connections import check_connection_name, refresh_oauth
 from .errors import ConnectionInitError
 
 
-def teams_client(connection: str, **kwargs):
+# Default buffer time to refresh OAuth tokens before they expire.
+DEFAULT_REFRESH_BUFFER_TIME = timedelta(minutes=5)
+
+
+def teams_client(connection: str, **kwargs) -> GraphServiceClient:
     """Initialize a Microsoft Teams client, based on an AutoKitteh connection.
+
+    API documentation:
+    https://docs.autokitteh.com/integrations/microsoft/teams/python
 
     Args:
         connection: AutoKitteh connection name.
 
     Returns:
-        Gmail client.
+        Microsoft Graph client.
 
     Raises:
-        ValueError: AutoKitteh connection name is invalid.
+        ValueError: AutoKitteh connection name or auth type are invalid.
+        ConnectionInitError: AutoKitteh connection was not initialized yet.
+        OAuthRefreshError: OAuth token refresh failed.
+    """
+    # TODO: Narrower scopes instead of all the default ones.
+    return _microsoft_client(connection, **kwargs)
+
+
+def _microsoft_client(connection: str, **kwargs) -> GraphServiceClient:
+    """Initialize a Microsoft Graph client, based on an AutoKitteh connection.
+
+    Args:
+        connection: AutoKitteh connection name.
+
+    Returns:
+        Microsoft Graph client.
+
+    Raises:
+        ValueError: AutoKitteh connection name or auth type are invalid.
         ConnectionInitError: AutoKitteh connection was not initialized yet.
         OAuthRefreshError: OAuth token refresh failed.
     """
     check_connection_name(connection)
 
-    auth_type = os.getenv(connection + "__auth_type")
-    if not auth_type:
-        raise ConnectionInitError(connection)
-    if not auth_type.startswith("oauth"):
-        raise ValueError(f"AutoKitteh connection {connection!r} not using OAuth")
+    auth_type = os.getenv(connection + "__auth_type", "")
+    match auth_type:
+        case "oauthDefault" | "oauthPrivate":
+            creds = OAuthTokenProvider(connection)
+        case "daemonApp":
+            if os.getenv(connection + "__private_certificate"):
+                creds = _certificate_credentials(connection)
+            else:
+                creds = _client_secret_credentials(connection)
+        case _:
+            err = f"AutoKitteh connection {connection!r} with "
+            raise ValueError(err + f" invalid auth type {auth_type!r}")
 
-    creds = OAuthTokenProvider(connection)
     return GraphServiceClient(credentials=creds, **kwargs)
 
 
-class OAuthTokenProvider(TokenCredential):
+class OAuthTokenProvider(credentials.TokenCredential):
     """OAuth 2.0 token wrapper for Microsoft Graph clients."""
 
-    def __init__(self, connection: str) -> None:
-        """Initialize based on an AutoKitteh connection's environment variables.
+    def __init__(self, connection: str, buffer_time: timedelta | None = None) -> None:
+        """Initialize credentials based on an AutoKitteh connection's variables.
+
+        Used by server-default and private OAuth 2.0 user-delegated apps.
 
         Args:
             connection: AutoKitteh connection name.
+            buffer_time: Buffer time to refresh OAuth tokens before they expire
+                (optional, default = 5 minutes).
 
         Raises:
             ValueError: AutoKitteh connection name is invalid, or not using OAuth.
@@ -53,6 +88,7 @@ class OAuthTokenProvider(TokenCredential):
         """
         self._connection = connection
         check_connection_name(connection)
+        self._buffer_time = buffer_time or DEFAULT_REFRESH_BUFFER_TIME
 
         auth_type = os.getenv(connection + "__auth_type")
         if not auth_type:
@@ -68,13 +104,78 @@ class OAuthTokenProvider(TokenCredential):
         self._expiry = datetime.fromisoformat(expiry).astimezone(UTC)
         self._refresh_token = os.getenv(connection + "__oauth_refresh_token", "")
 
-    def get_token(self, *scopes: str, **kwargs) -> AccessToken:
-        if self._expiry + timedelta(minutes=5) >= datetime.now(UTC):
+    def get_token(self, *scopes: str, **kwargs) -> credentials.AccessToken:
+        if self._expiry + self._buffer_time >= datetime.now(UTC):
             self._refresh_oauth_token()
 
         expires_on = int(self._expiry.timestamp())
-        return AccessToken(token=self._access_token, expires_on=expires_on)
+        return credentials.AccessToken(token=self._access_token, expires_on=expires_on)
 
     def _refresh_oauth_token(self) -> None:
         self._access_token, self._expiry = refresh_oauth("microsoft", self._connection)
         self._expiry = self._expiry.astimezone(UTC)
+
+
+def _certificate_credentials(connection: str) -> identity.CertificateCredential:
+    """Initialize credentials based on an AutoKitteh connection's variables.
+
+    Used by daemon (i.e. non-user-delegated) applications with advanced auth needs.
+
+    Args:
+        connection: AutoKitteh connection name.
+
+    Raises:
+        ValueError: AutoKitteh connection was configured to use OAuth
+            (i.e. user-delegated permissions instead of application ones).
+        ConnectionInitError: AutoKitteh connection was not initialized yet,
+            or initialized to use a client secret instead of a certificate.
+    """
+    check_connection_name(connection)
+    auth_type = os.getenv(connection + "__auth_type")
+    if not auth_type:
+        raise ConnectionInitError(connection)
+    if auth_type.startswith("oauth"):
+        raise ValueError(f"AutoKitteh connection {connection!r} using OAuth")
+
+    client_id = os.getenv(connection + "__private_client_id")
+    certificate = os.getenv(connection + "__private_certificate")
+    if not client_id or not certificate:
+        raise ConnectionInitError(connection)
+
+    return identity.CertificateCredential(
+        client_id=client_id,
+        certificate_data=certificate.encode("utf-8"),
+        tenant_id=os.getenv(connection + "__private_tenant_id", "") or "common",
+    )
+
+
+def _client_secret_credentials(connection: str) -> identity.ClientSecretCredential:
+    """Initialize credentials based on an AutoKitteh connection's variables.
+
+    Used by daemon (i.e. non-user-delegated) applications with simple auth needs.
+
+    Args:
+        connection: AutoKitteh connection name.
+
+    Raises:
+        ValueError: AutoKitteh connection was configured to use OAuth
+            (i.e. user-delegated permissions instead of application ones).
+        ConnectionInitError: AutoKitteh connection was not initialized yet.
+    """
+    check_connection_name(connection)
+    auth_type = os.getenv(connection + "__auth_type")
+    if not auth_type:
+        raise ConnectionInitError(connection)
+    if auth_type.startswith("oauth"):
+        raise ValueError(f"AutoKitteh connection {connection!r} using OAuth")
+
+    client_id = os.getenv(connection + "__private_client_id")
+    client_secret = os.getenv(connection + "__private_client_secret")
+    if not client_id or not client_secret:
+        raise ConnectionInitError(connection)
+
+    return identity.ClientSecretCredential(
+        client_id=client_id,
+        client_secret=client_secret,
+        tenant_id=os.getenv(connection + "__private_tenant_id", "") or "common",
+    )

--- a/web/static/microsoft/form.js
+++ b/web/static/microsoft/form.js
@@ -15,5 +15,12 @@ document.getElementById("authType").addEventListener("change", function () {
   }
   document.getElementById("clientId").disabled = isDefaultApp;
   document.getElementById("clientSecret").disabled = isDefaultApp;
-  document.getElementById("tenant").disabled = isDefaultApp;
+  document.getElementById("tenantId").disabled = isDefaultApp;
+
+  const submitButton = document.getElementById("submit");
+  if (this.value === "daemonApp") {
+    submitButton.textContent = "Save Connection";
+  } else {
+    submitButton.textContent = "Start OAuth Flow";
+  }
 });

--- a/web/static/microsoft/index.html
+++ b/web/static/microsoft/index.html
@@ -55,13 +55,13 @@
         <input type="text" name="auth_scopes" value="" readonly />
       </div>
 
-      <h2>OAuth 2.0</h2>
+      <h2>Authentication Type</h2>
 
       <div class="form-group">
-        <label for="auth_type">Auth Type</label>
         <select name="auth_type" id="authType">
-          <option value="oauthDefault">Default App</option>
-          <option value="oauthPrivate">Private App</option>
+          <option value="oauthDefault">Default user-delegated app</option>
+          <option value="oauthPrivate">Private user-delegated app</option>
+          <option value="daemonApp">Private daemon application</option>
         </select>
       </div>
 
@@ -77,6 +77,7 @@
             autocomplete="off"
             spellcheck="false"
             disabled
+            required
           />
         </div>
 
@@ -89,24 +90,28 @@
             autocomplete="off"
             spellcheck="false"
             disabled
+            required
           />
         </div>
 
         <div class="form-group">
-          <label for="tenant">Tenant (Default = "common")</label>
+          <label for="tenant_id">Tenant ID (Multi/Default = "common")</label>
           <input
             type="text"
-            id="tenant"
-            name="tenant"
+            id="tenantId"
+            name="tenant_id"
             value="common"
             autocomplete="off"
             spellcheck="false"
             disabled
+            required
           />
         </div>
       </div>
 
-      <button type="submit" class="submit-btn">Start OAuth Flow</button>
+      <button type="submit" class="submit-btn" id="submit">
+        Start OAuth Flow
+      </button>
     </form>
   </body>
 </html>

--- a/web/static/microsoft/teams/form.js
+++ b/web/static/microsoft/teams/form.js
@@ -15,5 +15,12 @@ document.getElementById("authType").addEventListener("change", function () {
   }
   document.getElementById("clientId").disabled = isDefaultApp;
   document.getElementById("clientSecret").disabled = isDefaultApp;
-  document.getElementById("tenant").disabled = isDefaultApp;
+  document.getElementById("tenantId").disabled = isDefaultApp;
+
+  const submitButton = document.getElementById("submit");
+  if (this.value === "daemonApp") {
+    submitButton.textContent = "Save Connection";
+  } else {
+    submitButton.textContent = "Start OAuth Flow";
+  }
 });

--- a/web/static/microsoft/teams/index.html
+++ b/web/static/microsoft/teams/index.html
@@ -55,13 +55,13 @@
         <input type="text" name="auth_scopes" value="teams" readonly />
       </div>
 
-      <h2>OAuth 2.0</h2>
+      <h2>Authentication Type</h2>
 
       <div class="form-group">
-        <label for="auth_type">Auth Type</label>
         <select name="auth_type" id="authType">
-          <option value="oauthDefault">Default App</option>
-          <option value="oauthPrivate">Private App</option>
+          <option value="oauthDefault">Default user-delegated app</option>
+          <option value="oauthPrivate">Private user-delegated app</option>
+          <option value="daemonApp">Private daemon application</option>
         </select>
       </div>
 
@@ -77,6 +77,7 @@
             autocomplete="off"
             spellcheck="false"
             disabled
+            required
           />
         </div>
 
@@ -89,24 +90,28 @@
             autocomplete="off"
             spellcheck="false"
             disabled
+            required
           />
         </div>
 
         <div class="form-group">
-          <label for="tenant">Tenant (Default = "common")</label>
+          <label for="tenant_id">Tenant ID (Multi/Default = "common")</label>
           <input
             type="text"
-            id="tenant"
-            name="tenant"
+            id="tenantId"
+            name="tenant_id"
             value="common"
             autocomplete="off"
             spellcheck="false"
             disabled
+            required
           />
         </div>
       </div>
 
-      <button type="submit" class="submit-btn">Start OAuth Flow</button>
+      <button type="submit" class="submit-btn" id="submit">
+        Start OAuth Flow
+      </button>
     </form>
   </body>
 </html>


### PR DESCRIPTION
1. Add support for "daemon apps" (apps with their own identity, like private OAuth apps but without user-delegated permissions, i.e. bots)
2. Connection test for daemon apps (there's no "me" user identity)
3. Add OAuth scopes for MS Teams
4. `"isCustomOauth"`: add logic to detect private MS apps
5. Python SDK: add MS Team initialization function, support for private OAuth/daemon apps, and certificate-based private apps

Refs: INT-202, INT-227