### PR TITLE
fix: avoid descope path conflicts

### DIFF
--- a/internal/backend/auth/authloginhttpsvc/descope.go
+++ b/internal/backend/auth/authloginhttpsvc/descope.go
@@ -28,7 +28,7 @@ func registerDescopeRoutes(mux *http.ServeMux, cfg descopeConfig, onSuccess func
 		return err
 	}
 
-	mux.HandleFunc(descopeLoginPath, func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(descopeProjectIDPath, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, "%q", cfg.ProjectID)
 	})


### PR DESCRIPTION
Currently in the [registerDescopeRoutes](https://github.com/autokitteh/autokitteh/blob/a72b8bd70da1e912eb703ecc03529fff161a5f6b/internal/backend/auth/authloginhttpsvc/descope.go#L21C6-L21C27) function we have two muxes handling the same path which is causing login issues.