### PR TITLE
fix: Block connection deletion with active tiggers

### DIFF
--- a/internal/backend/db/dbgorm/connections.go
+++ b/internal/backend/db/dbgorm/connections.go
@@ -2,6 +2,7 @@ package dbgorm
 
 import (
 	"context"
+	"errors"
 	"maps"
 
 	"github.com/google/uuid"
@@ -49,6 +50,13 @@ func (gdb *gormdb) deleteConnectionsAndVars(ctx context.Context, what string, id
 }
 
 func (gdb *gormdb) deleteConnection(ctx context.Context, id uuid.UUID) error {
+	hasTriggers, err := gdb.hasTriggers(ctx, id)
+	if err != nil {
+		return translateError(err)
+	}
+	if hasTriggers {
+		return errors.New("cannot delete a connection that has associated triggers")
+	}
 	return gdb.deleteConnectionsAndVars(ctx, "connection_id", id)
 }
 

--- a/internal/backend/db/dbgorm/triggers.go
+++ b/internal/backend/db/dbgorm/triggers.go
@@ -30,6 +30,23 @@ func (gdb *gormdb) getTriggerByID(ctx context.Context, triggerID uuid.UUID) (*sc
 	return getOne[scheme.Trigger](gdb.db.WithContext(ctx), "trigger_id = ?", triggerID)
 }
 
+func (gdb *gormdb) hasTriggers(ctx context.Context, connID uuid.UUID) (bool, error) {
+	var exists bool
+	q := gdb.db.WithContext(ctx)
+
+	q = q.Model(&scheme.Trigger{}).
+		Select("1").
+		Where("connection_id = ?", connID).
+		Where("deleted_at IS NULL").
+		Limit(1)
+
+	err := q.Find(&exists).Error
+	if err != nil {
+		return false, fmt.Errorf("checking active triggers: %w", err)
+	}
+	return exists, nil
+}
+
 func (gdb *gormdb) listTriggers(ctx context.Context, filter sdkservices.ListTriggersFilter) ([]scheme.Trigger, error) {
 	q := gdb.db.WithContext(ctx)
 

--- a/internal/backend/db/dbgorm/triggers.go
+++ b/internal/backend/db/dbgorm/triggers.go
@@ -30,23 +30,6 @@ func (gdb *gormdb) getTriggerByID(ctx context.Context, triggerID uuid.UUID) (*sc
 	return getOne[scheme.Trigger](gdb.db.WithContext(ctx), "trigger_id = ?", triggerID)
 }
 
-func (gdb *gormdb) hasTriggers(ctx context.Context, connID uuid.UUID) (bool, error) {
-	var exists bool
-	q := gdb.db.WithContext(ctx)
-
-	q = q.Model(&scheme.Trigger{}).
-		Select("1").
-		Where("connection_id = ?", connID).
-		Where("deleted_at IS NULL").
-		Limit(1)
-
-	err := q.Find(&exists).Error
-	if err != nil {
-		return false, fmt.Errorf("checking active triggers: %w", err)
-	}
-	return exists, nil
-}
-
 func (gdb *gormdb) listTriggers(ctx context.Context, filter sdkservices.ListTriggersFilter) ([]scheme.Trigger, error) {
 	q := gdb.db.WithContext(ctx)
 


### PR DESCRIPTION
Implemented `hasTriggers` function  to check for existing triggers and integrated it into `deleteConnection`.