### PR TITLE
fix: redirect from Github marketplace

### DIFF
--- a/internal/backend/oauth/webhook.go
+++ b/internal/backend/oauth/webhook.go
@@ -84,6 +84,10 @@ func (s *svc) exchange(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if handled := s.handleGitHubMarketplace(w, r, intg, state); handled {
+		return
+	}
+
 	// Ensure the state parameter is well-formed.
 	sub := regexp.MustCompile(`^(.+)_([a-z]+)$`).FindStringSubmatch(state)
 	if len(sub) != 3 {
@@ -154,6 +158,15 @@ func (s *svc) exchange(w http.ResponseWriter, r *http.Request) {
 	}
 
 	redirect(w, r, intg, sub[1], sub[2], "oauth", oauthData)
+}
+
+func (s *svc) handleGitHubMarketplace(w http.ResponseWriter, r *http.Request, intg string, state string) bool {
+	if intg == "github" && state == "" {
+		// User came from Marketplace (no AK-generated state)
+		http.Redirect(w, r, "https://github.com/settings/installations/"+r.FormValue("installation_id"), http.StatusFound)
+		return true
+	}
+	return false
 }
 
 func abort(w http.ResponseWriter, r *http.Request, intg, cid, origin, err string) {

--- a/internal/backend/oauth/webhook.go
+++ b/internal/backend/oauth/webhook.go
@@ -87,7 +87,7 @@ func (s *svc) exchange(w http.ResponseWriter, r *http.Request) {
 
 	handled, err := s.redirectToGitHub(w, r, intg, state)
 	if err != nil {
-		l.Error("Failed to redirect to GitHub", zap.Error(err))
+		l.Warn("Failed to redirect to GitHub", zap.Error(err))
 		return
 	}
 	if handled {


### PR DESCRIPTION
Marketplace Installation Flow Enhancement

- Added handleGitHubMarketplace function to handle direct app installations from GitHub Marketplace
- Redirects users to GitHub app installations page after successful installation
- Tested functionality using ngrok for local development

The redirect currently points to `/settings/installations/{installation_id}`. We could alternatively redirect to `/apps/installations/{installation_id}` to maintain marketplace context.

Refs: INT-172