### PR TITLE
refactor(integrations): simpler descriptors

### DIFF
--- a/integrations/asana/client.go
+++ b/integrations/asana/client.go
@@ -8,36 +8,25 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/integrations"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-type integration struct{ vars sdkservices.Vars }
-
-var (
-	integrationID = sdktypes.NewIntegrationIDFromName("asana")
-
-	pat      = sdktypes.NewSymbol("pat")
-	authType = sdktypes.NewSymbol("authType")
+const (
+	integrationName = "asana"
 )
 
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: integrationID.String(),
-	UniqueName:    "asana",
-	DisplayName:   "Asana",
-	Description:   "Asana is a web and mobile application designed to help teams organize, track, and manage their work.",
-	LogoUrl:       "/static/images/asana.svg",
-	UserLinks: map[string]string{
-		"Asana developer platform": "https://developers.asana.com/",
-	},
-	ConnectionUrl: "/asana/connect",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-	},
-}))
+var (
+	desc = common.LegacyDescriptor(integrationName, "Asana", "/static/images/asana.svg")
+
+	patVar      = sdktypes.NewSymbol("pat")
+	authTypeVar = sdktypes.NewSymbol("authType")
+)
+
+type integration struct{ vars sdkservices.Vars }
 
 func New(cvars sdkservices.Vars) sdkservices.Integration {
 	i := &integration{vars: cvars}
@@ -65,7 +54,7 @@ func connStatus(i *integration) sdkintegrations.OptFn {
 			return sdktypes.InvalidStatus, err
 		}
 
-		at := vs.Get(authType)
+		at := vs.Get(authTypeVar)
 		if !at.IsValid() || at.Value() == "" {
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		}
@@ -101,7 +90,7 @@ func connTest(i *integration) sdkintegrations.OptFn {
 			return sdktypes.InvalidStatus, err
 		}
 
-		pat := vs.Get(pat).Value()
+		pat := vs.Get(patVar).Value()
 		req.Header.Add("Authorization", "Bearer "+pat)
 
 		resp, err := http.DefaultClient.Do(req)

--- a/integrations/asana/client.go
+++ b/integrations/asana/client.go
@@ -15,12 +15,8 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-const (
-	integrationName = "asana"
-)
-
 var (
-	desc = common.LegacyDescriptor(integrationName, "Asana", "/static/images/asana.svg")
+	desc = common.LegacyDescriptor("asana", "Asana", "/static/images/asana.svg")
 
 	patVar      = sdktypes.NewSymbol("pat")
 	authTypeVar = sdktypes.NewSymbol("authType")

--- a/integrations/asana/save.go
+++ b/integrations/asana/save.go
@@ -86,6 +86,6 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Finalize the connection with the valid PAT
 	c.Finalize(sdktypes.NewVars().
-		Set(pat, ps, true).
-		Set(authType, integrations.PAT, false))
+		Set(patVar, ps, true).
+		Set(authTypeVar, integrations.PAT, false))
 }

--- a/integrations/atlassian/confluence/client.go
+++ b/integrations/atlassian/confluence/client.go
@@ -8,30 +8,26 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/integrations"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
+const (
+	integrationName = "confluence"
+)
+
+var (
+	integrationID = sdktypes.NewIntegrationIDFromName(integrationName)
+
+	desc = common.LegacyDescriptor(integrationName, "Atlassian Confluence", "/static/images/confluence.svg")
+)
+
 type integration struct {
 	vars sdkservices.Vars
 }
-
-var integrationID = sdktypes.NewIntegrationIDFromName("confluence")
-
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: integrationID.String(),
-	UniqueName:    "confluence",
-	DisplayName:   "Atlassian Confluence",
-	Description:   "Atlassian Confluence is a corporate wiki developed by Atlassian.",
-	LogoUrl:       "/static/images/confluence.svg",
-	ConnectionUrl: "/confluence/connect",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-	},
-}))
 
 func New(cvars sdkservices.Vars) sdkservices.Integration {
 	i := &integration{vars: cvars}

--- a/integrations/atlassian/jira/client.go
+++ b/integrations/atlassian/jira/client.go
@@ -8,36 +8,32 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/integrations"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
+const (
+	integrationName = "jira"
+)
+
+var (
+	IntegrationID = sdktypes.NewIntegrationIDFromName(integrationName)
+
+	desc = common.LegacyDescriptor(integrationName, "Atlassian Jira", "/static/images/jira.svg")
+)
+
 type integration struct {
 	vars sdkservices.Vars
 }
-
-var IntegrationID = sdktypes.NewIntegrationIDFromName("jira")
-
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: IntegrationID.String(),
-	UniqueName:    "jira",
-	DisplayName:   "Atlassian Jira",
-	Description:   "Atlassian Jira is an issue tracking and project management system.",
-	LogoUrl:       "/static/images/jira.svg",
-	ConnectionUrl: "/jira/connect",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-	},
-}))
 
 func New(cvars sdkservices.Vars) sdkservices.Integration {
 	i := &integration{vars: cvars}
 	return sdkintegrations.NewIntegration(
 		desc,
-		sdkmodule.New( /* No exported functions for Starlark */ ),
+		sdkmodule.New(),
 		connStatus(i),
 		connTest(i),
 		sdkintegrations.WithConnectionConfigFromVars(cvars),

--- a/integrations/auth0/client.go
+++ b/integrations/auth0/client.go
@@ -16,12 +16,8 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-const (
-	integrationName = "auth0"
-)
-
 var (
-	desc = common.LegacyDescriptor(integrationName, "Auth0", "/static/images/auth0.svg")
+	desc = common.LegacyDescriptor("auth0", "Auth0", "/static/images/auth0.svg")
 
 	authTypeVar         = sdktypes.NewSymbol("auth_type")
 	clientIDNameVar     = sdktypes.NewSymbol("client_id")

--- a/integrations/auth0/client.go
+++ b/integrations/auth0/client.go
@@ -9,40 +9,28 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/integrations"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-type integration struct{ vars sdkservices.Vars }
-
-var (
-	integrationID = sdktypes.NewIntegrationIDFromName("auth0")
-
-	authType         = sdktypes.NewSymbol("auth_type")
-	clientIDName     = sdktypes.NewSymbol("client_id")
-	clientSecretName = sdktypes.NewSymbol("client_secret")
-	domainName       = sdktypes.NewSymbol("auth0_domain")
-	authTokenName    = sdktypes.NewSymbol("oauth_AccessToken")
+const (
+	integrationName = "auth0"
 )
 
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: integrationID.String(),
-	UniqueName:    "auth0",
-	DisplayName:   "Auth0",
-	Description:   "Auth0 is an identity platform that provides authentication and authorization services.",
-	LogoUrl:       "/static/images/auth0.svg",
-	UserLinks: map[string]string{
-		"1 Auth0 API reference": "https://auth0.com/docs/api/management/v2",
-		"2 Python client API":   "https://auth0-python.readthedocs.io/en/latest/",
-	},
-	ConnectionUrl: "/auth0/connect",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-	},
-}))
+var (
+	desc = common.LegacyDescriptor(integrationName, "Auth0", "/static/images/auth0.svg")
+
+	authTypeVar         = sdktypes.NewSymbol("auth_type")
+	clientIDNameVar     = sdktypes.NewSymbol("client_id")
+	clientSecretNameVar = sdktypes.NewSymbol("client_secret")
+	domainNameVar       = sdktypes.NewSymbol("auth0_domain")
+	authTokenNameVar    = sdktypes.NewSymbol("oauth_AccessToken")
+)
+
+type integration struct{ vars sdkservices.Vars }
 
 func New(cvars sdkservices.Vars) sdkservices.Integration {
 	i := &integration{vars: cvars}
@@ -67,7 +55,7 @@ func connStatus(i *integration) sdkintegrations.OptFn {
 			return sdktypes.InvalidStatus, err
 		}
 
-		at := vs.Get(authType)
+		at := vs.Get(authTypeVar)
 		if !at.IsValid() || at.Value() == "" {
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		}
@@ -98,8 +86,8 @@ func connTest(i *integration) sdkintegrations.OptFn {
 		}
 
 		// TODO(INT-124): Use the refresh token to get a new access token.
-		token := vs.Get(authTokenName).Value()
-		domain := vs.Get(domainName).Value()
+		token := vs.Get(authTokenNameVar).Value()
+		domain := vs.Get(domainNameVar).Value()
 		// https://auth0.com/docs/api/management/v2/stats/get-active-users
 		url := fmt.Sprintf("https://%s/api/v2/stats/active-users", domain)
 

--- a/integrations/auth0/oauth.go
+++ b/integrations/auth0/oauth.go
@@ -72,7 +72,6 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 
 	// Tests OAuth0's Management API.
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s/api/v2/roles", d), nil)
-
 	if err != nil {
 		l.Error("Failed to create HTTP request", zap.Error(err))
 		c.AbortServerError("request creation error")
@@ -107,5 +106,5 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	c.Finalize(sdktypes.NewVars(data.ToVars()...).
-		Append(sdktypes.NewVar(authType).SetValue(integrations.OAuth)))
+		Append(sdktypes.NewVar(authTypeVar).SetValue(integrations.OAuth)))
 }

--- a/integrations/auth0/save.go
+++ b/integrations/auth0/save.go
@@ -46,9 +46,9 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 	}
 
 	vs := sdktypes.NewVars().
-		Set(clientIDName, clientID, false).
-		Set(clientSecretName, clientSecret, true).
-		Set(domainName, auth0Domain, false)
+		Set(clientIDNameVar, clientID, false).
+		Set(clientSecretNameVar, clientSecret, true).
+		Set(domainNameVar, auth0Domain, false)
 
 	if err := h.saveAuthCredentials(r.Context(), c, vs); err != nil {
 		l.Error("Failed to save Auth0 credentials", zap.Error(err))

--- a/integrations/aws/client.go
+++ b/integrations/aws/client.go
@@ -29,11 +29,7 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-const (
-	integrationName = "aws"
-)
-
-var desc = common.LegacyDescriptor(integrationName, "AWS (All APIs)", "/static/images/aws.svg")
+var desc = common.LegacyDescriptor("aws", "AWS (All APIs)", "/static/images/aws.svg")
 
 type integration struct {
 	vars sdkservices.Vars

--- a/integrations/aws/client.go
+++ b/integrations/aws/client.go
@@ -20,6 +20,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/integrations"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdklogger"
@@ -27,6 +28,12 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
+
+const (
+	integrationName = "aws"
+)
+
+var desc = common.LegacyDescriptor(integrationName, "AWS (All APIs)", "/static/images/aws.svg")
 
 type integration struct {
 	vars sdkservices.Vars
@@ -80,21 +87,6 @@ func initOpts(vars sdkservices.Vars) (opts []sdkmodule.Optfn) {
 	}
 	return
 }
-
-var integrationID = sdktypes.NewIntegrationIDFromName("aws")
-
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: integrationID.String(),
-	UniqueName:    "aws",
-	DisplayName:   "AWS (All APIs)",
-	Description:   "Aggregation of all available Amazon Web Services (AWS) APIs.",
-	LogoUrl:       "/static/images/aws.svg",
-	UserLinks: map[string]string{
-		"1 API documentation": "https://docs.aws.amazon.com/",
-		"2 Service console":   "https://console.aws.amazon.com/",
-	},
-	ConnectionUrl: "/aws/connect",
-}))
 
 func New(cvars sdkservices.Vars) sdkservices.Integration {
 	i := &integration{vars: cvars}

--- a/integrations/chatgpt/client.go
+++ b/integrations/chatgpt/client.go
@@ -7,37 +7,25 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/integrations"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-type integration struct{ vars sdkservices.Vars }
-
-var (
-	integrationID = sdktypes.NewIntegrationIDFromName("chatgpt")
-
-	apiKeyVar = sdktypes.NewSymbol("apiKey")
-	authType  = sdktypes.NewSymbol("authType")
+const (
+	integrationName = "chatgpt"
 )
 
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: integrationID.String(),
-	UniqueName:    "chatgpt",
-	DisplayName:   "OpenAI ChatGPT",
-	Description:   "ChatGPT is a conversational AI model that can generates human-like responses based on prompts.",
-	LogoUrl:       "/static/images/chatgpt.svg",
-	UserLinks: map[string]string{
-		"1 OpenAI developer platform": "https://platform.openai.com/",
-		"2 Go client API":             "https://pkg.go.dev/github.com/sashabaranov/go-openai",
-	},
-	ConnectionUrl: "/chatgpt/connect",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-	},
-}))
+var (
+	desc = common.LegacyDescriptor(integrationName, "OpenAI ChatGPT", "/static/images/chatgpt.svg")
+
+	apiKeyVar   = sdktypes.NewSymbol("apiKey")
+	authTypeVar = sdktypes.NewSymbol("authType")
+)
+
+type integration struct{ vars sdkservices.Vars }
 
 func New(vars sdkservices.Vars) sdkservices.Integration {
 	i := &integration{vars: vars}
@@ -72,7 +60,7 @@ func connStatus(i *integration) sdkintegrations.OptFn {
 			return sdktypes.InvalidStatus, err
 		}
 
-		at := vs.Get(authType)
+		at := vs.Get(authTypeVar)
 		if !at.IsValid() || at.Value() == "" {
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		}

--- a/integrations/chatgpt/client.go
+++ b/integrations/chatgpt/client.go
@@ -14,12 +14,8 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-const (
-	integrationName = "chatgpt"
-)
-
 var (
-	desc = common.LegacyDescriptor(integrationName, "OpenAI ChatGPT", "/static/images/chatgpt.svg")
+	desc = common.LegacyDescriptor("chatgpt", "OpenAI ChatGPT", "/static/images/chatgpt.svg")
 
 	apiKeyVar   = sdktypes.NewSymbol("apiKey")
 	authTypeVar = sdktypes.NewSymbol("authType")

--- a/integrations/chatgpt/save.go
+++ b/integrations/chatgpt/save.go
@@ -46,5 +46,5 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	c.Finalize(sdktypes.NewVars().
 		Set(apiKeyVar, r.Form.Get("key"), true).
-		Set(authType, integrations.Init, false))
+		Set(authTypeVar, integrations.Init, false))
 }

--- a/integrations/common/client.go
+++ b/integrations/common/client.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"fmt"
+
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+func Descriptor(uniqueName, displayName, logoURL string) sdktypes.Integration {
+	return kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
+		IntegrationId: sdktypes.NewIntegrationIDFromName(uniqueName).String(),
+		UniqueName:    uniqueName,
+		DisplayName:   displayName,
+		LogoUrl:       logoURL,
+		ConnectionUrl: "/" + uniqueName,
+		ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
+			RequiresConnectionInit: true,
+			SupportsConnectionTest: true,
+		},
+	}))
+}
+
+func LegacyDescriptor(uniqueName, displayName, logoURL string) sdktypes.Integration {
+	u := fmt.Sprintf("/%s/connect", uniqueName)
+	return Descriptor(uniqueName, displayName, logoURL).WithConnectionURL(u)
+}

--- a/integrations/common/doc.go
+++ b/integrations/common/doc.go
@@ -1,0 +1,2 @@
+// Package common provides common utilities for integrations.
+package common

--- a/integrations/discord/client.go
+++ b/integrations/discord/client.go
@@ -7,40 +7,31 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/integrations"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/discord/internal/vars"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
+const (
+	integrationName = "discord"
+)
+
+var (
+	integrationID = sdktypes.NewIntegrationIDFromName(integrationName)
+
+	desc = common.LegacyDescriptor(integrationName, "Discord", "/static/images/discord.svg")
+)
+
 type integration struct{ vars sdkservices.Vars }
-
-var integrationID = sdktypes.NewIntegrationIDFromName("discord")
-
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: integrationID.String(),
-	UniqueName:    "discord",
-	DisplayName:   "Discord",
-	Description:   "Discord is an instant messaging and VoIP social platform which allows communication through voice calls, video calls, text messaging, and media.",
-	LogoUrl:       "/static/images/discord.svg",
-	UserLinks: map[string]string{
-		"1 REST API reference": "https://discord.com/developers/docs/reference",
-		"2 Python client API":  "https://discordpy.readthedocs.io/en/stable/api.html",
-		"3 Python samples":     "https://github.com/Rapptz/discord.py/tree/master/example",
-	},
-	ConnectionUrl: "/discord/connect",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-	},
-}))
 
 func New(cvars sdkservices.Vars) sdkservices.Integration {
 	i := &integration{vars: cvars}
 	return sdkintegrations.NewIntegration(
 		desc,
-		sdkmodule.New( /* No exported functions for Starlark */ ),
+		sdkmodule.New(),
 		connStatus(i),
 		connTest(i),
 		sdkintegrations.WithConnectionConfigFromVars(cvars),

--- a/integrations/github/client.go
+++ b/integrations/github/client.go
@@ -7,31 +7,27 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/integrations"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/github/internal/vars"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
+const (
+	integrationName = "github"
+)
+
+var (
+	integrationID = sdktypes.NewIntegrationIDFromName(integrationName)
+
+	desc = common.LegacyDescriptor(integrationName, "GitHub", "/static/images/github.svg")
+)
+
 type integration struct {
 	vars sdkservices.Vars
 }
-
-var integrationID = sdktypes.NewIntegrationIDFromName("github")
-
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: integrationID.String(),
-	UniqueName:    "github",
-	DisplayName:   "GitHub",
-	Description:   "GitHub is a development platform with distributed version control, issue tracking, continuous integration, and more.",
-	LogoUrl:       "/static/images/github.svg",
-	ConnectionUrl: "/github/connect",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-	},
-}))
 
 func New(cvars sdkservices.Vars) sdkservices.Integration {
 	i := &integration{vars: cvars}

--- a/integrations/google/calendar/client.go
+++ b/integrations/google/calendar/client.go
@@ -14,13 +14,23 @@ import (
 	googleoauth2 "google.golang.org/api/oauth2/v2"
 	"google.golang.org/api/option"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/google/connections"
 	"go.autokitteh.dev/autokitteh/integrations/google/vars"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+const (
+	integrationName = "googlecalendar"
+)
+
+var (
+	IntegrationID = sdktypes.NewIntegrationIDFromName(integrationName)
+
+	desc = common.LegacyDescriptor(integrationName, "Google Calendar", "/static/images/google_calendar.svg")
 )
 
 type api struct {
@@ -29,24 +39,10 @@ type api struct {
 	cid    sdktypes.ConnectionID
 }
 
-var IntegrationID = sdktypes.NewIntegrationIDFromName("googlecalendar")
-
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: IntegrationID.String(),
-	UniqueName:    "googlecalendar",
-	DisplayName:   "Google Calendar",
-	Description:   "Google Calendar is a time-management and scheduling calendar service developed by Google.",
-	LogoUrl:       "/static/images/google_calendar.svg",
-	ConnectionUrl: "/googlecalendar/connect",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-	},
-}))
-
 func New(cvars sdkservices.Vars) sdkservices.Integration {
 	return sdkintegrations.NewIntegration(
 		desc,
-		sdkmodule.New( /* No exported functions for Starlark */ ),
+		sdkmodule.New(),
 		connections.ConnStatus(cvars),
 		connections.ConnTest(cvars),
 		sdkintegrations.WithConnectionConfigFromVars(cvars),

--- a/integrations/google/client.go
+++ b/integrations/google/client.go
@@ -8,11 +8,7 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 )
 
-const (
-	integrationName = "google"
-)
-
-var desc = common.LegacyDescriptor(integrationName, "Google (All APIs)", "/static/images/google.svg")
+var desc = common.LegacyDescriptor("google", "Google (All APIs)", "/static/images/google.svg")
 
 func New(cvars sdkservices.Vars) sdkservices.Integration {
 	return sdkintegrations.NewIntegration(

--- a/integrations/google/client.go
+++ b/integrations/google/client.go
@@ -1,44 +1,23 @@
 package google
 
 import (
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/google/connections"
-	"go.autokitteh.dev/autokitteh/integrations/google/gmail"
-	"go.autokitteh.dev/autokitteh/integrations/google/sheets"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
-	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-var integrationID = sdktypes.NewIntegrationIDFromName("google")
+const (
+	integrationName = "google"
+)
 
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: integrationID.String(),
-	UniqueName:    "google",
-	DisplayName:   "Google (All APIs)",
-	Description:   "Aggregation of all available Google APIs.",
-	LogoUrl:       "/static/images/google.svg",
-	UserLinks: map[string]string{
-		"1 REST API reference": "https://developers.google.com/apis-explorer",
-		"2 Go client API":      "https://pkg.go.dev/google.golang.org/api",
-		"3 Python samples":     "https://github.com/googleworkspace/python-samples",
-	},
-	ConnectionUrl: "/google/connect",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-	},
-}))
+var desc = common.LegacyDescriptor(integrationName, "Google (All APIs)", "/static/images/google.svg")
 
 func New(cvars sdkservices.Vars) sdkservices.Integration {
-	scope := desc.UniqueName().String()
-
-	opts := gmail.ExportedFunctions(cvars, scope, true)
-	opts = append(opts, sheets.ExportedFunctions(cvars, scope, true)...)
-
 	return sdkintegrations.NewIntegration(
 		desc,
-		sdkmodule.New(opts...),
+		sdkmodule.New(),
 		connections.ConnStatus(cvars),
 		connections.ConnTest(cvars),
 		sdkintegrations.WithConnectionConfigFromVars(cvars))

--- a/integrations/google/drive/client.go
+++ b/integrations/google/drive/client.go
@@ -14,16 +14,24 @@ import (
 	googleoauth2 "google.golang.org/api/oauth2/v2"
 	"google.golang.org/api/option"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/google/connections"
 	"go.autokitteh.dev/autokitteh/integrations/google/vars"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-var IntegrationID = sdktypes.NewIntegrationIDFromName("googledrive")
+const (
+	integrationName = "googledrive"
+)
+
+var (
+	IntegrationID = sdktypes.NewIntegrationIDFromName(integrationName)
+
+	desc = common.LegacyDescriptor(integrationName, "Google Drive", "/static/images/google_drive.svg")
+)
 
 type api struct {
 	logger *zap.Logger
@@ -31,27 +39,10 @@ type api struct {
 	cid    sdktypes.ConnectionID
 }
 
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: IntegrationID.String(),
-	UniqueName:    "googledrive",
-	DisplayName:   "Google Drive",
-	Description:   "Google Drive is a file-hosting service and synchronization service developed by Google.",
-	LogoUrl:       "/static/images/google_drive.svg",
-	UserLinks: map[string]string{
-		"1 REST API reference": "https://developers.google.com/drive/api/reference/rest/v3",
-		"2 Python client API":  "https://developers.google.com/resources/api-libraries/documentation/drive/v3/python/latest/",
-		"3 Python samples":     "https://github.com/googleworkspace/python-samples/tree/main/drive",
-	},
-	ConnectionUrl: "/googledrive/connect",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-	},
-}))
-
 func New(cvars sdkservices.Vars) sdkservices.Integration {
 	return sdkintegrations.NewIntegration(
 		desc,
-		sdkmodule.New( /* No exported functions for Starlark */ ),
+		sdkmodule.New(),
 		connections.ConnStatus(cvars),
 		connections.ConnTest(cvars),
 		sdkintegrations.WithConnectionConfigFromVars(cvars),

--- a/integrations/google/forms/client.go
+++ b/integrations/google/forms/client.go
@@ -11,33 +11,29 @@ import (
 	googleoauth2 "google.golang.org/api/oauth2/v2"
 	"google.golang.org/api/option"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/google/connections"
 	"go.autokitteh.dev/autokitteh/integrations/google/vars"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
+const (
+	integrationName = "googleforms"
+)
+
+var (
+	IntegrationID = sdktypes.NewIntegrationIDFromName(integrationName)
+
+	desc = common.LegacyDescriptor(integrationName, "Google Forms", "/static/images/google_forms.svg")
+)
+
 type api struct {
 	vars sdkservices.Vars
 	cid  sdktypes.ConnectionID
 }
-
-var IntegrationID = sdktypes.NewIntegrationIDFromName("googleforms")
-
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: IntegrationID.String(),
-	UniqueName:    "googleforms",
-	DisplayName:   "Google Forms",
-	Description:   "Google Forms is a survey administration software that part of the Google Workspace office suite.",
-	LogoUrl:       "/static/images/google_forms.svg",
-	ConnectionUrl: "/googleforms/connect",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-	},
-}))
 
 const (
 	// pubsubTopicEnvVar is the name of an environment variable that
@@ -48,7 +44,7 @@ const (
 func New(cvars sdkservices.Vars) sdkservices.Integration {
 	return sdkintegrations.NewIntegration(
 		desc,
-		sdkmodule.New( /* No exported functions for Starlark */ ),
+		sdkmodule.New(),
 		connections.ConnStatus(cvars),
 		connections.ConnTest(cvars),
 		sdkintegrations.WithConnectionConfigFromVars(cvars),

--- a/integrations/google/gemini/client.go
+++ b/integrations/google/gemini/client.go
@@ -8,37 +8,24 @@ import (
 	"google.golang.org/api/option"
 
 	"go.autokitteh.dev/autokitteh/integrations"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/google/vars"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-var integrationID = sdktypes.NewIntegrationIDFromName("googlegemini")
+const (
+	integrationName = "googlegemini"
+)
 
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: integrationID.String(),
-	UniqueName:    "googlegemini",
-	DisplayName:   "Google Gemini",
-	Description:   "Gemini is a generative artificial intelligence chatbot developed by Google.",
-	LogoUrl:       "/static/images/google_gemini.svg",
-	UserLinks: map[string]string{
-		"1 REST API reference": "https://ai.google.dev/api/rest",
-		"2 Python client API":  "https://ai.google.dev/api/python/google/generativeai",
-		"3 Python samples":     "https://github.com/google-gemini/generative-ai-python/tree/main/samples",
-	},
-	ConnectionUrl: "/googlegemini/connect",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-	},
-}))
+var desc = common.LegacyDescriptor(integrationName, "Google Gemini", "/static/images/google_gemini.svg")
 
 func New(cvars sdkservices.Vars) sdkservices.Integration {
 	return sdkintegrations.NewIntegration(
 		desc,
-		sdkmodule.New( /* No exported functions for Starlark */ ),
+		sdkmodule.New(),
 		connStatus(cvars),
 		connTest(cvars),
 		sdkintegrations.WithConnectionConfigFromVars(cvars),

--- a/integrations/google/gemini/client.go
+++ b/integrations/google/gemini/client.go
@@ -16,11 +16,7 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-const (
-	integrationName = "googlegemini"
-)
-
-var desc = common.LegacyDescriptor(integrationName, "Google Gemini", "/static/images/google_gemini.svg")
+var desc = common.LegacyDescriptor("googlegemini", "Google Gemini", "/static/images/google_gemini.svg")
 
 func New(cvars sdkservices.Vars) sdkservices.Integration {
 	return sdkintegrations.NewIntegration(

--- a/integrations/google/gmail/client.go
+++ b/integrations/google/gmail/client.go
@@ -11,9 +11,9 @@ import (
 	googleoauth2 "google.golang.org/api/oauth2/v2"
 	"google.golang.org/api/option"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/google/connections"
 	"go.autokitteh.dev/autokitteh/integrations/google/vars"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
@@ -21,7 +21,13 @@ import (
 )
 
 const (
-	googleScope = "google"
+	integrationName = "gmail"
+)
+
+var (
+	IntegrationID = sdktypes.NewIntegrationIDFromName(integrationName)
+
+	desc = common.LegacyDescriptor(integrationName, "Gmail", "/static/images/gmail.svg")
 )
 
 type api struct {
@@ -29,24 +35,8 @@ type api struct {
 	cid  sdktypes.ConnectionID
 }
 
-var IntegrationID = sdktypes.NewIntegrationIDFromName("gmail")
-
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: IntegrationID.String(),
-	UniqueName:    "gmail",
-	DisplayName:   "Gmail",
-	Description:   "Gmail is an email service provided by Google.",
-	LogoUrl:       "/static/images/gmail.svg",
-	ConnectionUrl: "/gmail/connect",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-	},
-}))
-
 func New(cvars sdkservices.Vars) sdkservices.Integration {
-	scope := googleScope
-
-	opts := ExportedFunctions(cvars, scope, false)
+	opts := ExportedFunctions(cvars, "google", false)
 
 	return sdkintegrations.NewIntegration(
 		desc,

--- a/integrations/google/sheets/client.go
+++ b/integrations/google/sheets/client.go
@@ -20,11 +20,7 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-const (
-	integrationName = "googlesheets"
-)
-
-var desc = common.LegacyDescriptor(integrationName, "Google Sheets", "/static/images/google_sheets.svg")
+var desc = common.LegacyDescriptor("googlesheets", "Google Sheets", "/static/images/google_sheets.svg")
 
 type api struct {
 	vars sdkservices.Vars

--- a/integrations/google/sheets/client.go
+++ b/integrations/google/sheets/client.go
@@ -11,9 +11,9 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/sheets/v4"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/google/connections"
 	"go.autokitteh.dev/autokitteh/integrations/google/vars"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
@@ -21,32 +21,17 @@ import (
 )
 
 const (
-	googleScope = "google"
+	integrationName = "googlesheets"
 )
+
+var desc = common.LegacyDescriptor(integrationName, "Google Sheets", "/static/images/google_sheets.svg")
 
 type api struct {
 	vars sdkservices.Vars
 }
 
-var integrationID = sdktypes.NewIntegrationIDFromName("googlesheets")
-
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: integrationID.String(),
-	UniqueName:    "googlesheets",
-	DisplayName:   "Google Sheets",
-	Description:   "Google Sheets is a web-based spreadsheet application that is part of the Google Workspace office suite.",
-	LogoUrl:       "/static/images/google_sheets.svg",
-	ConnectionUrl: "/googlesheets/connect",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-	},
-}))
-
 func New(cvars sdkservices.Vars) sdkservices.Integration {
-	scope := googleScope
-
-	opts := ExportedFunctions(cvars, scope, false)
-
+	opts := ExportedFunctions(cvars, "google", false)
 	return sdkintegrations.NewIntegration(
 		desc,
 		sdkmodule.New(opts...),

--- a/integrations/height/client.go
+++ b/integrations/height/client.go
@@ -7,11 +7,7 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 )
 
-const (
-	integrationName = "height"
-)
-
-var desc = common.Descriptor(integrationName, "Height", "/static/images/height.png")
+var desc = common.Descriptor("height", "Height", "/static/images/height.png")
 
 // New defines an AutoKitteh integration, which
 // is registered when the AutoKitteh server starts.

--- a/integrations/height/client.go
+++ b/integrations/height/client.go
@@ -1,28 +1,17 @@
 package height
 
 import (
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
-	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 const (
 	integrationName = "height"
 )
 
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: sdktypes.NewIntegrationIDFromName(integrationName).String(),
-	UniqueName:    integrationName,
-	DisplayName:   "Height",
-	LogoUrl:       "/static/images/height.png",
-	ConnectionUrl: "/height",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-		SupportsConnectionTest: true,
-	},
-}))
+var desc = common.Descriptor(integrationName, "Height", "/static/images/height.png")
 
 // New defines an AutoKitteh integration, which
 // is registered when the AutoKitteh server starts.

--- a/integrations/hubspot/client.go
+++ b/integrations/hubspot/client.go
@@ -7,35 +7,24 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/integrations"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-type integration struct{ vars sdkservices.Vars }
-
-var (
-	integrationID = sdktypes.NewIntegrationIDFromName("hubspot")
-
-	authType = sdktypes.NewSymbol("auth_type")
+const (
+	integrationName = "hubspot"
 )
 
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: integrationID.String(),
-	UniqueName:    "hubspot",
-	DisplayName:   "HubSpot",
-	Description:   "HubSpot is an AI-powered customer platform that provides software, integrations, and resources to support marketing, sales, and customer service.",
-	LogoUrl:       "/static/images/hubspot.svg",
-	UserLinks: map[string]string{
-		"HubSpot developer platform": "https://developers.hubspot.com/",
-	},
-	ConnectionUrl: "/hubspot/connect",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-	},
-}))
+var (
+	desc = common.LegacyDescriptor(integrationName, "HubSpot", "/static/images/hubspot.svg")
+
+	authTypeVar = sdktypes.NewSymbol("auth_type")
+)
+
+type integration struct{ vars sdkservices.Vars }
 
 func New(cvars sdkservices.Vars) sdkservices.Integration {
 	i := &integration{vars: cvars}
@@ -60,7 +49,7 @@ func connStatus(i *integration) sdkintegrations.OptFn {
 			return sdktypes.InvalidStatus, err
 		}
 
-		at := vs.Get(authType)
+		at := vs.Get(authTypeVar)
 		if !at.IsValid() || at.Value() == "" {
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		}

--- a/integrations/hubspot/client.go
+++ b/integrations/hubspot/client.go
@@ -14,12 +14,8 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-const (
-	integrationName = "hubspot"
-)
-
 var (
-	desc = common.LegacyDescriptor(integrationName, "HubSpot", "/static/images/hubspot.svg")
+	desc = common.LegacyDescriptor("hubspot", "HubSpot", "/static/images/hubspot.svg")
 
 	authTypeVar = sdktypes.NewSymbol("auth_type")
 )

--- a/integrations/linear/client.go
+++ b/integrations/linear/client.go
@@ -1,28 +1,17 @@
 package linear
 
 import (
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
-	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 const (
 	integrationName = "linear"
 )
 
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: sdktypes.NewIntegrationIDFromName(integrationName).String(),
-	UniqueName:    integrationName,
-	DisplayName:   "Linear",
-	LogoUrl:       "/static/images/linear.svg",
-	ConnectionUrl: "/linear",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-		SupportsConnectionTest: true,
-	},
-}))
+var desc = common.Descriptor(integrationName, "Linear", "/static/images/linear.svg")
 
 // New defines an AutoKitteh integration, which
 // is registered when the AutoKitteh server starts.

--- a/integrations/linear/client.go
+++ b/integrations/linear/client.go
@@ -7,11 +7,7 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 )
 
-const (
-	integrationName = "linear"
-)
-
-var desc = common.Descriptor(integrationName, "Linear", "/static/images/linear.svg")
+var desc = common.Descriptor("linear", "Linear", "/static/images/linear.svg")
 
 // New defines an AutoKitteh integration, which
 // is registered when the AutoKitteh server starts.

--- a/integrations/microsoft/client.go
+++ b/integrations/microsoft/client.go
@@ -10,11 +10,7 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-const (
-	integrationName = "microsoft"
-)
-
-var desc = common.Descriptor(integrationName, "Microsoft (All APIs)", "/static/images/microsoft.svg")
+var desc = common.Descriptor("microsoft", "Microsoft (All APIs)", "/static/images/microsoft.svg")
 
 // New defines an AutoKitteh integration, which
 // is registered when the AutoKitteh server starts.

--- a/integrations/microsoft/client.go
+++ b/integrations/microsoft/client.go
@@ -1,9 +1,9 @@
 package microsoft
 
 import (
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/microsoft/connection"
 	"go.autokitteh.dev/autokitteh/integrations/microsoft/teams"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
@@ -14,17 +14,7 @@ const (
 	integrationName = "microsoft"
 )
 
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: sdktypes.NewIntegrationIDFromName(integrationName).String(),
-	UniqueName:    integrationName,
-	DisplayName:   "Microsoft (All APIs)",
-	LogoUrl:       "/static/images/microsoft.svg",
-	ConnectionUrl: "/microsoft",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-		SupportsConnectionTest: true,
-	},
-}))
+var desc = common.Descriptor(integrationName, "Microsoft (All APIs)", "/static/images/microsoft.svg")
 
 // New defines an AutoKitteh integration, which
 // is registered when the AutoKitteh server starts.

--- a/integrations/microsoft/teams/client.go
+++ b/integrations/microsoft/teams/client.go
@@ -1,29 +1,19 @@
 package teams
 
 import (
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/microsoft/connection"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
-	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 const (
 	IntegrationName = "microsoft_teams"
 )
 
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: sdktypes.NewIntegrationIDFromName(IntegrationName).String(),
-	UniqueName:    IntegrationName,
-	DisplayName:   "Microsoft Teams",
-	LogoUrl:       "/static/images/microsoft_teams.svg",
-	ConnectionUrl: "/microsoft/teams",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-		SupportsConnectionTest: true,
-	},
-}))
+var desc = common.Descriptor(IntegrationName, "Microsoft Teams", "/static/images/microsoft_teams.svg").
+	WithConnectionURL("/microsoft/teams")
 
 // New defines an AutoKitteh integration, which
 // is registered when the AutoKitteh server starts.

--- a/integrations/slack/client.go
+++ b/integrations/slack/client.go
@@ -6,6 +6,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/integrations"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/auth"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/bookmarks"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/bots"
@@ -14,31 +15,21 @@ import (
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/reactions"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/users"
 	"go.autokitteh.dev/autokitteh/integrations/slack/internal/vars"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-var integrationID = sdktypes.NewIntegrationIDFromName("slack")
+const (
+	integrationName = "slack"
+)
 
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: integrationID.String(),
-	UniqueName:    "slack",
-	DisplayName:   "Slack",
-	Description:   "Slack is a cloud-based team communication platform.",
-	LogoUrl:       "/static/images/slack.svg",
-	UserLinks: map[string]string{
-		"1 Web API reference":    "https://api.slack.com/methods",
-		"2 Events API reference": "https://api.slack.com/events?filter=Events",
-		"3 Python client API":    "https://slack.dev/python-slack-sdk/api-docs/slack_sdk/",
-	},
-	ConnectionUrl: "/slack/connect",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-	},
-}))
+var (
+	integrationID = sdktypes.NewIntegrationIDFromName(integrationName)
+
+	desc = common.LegacyDescriptor(integrationName, "Slack", "/static/images/slack.svg")
+)
 
 func New(vs sdkservices.Vars) sdkservices.Integration {
 	return sdkintegrations.NewIntegration(

--- a/integrations/twilio/client.go
+++ b/integrations/twilio/client.go
@@ -7,33 +7,21 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/integrations"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/twilio/webhooks"
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
+const (
+	integrationName = "twilio"
+)
+
+var desc = common.LegacyDescriptor(integrationName, "Twilio", "/static/images/twilio.png")
+
 type integration struct{ vars sdkservices.Vars }
-
-var integrationID = sdktypes.NewIntegrationIDFromName("twilio")
-
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: integrationID.String(),
-	UniqueName:    "twilio",
-	DisplayName:   "Twilio",
-	Description:   "Twilio is a programmable phone-based communication platform: sending an receiving messages, making and receiving voice calls, and more.",
-	LogoUrl:       "/static/images/twilio.png",
-	UserLinks: map[string]string{
-		"1 Messaging API overview": "https://www.twilio.com/docs/messaging/api",
-		"2 Voice API overview":     "https://www.twilio.com/docs/voice/api",
-	},
-	ConnectionUrl: "/twilio/connect",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-	},
-}))
 
 func New(vars sdkservices.Vars) sdkservices.Integration {
 	i := &integration{vars: vars}

--- a/integrations/twilio/client.go
+++ b/integrations/twilio/client.go
@@ -15,11 +15,7 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-const (
-	integrationName = "twilio"
-)
-
-var desc = common.LegacyDescriptor(integrationName, "Twilio", "/static/images/twilio.png")
+var desc = common.LegacyDescriptor("twilio", "Twilio", "/static/images/twilio.png")
 
 type integration struct{ vars sdkservices.Vars }
 

--- a/integrations/zoom/client.go
+++ b/integrations/zoom/client.go
@@ -1,28 +1,17 @@
 package zoom
 
 import (
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
-	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 const (
 	integrationName = "zoom"
 )
 
-var desc = kittehs.Must1(sdktypes.StrictIntegrationFromProto(&sdktypes.IntegrationPB{
-	IntegrationId: sdktypes.NewIntegrationIDFromName(integrationName).String(),
-	UniqueName:    integrationName,
-	DisplayName:   "Zoom",
-	LogoUrl:       "/static/images/zoom.svg",
-	ConnectionUrl: "/zoom",
-	ConnectionCapabilities: &sdktypes.ConnectionCapabilitiesPB{
-		RequiresConnectionInit: true,
-		SupportsConnectionTest: true,
-	},
-}))
+var desc = common.Descriptor(integrationName, "Zoom", "/static/images/zoom.svg")
 
 // New defines an AutoKitteh integration, which
 // is registered when the AutoKitteh server starts.

--- a/integrations/zoom/client.go
+++ b/integrations/zoom/client.go
@@ -7,11 +7,7 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 )
 
-const (
-	integrationName = "zoom"
-)
-
-var desc = common.Descriptor(integrationName, "Zoom", "/static/images/zoom.svg")
+var desc = common.Descriptor("zoom", "Zoom", "/static/images/zoom.svg")
 
 // New defines an AutoKitteh integration, which
 // is registered when the AutoKitteh server starts.

--- a/sdk/sdktypes/integration.go
+++ b/sdk/sdktypes/integration.go
@@ -66,6 +66,10 @@ func (p Integration) ConnectionURL() *url.URL {
 	return kittehs.Must1(url.Parse(p.m.ConnectionUrl))
 }
 
+func (p Integration) WithConnectionURL(u string) Integration {
+	return Integration{p.forceUpdate(func(pb *IntegrationPB) { pb.ConnectionUrl = u })}
+}
+
 func (p Integration) UpdateModule(m Module) Integration {
 	return Integration{p.forceUpdate(func(pb *IntegrationPB) { pb.Module = m.ToProto() })}
 }
@@ -92,8 +96,4 @@ func (p Integration) WithConnectionCapabilities(c ConnectionCapabilities) Integr
 
 func (p Integration) InitialConnectionStatus() Status {
 	return kittehs.Must1(StatusFromProto(p.read().InitialConnectionStatus))
-}
-
-func (p Integration) WithInitialConnectionStatus(s Status) Integration {
-	return Integration{p.forceUpdate(func(pb *IntegrationPB) { pb.InitialConnectionStatus = s.ToProto() })}
 }


### PR DESCRIPTION
Reuse a common function instead of copy-pasting the full protocol buffer in all integrations.

In a few integrations that define connection var names, rename them from "Xxx" to "XxxVar".