### PR TITLE
refactor(integrations): webhook handlers

### DIFF
--- a/integrations/asana/server.go
+++ b/integrations/asana/server.go
@@ -1,18 +1,14 @@
 package asana
 
 import (
-	"net/http"
-
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
 	"go.autokitteh.dev/autokitteh/web/static"
 )
 
 const (
-	// uiPath is the URL root path of a simple web UI to interact with users.
-	uiPath = "/asana/connect/"
-
 	// savePath is the URL path for our handler to save new
 	// connections, after users submit them via a web form.
 	savePath = "/asana/save"
@@ -20,13 +16,12 @@ const (
 
 // Start initializes all the HTTP handlers of the AWS integration.
 // This includes connection UIs and initialization webhooks.
-func Start(l *zap.Logger, muxes *muxes.Muxes) {
-	// Connection UI.
-	muxes.NoAuth.Handle(uiPath, http.FileServer(http.FS(static.AsanaWebContent)))
+func Start(l *zap.Logger, m *muxes.Muxes) {
+	common.ServeStaticUI(m, desc, static.AsanaWebContent)
 
 	// Init webhooks save connection vars (via "c.Finalize" calls), so they need
 	// to have an authenticated user context, so the DB layer won't reject them.
 	// For this purpose, init webhooks are managed by the "auth" mux, which passes
 	// through AutoKitteh's auth middleware to extract the user ID from a cookie.
-	muxes.Auth.Handle(savePath, NewHTTPHandler(l))
+	m.Auth.Handle(savePath, NewHTTPHandler(l))
 }

--- a/integrations/atlassian/confluence/server.go
+++ b/integrations/atlassian/confluence/server.go
@@ -1,10 +1,9 @@
 package confluence
 
 import (
-	"net/http"
-
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/web/static"
@@ -24,19 +23,17 @@ const (
 
 // Start initializes all the HTTP handlers of the Confluence integration.
 // This includes connection UIs, initialization webhooks, and event webhooks.
-func Start(l *zap.Logger, muxes *muxes.Muxes, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.DispatchFunc) {
-	// Connection UI.
-	uiPath := "GET " + desc.ConnectionURL().Path + "/"
-	muxes.NoAuth.Handle(uiPath, http.FileServer(http.FS(static.ConfluenceWebContent)))
+func Start(l *zap.Logger, m *muxes.Muxes, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.DispatchFunc) {
+	common.ServeStaticUI(m, desc, static.ConfluenceWebContent)
 
 	// Init webhooks save connection vars (via "c.Finalize" calls), so they need
 	// to have an authenticated user context, so the DB layer won't reject them.
 	// For this purpose, init webhooks are managed by the "auth" mux, which passes
 	// through AutoKitteh's auth middleware to extract the user ID from a cookie.
 	h := NewHTTPHandler(l, o, v, d)
-	muxes.Auth.HandleFunc("GET "+oauthPath, h.handleOAuth)
-	muxes.Auth.HandleFunc("POST "+savePath, h.handleSave)
+	m.Auth.HandleFunc("GET "+oauthPath, h.handleOAuth)
+	m.Auth.HandleFunc("POST "+savePath, h.handleSave)
 
 	// Event webhooks (unauthenticated by definition).
-	muxes.NoAuth.HandleFunc("POST "+webhookPath, h.handleEvent)
+	m.NoAuth.HandleFunc("POST "+webhookPath, h.handleEvent)
 }

--- a/integrations/atlassian/jira/server.go
+++ b/integrations/atlassian/jira/server.go
@@ -1,10 +1,9 @@
 package jira
 
 import (
-	"net/http"
-
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/web/static"
@@ -24,19 +23,17 @@ const (
 
 // Start initializes all the HTTP handlers of the Jira integration.
 // This includes connection UIs, initialization webhooks, and event webhooks.
-func Start(l *zap.Logger, muxes *muxes.Muxes, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.DispatchFunc) {
-	// Connection UI.
-	uiPath := "GET " + desc.ConnectionURL().Path + "/"
-	muxes.NoAuth.Handle(uiPath, http.FileServer(http.FS(static.JiraWebContent)))
+func Start(l *zap.Logger, m *muxes.Muxes, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.DispatchFunc) {
+	common.ServeStaticUI(m, desc, static.JiraWebContent)
 
 	// Init webhooks save connection vars (via "c.Finalize" calls), so they need
 	// to have an authenticated user context, so the DB layer won't reject them.
 	// For this purpose, init webhooks are managed by the "auth" mux, which passes
 	// through AutoKitteh's auth middleware to extract the user ID from a cookie.
 	h := NewHTTPHandler(l, o, v, d)
-	muxes.Auth.HandleFunc("GET "+oauthPath, h.handleOAuth)
-	muxes.Auth.HandleFunc("POST "+savePath, h.handleSave)
+	m.Auth.HandleFunc("GET "+oauthPath, h.handleOAuth)
+	m.Auth.HandleFunc("POST "+savePath, h.handleSave)
 
 	// Event webhook (unauthenticated by definition).
-	muxes.NoAuth.HandleFunc("POST "+webhookPath, h.handleEvent)
+	m.NoAuth.HandleFunc("POST "+webhookPath, h.handleEvent)
 }

--- a/integrations/auth0/server.go
+++ b/integrations/auth0/server.go
@@ -1,38 +1,20 @@
 package auth0
 
 import (
-	"net/http"
-
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/web/static"
 )
 
-const (
-	// oauthPath is the URL path for our handler to save
-	// new OAuth-based connections.
-	oauthPath = "/auth0/oauth"
-
-	// savePath is the URL path for our handler to save authentication credentials.
-	// It acts as a passthrough for the OAuth flow.
-	savePath = "/auth0/save"
-)
-
 // Start initializes all the HTTP handlers of the Auth0 integration.
 // This includes connection UIs, initialization webhooks, and event webhooks.
-func Start(l *zap.Logger, muxes *muxes.Muxes, vars sdkservices.Vars) {
-	// Connection UI.
-	uiPath := "GET " + desc.ConnectionURL().Path + "/"
-	muxes.NoAuth.Handle(uiPath, http.FileServer(http.FS(static.Auth0WebContent)))
+func Start(l *zap.Logger, m *muxes.Muxes, vars sdkservices.Vars) {
+	common.ServeStaticUI(m, desc, static.Auth0WebContent)
 
-	// Init webhooks save connection vars (via "c.Finalize" calls), so they need
-	// to have an authenticated user context, so the DB layer won't reject them.
-	// For this purpose, init webhooks are managed by the "auth" mux, which passes
-	// through AutoKitteh's auth middleware to extract the user ID from a cookie.
 	h := NewHTTPHandler(l, vars)
-	muxes.Auth.HandleFunc("GET "+oauthPath, h.handleOAuth)
-	muxes.Auth.HandleFunc("GET "+savePath, h.handleSave)  // Web UI passthrough for OAuth.
-	muxes.Auth.HandleFunc("POST "+savePath, h.handleSave) // Internal UI passthrough for OAuth.
+	common.RegisterSaveHandler(m, desc, h.handleSave)
+	common.RegisterOAuthHandler(m, desc, h.handleOAuth)
 }

--- a/integrations/aws/server.go
+++ b/integrations/aws/server.go
@@ -1,18 +1,14 @@
 package aws
 
 import (
-	"net/http"
-
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
 	"go.autokitteh.dev/autokitteh/web/static"
 )
 
 const (
-	// uiPath is the URL root path of a simple web UI to interact with users.
-	uiPath = "/aws/connect/"
-
 	// savePath is the URL path for our handler to save new
 	// connections, after users submit them via a web form.
 	savePath = "/aws/save"
@@ -20,13 +16,12 @@ const (
 
 // Start initializes all the HTTP handlers of the AWS integration.
 // This includes connection UIs and initialization webhooks.
-func Start(l *zap.Logger, muxes *muxes.Muxes) {
-	// Connection UI.
-	muxes.NoAuth.Handle(uiPath, http.FileServer(http.FS(static.AWSWebContent)))
+func Start(l *zap.Logger, m *muxes.Muxes) {
+	common.ServeStaticUI(m, desc, static.AWSWebContent)
 
 	// Init webhooks save connection vars (via "c.Finalize" calls), so they need
 	// to have an authenticated user context, so the DB layer won't reject them.
 	// For this purpose, init webhooks are managed by the "auth" mux, which passes
 	// through AutoKitteh's auth middleware to extract the user ID from a cookie.
-	muxes.Auth.Handle(savePath, NewHTTPHandler(l))
+	m.Auth.Handle(savePath, NewHTTPHandler(l))
 }

--- a/integrations/chatgpt/server.go
+++ b/integrations/chatgpt/server.go
@@ -1,10 +1,9 @@
 package chatgpt
 
 import (
-	"net/http"
-
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
 	"go.autokitteh.dev/autokitteh/web/static"
 )
@@ -17,14 +16,12 @@ const (
 
 // Start initializes all the HTTP handlers of the ChatGPT integration.
 // This includes connection UIs and initialization webhooks.
-func Start(l *zap.Logger, muxes *muxes.Muxes) {
-	// Connection UI.
-	uiPath := "GET " + desc.ConnectionURL().Path + "/"
-	muxes.NoAuth.Handle(uiPath, http.FileServer(http.FS(static.ChatGPTWebContent)))
+func Start(l *zap.Logger, m *muxes.Muxes) {
+	common.ServeStaticUI(m, desc, static.ChatGPTWebContent)
 
 	// Init webhooks save connection vars (via "c.Finalize" calls), so they need
 	// to have an authenticated user context, so the DB layer won't reject them.
 	// For this purpose, init webhooks are managed by the "auth" mux, which passes
 	// through AutoKitteh's auth middleware to extract the user ID from a cookie.
-	muxes.Auth.Handle("POST "+savePath, NewHTTPHandler(l))
+	m.Auth.Handle("POST "+savePath, NewHTTPHandler(l))
 }

--- a/integrations/common/server.go
+++ b/integrations/common/server.go
@@ -1,0 +1,38 @@
+package common
+
+import (
+	"embed"
+	"fmt"
+	"net/http"
+
+	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+// ServeStaticUI registers an integration's static web content to
+// AutoKitteh's internal user-authenticated HTTP server. User auth
+// isn't actually required for serving these files, but it's impossible
+// to use them (i.e. to initialize a connection) without authentication.
+func ServeStaticUI(m *muxes.Muxes, i sdktypes.Integration, fs embed.FS) {
+	pattern := fmt.Sprintf("GET %s/", i.ConnectionURL().Path)
+	m.Auth.Handle(pattern, http.FileServer(http.FS(fs)))
+}
+
+// RegisterSaveHandler registers a webhook to handle saving connection variables.
+// This is always the first step in initializing a connection, regardless of its
+// auth type. It's also the last step for non-OAuth authentication types. The
+// handler function requires an authenticated user context for database access.
+func RegisterSaveHandler(m *muxes.Muxes, i sdktypes.Integration, h http.HandlerFunc) {
+	pattern := fmt.Sprintf(" %s/save", i.ConnectionURL().Path)
+	m.Auth.HandleFunc(http.MethodGet+pattern, h)
+	m.Auth.HandleFunc(http.MethodPost+pattern, h)
+}
+
+// RegisterOAuthHandler registers a webhook to handle the last step in a 3-legged
+// OAuth 2.0 flow. This is the only step that requires an authenticated user context
+// for database access. The handler function receives an incoming redirect request
+// from AutoKitteh's generic OAuth service, which contains an OAuth token (if the
+// OAuth flow was successful) and form parameters for debugging and validation.
+func RegisterOAuthHandler(m *muxes.Muxes, i sdktypes.Integration, h http.HandlerFunc) {
+	m.Auth.HandleFunc(fmt.Sprintf("GET %s/oauth", i.ConnectionURL().Path), h)
+}

--- a/integrations/google/server.go
+++ b/integrations/google/server.go
@@ -6,19 +6,13 @@ import (
 
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/web/static"
 )
 
 const (
-	// oauthPath is the URL path for our handler to save new OAuth-based connections.
-	oauthPath = "/google/oauth"
-
-	// savePath is the URL path for our handler to save new JSON key-based
-	// connections, after users submit them via a web form.
-	savePath = "/google/save"
-
 	// calWebhookPath is the URL path to receive incoming Google Calendar push notifications.
 	calWebhookPath = "/googlecalendar/notif"
 	// driveWebhookPath is the URL path to receive incoming Google Drive push notifications.
@@ -31,42 +25,37 @@ const (
 
 // Start initializes all the HTTP handlers of all the Google integrations.
 // This includes connection UIs, initialization webhooks, and event webhooks.
-func Start(l *zap.Logger, muxes *muxes.Muxes, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.DispatchFunc) {
+func Start(l *zap.Logger, m *muxes.Muxes, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.DispatchFunc) {
 	uiPath := "GET " + desc.ConnectionURL().Path + "/"
 
 	// Connection UI.
-	muxes.NoAuth.Handle(uiPath, http.FileServer(http.FS(static.GoogleWebContent)))
+	m.NoAuth.Handle(uiPath, http.FileServer(http.FS(static.GoogleWebContent)))
 
 	urlPath := strings.ReplaceAll(uiPath, "google", "gmail")
-	muxes.NoAuth.Handle(urlPath, http.FileServer(http.FS(static.GmailWebContent)))
+	m.NoAuth.Handle(urlPath, http.FileServer(http.FS(static.GmailWebContent)))
 
 	urlPath = strings.ReplaceAll(uiPath, "google", "googlecalendar")
-	muxes.NoAuth.Handle(urlPath, http.FileServer(http.FS(static.GoogleCalendarWebContent)))
+	m.NoAuth.Handle(urlPath, http.FileServer(http.FS(static.GoogleCalendarWebContent)))
 
 	urlPath = strings.ReplaceAll(uiPath, "google", "googlechat")
-	muxes.NoAuth.Handle(urlPath, http.FileServer(http.FS(static.GoogleChatWebContent)))
+	m.NoAuth.Handle(urlPath, http.FileServer(http.FS(static.GoogleChatWebContent)))
 
 	urlPath = strings.ReplaceAll(uiPath, "google", "googledrive")
-	muxes.NoAuth.Handle(urlPath, http.FileServer(http.FS(static.GoogleDriveWebContent)))
+	m.NoAuth.Handle(urlPath, http.FileServer(http.FS(static.GoogleDriveWebContent)))
 
 	urlPath = strings.ReplaceAll(uiPath, "google", "googleforms")
-	muxes.NoAuth.Handle(urlPath, http.FileServer(http.FS(static.GoogleFormsWebContent)))
+	m.NoAuth.Handle(urlPath, http.FileServer(http.FS(static.GoogleFormsWebContent)))
 
 	urlPath = strings.ReplaceAll(uiPath, "google", "googlesheets")
-	muxes.NoAuth.Handle(urlPath, http.FileServer(http.FS(static.GoogleSheetsWebContent)))
+	m.NoAuth.Handle(urlPath, http.FileServer(http.FS(static.GoogleSheetsWebContent)))
 
-	// Init webhooks save connection vars (via "c.Finalize" calls), so they need
-	// to have an authenticated user context, so the DB layer won't reject them.
-	// For this purpose, init webhooks are managed by the "auth" mux, which passes
-	// through AutoKitteh's auth middleware to extract the user ID from a cookie.
 	h := NewHTTPHandler(l, o, v, d)
-	muxes.Auth.HandleFunc("GET "+oauthPath, h.handleOAuth)
-	muxes.Auth.HandleFunc("GET "+savePath, h.handleCreds)  // Passthrough for OAuth.
-	muxes.Auth.HandleFunc("POST "+savePath, h.handleCreds) // Save JSON key.
+	common.RegisterSaveHandler(m, desc, h.handleCreds)
+	common.RegisterOAuthHandler(m, desc, h.handleOAuth)
 
 	// Event webhooks (unauthenticated by definition).
-	muxes.NoAuth.HandleFunc("POST "+calWebhookPath, h.handleCalNotification)
-	muxes.NoAuth.HandleFunc("POST "+driveWebhookPath, h.handleDriveNotification)
-	muxes.NoAuth.HandleFunc("POST "+formsWebhookPath, h.handleFormsNotification)
-	muxes.NoAuth.HandleFunc("POST "+gmailWebhookPath, h.handleGmailNotification)
+	m.NoAuth.HandleFunc("POST "+calWebhookPath, h.handleCalNotification)
+	m.NoAuth.HandleFunc("POST "+driveWebhookPath, h.handleDriveNotification)
+	m.NoAuth.HandleFunc("POST "+formsWebhookPath, h.handleFormsNotification)
+	m.NoAuth.HandleFunc("POST "+gmailWebhookPath, h.handleGmailNotification)
 }

--- a/integrations/height/save.go
+++ b/integrations/height/save.go
@@ -76,7 +76,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 		}
 		urlPath, err := c.FinalURL()
 		if err != nil {
-			l.Error("failed to construct final OAuth URL", zap.Error(err))
+			l.Error("failed to construct final URL", zap.Error(err))
 			c.AbortServerError("save connection: bad redirect URL")
 			return
 		}

--- a/integrations/height/server.go
+++ b/integrations/height/server.go
@@ -1,10 +1,9 @@
 package height
 
 import (
-	"net/http"
-
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/web/static"
@@ -12,17 +11,12 @@ import (
 
 // Start initializes all the HTTP handlers of the Height integration. This
 // includes connection UIs, connection initialization webhooks, and event webhooks.
-func Start(l *zap.Logger, muxes *muxes.Muxes, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.DispatchFunc) {
-	// Connection UI for authenticated AutoKitteh users (user authentication
-	// isn't required, but it makes no sense to create a connection without it).
-	muxes.Auth.Handle("GET /height/", http.FileServer(http.FS(static.HeightWebContent)))
+func Start(l *zap.Logger, m *muxes.Muxes, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.DispatchFunc) {
+	common.ServeStaticUI(m, desc, static.HeightWebContent)
 
-	// Connection initialization webhooks save connection variables (e.g. auth and
-	// metadata), which requires an authenticated user context for database access.
 	h := newHTTPHandler(l, v, o, d)
-	muxes.Auth.HandleFunc("POST /height/save", h.handleSave)
-	muxes.Auth.HandleFunc("GET /height/save", h.handleSave)
-	muxes.Auth.HandleFunc("GET /height/oauth", h.handleOAuth)
+	common.RegisterSaveHandler(m, desc, h.handleSave)
+	common.RegisterOAuthHandler(m, desc, h.handleOAuth)
 
 	// TODO: Event webhooks (no AutoKitteh user authentication by definition, because
 	// these asynchronous requests are sent to us by third-party services).

--- a/integrations/hubspot/server.go
+++ b/integrations/hubspot/server.go
@@ -1,10 +1,9 @@
 package hubspot
 
 import (
-	"net/http"
-
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/web/static"
@@ -18,14 +17,12 @@ const (
 
 // Start initializes all the HTTP handlers of the HubSpot integration.
 // This includes connection UIs and initialization webhooks.
-func Start(l *zap.Logger, muxes *muxes.Muxes, o sdkservices.OAuth) {
-	// Connection UI.
-	uiPath := "GET " + desc.ConnectionURL().Path + "/"
-	muxes.NoAuth.Handle(uiPath, http.FileServer(http.FS(static.HubSpotWebContent)))
+func Start(l *zap.Logger, m *muxes.Muxes, o sdkservices.OAuth) {
+	common.ServeStaticUI(m, desc, static.HubSpotWebContent)
 
 	// Init webhooks save connection vars (via "c.Finalize" calls), so they need
 	// to have an authenticated user context, so the DB layer won't reject them.
 	// For this purpose, init webhooks are managed by the "auth" mux, which passes
 	// through AutoKitteh's auth middleware to extract the user ID from a cookie.
-	muxes.Auth.Handle(oauthPath, NewHTTPHandler(l, o))
+	m.Auth.Handle(oauthPath, NewHTTPHandler(l, o))
 }

--- a/integrations/linear/checks.go
+++ b/integrations/linear/checks.go
@@ -39,7 +39,7 @@ func status(v sdkservices.Vars) sdkintegrations.OptFn {
 
 // test checks whether the connection is actually usable, i.e. the configured
 // authentication credentials are valid and can be used to make API calls.
-func test(v sdkservices.Vars, o sdkservices.OAuth) sdkintegrations.OptFn {
+func test(v sdkservices.Vars) sdkintegrations.OptFn {
 	return sdkintegrations.WithConnectionTest(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
 		if !cid.IsValid() {
 			return sdktypes.NewStatus(sdktypes.StatusCodeError, "Init required"), nil

--- a/integrations/linear/client.go
+++ b/integrations/linear/client.go
@@ -11,8 +11,8 @@ var desc = common.Descriptor("linear", "Linear", "/static/images/linear.svg")
 
 // New defines an AutoKitteh integration, which
 // is registered when the AutoKitteh server starts.
-func New(v sdkservices.Vars, o sdkservices.OAuth) sdkservices.Integration {
+func New(v sdkservices.Vars) sdkservices.Integration {
 	return sdkintegrations.NewIntegration(
-		desc, sdkmodule.New(), status(v), test(v, o),
+		desc, sdkmodule.New(), status(v), test(v),
 		sdkintegrations.WithConnectionConfigFromVars(v))
 }

--- a/integrations/linear/save.go
+++ b/integrations/linear/save.go
@@ -52,7 +52,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 	authType := h.saveAuthType(r.Context(), vsid, r.FormValue("auth_type"))
 
 	switch authType {
-	// Use the AutoKitteh's server's default Linear OAuth 2.0 app, i.e.
+	// Use the AutoKitteh server's default Linear OAuth 2.0 app, i.e.
 	// immediately redirect to the 3-legged OAuth 2.0 flow's starting point.
 	case integrations.OAuthDefault:
 		if err := h.saveActor(r, vsid); err != nil {

--- a/integrations/linear/save.go
+++ b/integrations/linear/save.go
@@ -86,7 +86,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 		}
 		urlPath, err := c.FinalURL()
 		if err != nil {
-			l.Error("failed to construct final OAuth URL", zap.Error(err))
+			l.Error("failed to construct final URL", zap.Error(err))
 			c.AbortServerError("save connection: bad redirect URL")
 			return
 		}

--- a/integrations/linear/server.go
+++ b/integrations/linear/server.go
@@ -1,10 +1,9 @@
 package linear
 
 import (
-	"net/http"
-
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/web/static"
@@ -12,17 +11,12 @@ import (
 
 // Start initializes all the HTTP handlers of the Linear integration. This
 // includes connection UIs, connection initialization webhooks, and event webhooks.
-func Start(l *zap.Logger, muxes *muxes.Muxes, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.DispatchFunc) {
-	// Connection UI for authenticated AutoKitteh users (user authentication
-	// isn't required, but it makes no sense to create a connection without it).
-	muxes.Auth.Handle("GET /linear/", http.FileServer(http.FS(static.LinearWebContent)))
+func Start(l *zap.Logger, m *muxes.Muxes, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.DispatchFunc) {
+	common.ServeStaticUI(m, desc, static.LinearWebContent)
 
-	// // Connection initialization webhooks save connection variables (e.g. auth and
-	// // metadata), which requires an authenticated user context for database access.
 	h := newHTTPHandler(l, v, o, d)
-	muxes.Auth.HandleFunc("POST /linear/save", h.handleSave)
-	muxes.Auth.HandleFunc("GET /linear/save", h.handleSave)
-	muxes.Auth.HandleFunc("GET /linear/oauth", h.handleOAuth)
+	common.RegisterSaveHandler(m, desc, h.handleSave)
+	common.RegisterOAuthHandler(m, desc, h.handleOAuth)
 
 	// TODO: Event webhooks (no AutoKitteh user authentication by definition, because
 	// these asynchronous requests are sent to us by third-party services).

--- a/integrations/linear/vars.go
+++ b/integrations/linear/vars.go
@@ -31,8 +31,7 @@ func newOAuthData(t *oauth2.Token) oauthData {
 	}
 }
 
-// privateOAuth contains the user-provided details of
-// a private Linear OAuth 2.0 app.
+// privateOAuth contains the user-provided details of a private Linear OAuth 2.0 app.
 type privateOAuth struct {
 	ClientID      string `var:"private_client_id"`
 	ClientSecret  string `var:"private_client_secret,secret"`

--- a/integrations/microsoft/save.go
+++ b/integrations/microsoft/save.go
@@ -53,7 +53,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 	authType := h.saveAuthType(r.Context(), vsid, r.FormValue("auth_type"))
 
 	switch authType {
-	// Use the AutoKitteh's server's default Microsoft OAuth 2.0 app, i.e.
+	// Use the AutoKitteh server's default Microsoft OAuth 2.0 app, i.e.
 	// immediately redirect to the 3-legged OAuth 2.0 flow's starting point.
 	case integrations.OAuthDefault:
 		startOAuth(w, r, c, l)
@@ -78,7 +78,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 		}
 		urlPath, err := c.FinalURL()
 		if err != nil {
-			l.Error("failed to construct final OAuth URL", zap.Error(err))
+			l.Error("failed to construct final URL", zap.Error(err))
 			c.AbortServerError("save connection: bad redirect URL")
 			return
 		}
@@ -101,7 +101,7 @@ func (h handler) saveAuthType(ctx context.Context, vsid sdktypes.VarScopeID, aut
 }
 
 // savePrivateApp saves the user-provided details of a private
-// Microsoft OAuth 2.0 or daemon app as connection variables.
+// Microsoft OAuth 2.0 app or daemon app as connection variables.
 func (h handler) savePrivateApp(r *http.Request, i sdktypes.Integration, cid sdktypes.ConnectionID) error {
 	tenantID := r.FormValue("tenant_id")
 	if tenantID == "" {

--- a/integrations/twilio/server.go
+++ b/integrations/twilio/server.go
@@ -1,10 +1,9 @@
 package twilio
 
 import (
-	"net/http"
-
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/twilio/webhooks"
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
@@ -13,19 +12,12 @@ import (
 
 // Start initializes all the HTTP handlers of the Twilio integration.
 // This includes connection UIs, initialization webhooks, and event webhooks.
-func Start(l *zap.Logger, muxes *muxes.Muxes, v sdkservices.Vars, d sdkservices.DispatchFunc) {
+func Start(l *zap.Logger, m *muxes.Muxes, v sdkservices.Vars, d sdkservices.DispatchFunc) {
+	common.ServeStaticUI(m, desc, static.TwilioWebContent)
+
 	h := webhooks.NewHandler(l, v, d, "twilio", desc)
-
-	// Connection UI.
-	uiPath := "GET " + desc.ConnectionURL().Path + "/"
-	muxes.NoAuth.Handle(uiPath, http.FileServer(http.FS(static.TwilioWebContent)))
-
-	// Init webhooks save connection vars (via "c.Finalize" calls), so they need
-	// to have an authenticated user context, so the DB layer won't reject them.
-	// For this purpose, init webhooks are managed by the "auth" mux, which passes
-	// through AutoKitteh's auth middleware to extract the user ID from a cookie.
-	muxes.Auth.HandleFunc(webhooks.AuthPath, h.HandleAuth)
+	common.RegisterSaveHandler(m, desc, h.HandleAuth)
 
 	// Event webhook (unauthenticated by definition).
-	muxes.NoAuth.HandleFunc(webhooks.MessagePath, h.HandleMessage)
+	m.NoAuth.HandleFunc(webhooks.MessagePath, h.HandleMessage)
 }

--- a/integrations/zoom/server.go
+++ b/integrations/zoom/server.go
@@ -1,10 +1,9 @@
 package zoom
 
 import (
-	"net/http"
-
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/web/static"
@@ -12,17 +11,12 @@ import (
 
 // Start initializes all the HTTP handlers of all the Zoom integrations. This
 // includes connection UIs, connection initialization webhooks, and event webhooks.
-func Start(l *zap.Logger, muxes *muxes.Muxes, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.DispatchFunc) {
-	// Connection UI for authenticated AutoKitteh users (user authentication
-	// isn't required, but it makes no sense to create a connection without it).
-	muxes.Auth.Handle("GET /zoom/", http.FileServer(http.FS(static.ZoomWebContent)))
+func Start(l *zap.Logger, m *muxes.Muxes, v sdkservices.Vars, o sdkservices.OAuth, d sdkservices.DispatchFunc) {
+	common.ServeStaticUI(m, desc, static.ZoomWebContent)
 
-	// Connection initialization webhooks save connection variables (e.g. auth and
-	// metadata), which requires an authenticated user context for database access.
 	h := newHTTPHandler(l, v, o, d)
-	muxes.Auth.HandleFunc("POST /zoom/save", h.handleSave)
-	muxes.Auth.HandleFunc("GET /zoom/save", h.handleSave)
-	muxes.Auth.HandleFunc("GET /zoom/oauth", h.handleOAuth)
+	common.RegisterSaveHandler(m, desc, h.handleSave)
+	common.RegisterOAuthHandler(m, desc, h.handleOAuth)
 
 	// TODO: Event webhooks (no AutoKitteh user authentication by definition, because
 	// these asynchronous requests are sent to us by third-party services).

--- a/web/static/height/form.js
+++ b/web/static/height/form.js
@@ -19,17 +19,13 @@ document.getElementById("authType").addEventListener("change", function () {
   document.getElementById("clientSecret").disabled = !isOauthPrivate;
 
   const apiKeySection = document.getElementById("apiKeySection");
+  const submitButton = document.getElementById("submit");
   if (isApiKey) {
     apiKeySection.classList.remove("hidden");
-  } else {
-    apiKeySection.classList.add("hidden");
-  }
-  document.getElementById("apiKey").disabled = !isApiKey;
-
-  const submitButton = document.getElementById("submit");
-  if (this.value === "apiKey") {
     submitButton.textContent = "Save Connection";
   } else {
+    apiKeySection.classList.add("hidden");
     submitButton.textContent = "Start OAuth Flow";
   }
+  document.getElementById("apiKey").disabled = !isApiKey;
 });

--- a/web/static/linear/form.js
+++ b/web/static/linear/form.js
@@ -28,17 +28,13 @@ document.getElementById("authType").addEventListener("change", function () {
   document.getElementById("webhookSecret").disabled = !isOauthPrivate;
 
   const apiKeySection = document.getElementById("apiKeySection");
+  const submitButton = document.getElementById("submit");
   if (isApiKey) {
     apiKeySection.classList.remove("hidden");
-  } else {
-    apiKeySection.classList.add("hidden");
-  }
-  document.getElementById("apiKey").disabled = !isApiKey;
-
-  const submitButton = document.getElementById("submit");
-  if (this.value === "apiKey") {
     submitButton.textContent = "Save Connection";
   } else {
+    apiKeySection.classList.add("hidden");
     submitButton.textContent = "Start OAuth Flow";
   }
+  document.getElementById("apiKey").disabled = !isApiKey;
 });

--- a/web/static/microsoft/form.js
+++ b/web/static/microsoft/form.js
@@ -7,6 +7,8 @@ document.getElementById("origin").value = urlParams.get("origin") ?? "";
 // Show/hide fields based on the selected auth type.
 document.getElementById("authType").addEventListener("change", function () {
   const isDefaultApp = this.value === "oauthDefault";
+  const isOauthPrivate = this.value === "oauthPrivate";
+
   const privateAppSection = document.getElementById("privateAppSection");
   if (isDefaultApp) {
     privateAppSection.classList.add("hidden");
@@ -18,9 +20,9 @@ document.getElementById("authType").addEventListener("change", function () {
   document.getElementById("tenantId").disabled = isDefaultApp;
 
   const submitButton = document.getElementById("submit");
-  if (this.value === "daemonApp") {
-    submitButton.textContent = "Save Connection";
-  } else {
+  if (isDefaultApp || isOauthPrivate) {
     submitButton.textContent = "Start OAuth Flow";
+  } else {
+    submitButton.textContent = "Save Connection";
   }
 });

--- a/web/static/microsoft/teams/form.js
+++ b/web/static/microsoft/teams/form.js
@@ -7,6 +7,8 @@ document.getElementById("origin").value = urlParams.get("origin") ?? "";
 // Show/hide fields based on the selected auth type.
 document.getElementById("authType").addEventListener("change", function () {
   const isDefaultApp = this.value === "oauthDefault";
+  const isOauthPrivate = this.value === "oauthPrivate";
+
   const privateAppSection = document.getElementById("privateAppSection");
   if (isDefaultApp) {
     privateAppSection.classList.add("hidden");
@@ -18,9 +20,9 @@ document.getElementById("authType").addEventListener("change", function () {
   document.getElementById("tenantId").disabled = isDefaultApp;
 
   const submitButton = document.getElementById("submit");
-  if (this.value === "daemonApp") {
-    submitButton.textContent = "Save Connection";
-  } else {
+  if (isDefaultApp || isOauthPrivate) {
     submitButton.textContent = "Start OAuth Flow";
+  } else {
+    submitButton.textContent = "Save Connection";
   }
 });


### PR DESCRIPTION
New reusable functions to register UI/save/OAuth webhook handlers in `integrations/common/server.go` - mostly for new-style integrations, but not just.

Most of the PR is tweaks related to that (using these new functions), or cosmetic tweaks (e.g. rename `muxes *muxes.Muxes` variable to `m` to be more idiomatic about Go var naming).