### PR TITLE
fix(zoom): oauth flow

### DIFF
--- a/internal/backend/oauth/oauth.go
+++ b/internal/backend/oauth/oauth.go
@@ -530,17 +530,7 @@ func New(l *zap.Logger, vars sdkservices.Vars) sdkservices.OAuth {
 					DeviceAuthURL: "https://zoom.us/oauth/devicecode",
 				},
 				RedirectURL: redirectURL + "zoom",
-				// https://developers.zoom.us/docs/integrations/oauth-scopes/
-				Scopes: []string{
-					"calendar:write",
-					"contact:read",
-					"meeting:write",
-					"meeting_summary:read",
-					"recording:read",
-					"scheduler:write",
-					"user:read",
-					"whiteboard:read",
-				},
+				Scopes:      []string{},
 			},
 		},
 


### PR DESCRIPTION
The original scopes I specified were legacy-style, which is no longer allowed for new apps. Need to use only new granular scopes.

Anyway, passing an empty list is fine because it uses the apps default scopes, and it's actually preferable because there are 100+ granular scopes that we currently use.

Tested that an OAuth 3-legged flow really works, documented in https://docs.autokitteh.com/integrations/zoom

Refs: INT-241