### PR TITLE
feat: Add noctx linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - gocritic
     - intrange
     - loggercheck
+    - noctx
     - nosprintfhostport
     - perfsprint
     - unconvert

--- a/integrations/asana/client.go
+++ b/integrations/asana/client.go
@@ -81,7 +81,7 @@ func connTest(i *integration) sdkintegrations.OptFn {
 			return sdktypes.InvalidStatus, err
 		}
 
-		req, err := http.NewRequest(http.MethodGet, "https://app.asana.com/api/1.0/users/me", nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://app.asana.com/api/1.0/users/me", nil)
 		if err != nil {
 			return sdktypes.InvalidStatus, err
 		}

--- a/integrations/asana/save.go
+++ b/integrations/asana/save.go
@@ -46,7 +46,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Test the PAT's usability
-	req, err := http.NewRequest(http.MethodGet, "https://app.asana.com/api/1.0/users/me", nil)
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, "https://app.asana.com/api/1.0/users/me", nil)
 	if err != nil {
 		l.Error("Failed to create HTTP request", zap.Error(err))
 		c.AbortServerError("request creation error")

--- a/integrations/atlassian/confluence/client.go
+++ b/integrations/atlassian/confluence/client.go
@@ -100,7 +100,7 @@ func connTest(i *integration) sdkintegrations.OptFn {
 				return sdktypes.NewStatus(sdktypes.StatusCodeError, err.Error()), nil
 			}
 		case integrations.APIToken:
-			err := apiTokenConnTest(nil, vs)
+			err := apiTokenConnTest(ctx, nil, vs)
 			if err != nil {
 				return sdktypes.NewStatus(sdktypes.StatusCodeError, err.Error()), nil
 			}
@@ -130,13 +130,13 @@ func oauthConnTest(vs sdktypes.Vars) error {
 // apiTokenConnTest verifies the connection for API key authentication.
 // It sends a request to the API to confirm credentials and access.
 // https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#about
-func apiTokenConnTest(l *zap.Logger, vs sdktypes.Vars) error {
+func apiTokenConnTest(ctx context.Context, l *zap.Logger, vs sdktypes.Vars) error {
 	baseURL := vs.Get(baseURL).Value()
 	email := vs.Get(email).Value()
 	token := vs.Get(token).Value()
 
 	u := baseURL + "/wiki/rest/api/user/current"
-	req, err := http.NewRequest(http.MethodGet, u, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		logWarnIfNotNil(l, "Failed to construct HTTP request for Confluence API token test", zap.Error(err))
 		return err

--- a/integrations/atlassian/confluence/save.go
+++ b/integrations/atlassian/confluence/save.go
@@ -72,13 +72,13 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 	for _, category := range eventCategories {
 		// Register a new webhook to receive, parse, and dispatch
 		// Confluence events, if there isn't one already.
-		id, ok := getWebhook(l, b, e, t, category)
+		id, ok := getWebhook(r.Context(), l, b, e, t, category)
 		if ok {
 			// TODO: In the future, when we're sure which events we want to
 			// subscribe to, uncomment this line and don't delete the webhook.
 			// initData = initData.Set(webhookID, fmt.Sprintf("%d", id), false)
 
-			if err := deleteWebhook(l, b, e, t, id); err != nil {
+			if err := deleteWebhook(r.Context(), l, b, e, t, id); err != nil {
 				l.Error("Failed to delete existing webhook", zap.Error(err))
 				c.AbortServerError("failed to delete existing webhook")
 				return
@@ -86,7 +86,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 		} // else {
 		var secret string
 		var err error
-		id, secret, err = registerWebhook(l, b, e, t, category)
+		id, secret, err = registerWebhook(r.Context(), l, b, e, t, category)
 		if err != nil {
 			l.Error("Failed to register webhook", zap.Error(err))
 			c.AbortServerError("failed to register webhook")

--- a/integrations/atlassian/jira/oauth.go
+++ b/integrations/atlassian/jira/oauth.go
@@ -89,15 +89,15 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	t := utc30Days()
-	id, ok := getWebhook(l, u, oauthToken.AccessToken)
+	id, ok := getWebhook(r.Context(), l, u, oauthToken.AccessToken)
 	if !ok {
-		id, ok = registerWebhook(l, u, oauthToken.AccessToken)
+		id, ok = registerWebhook(r.Context(), l, u, oauthToken.AccessToken)
 		if !ok {
 			c.AbortServerError("failed to register webhook")
 			return
 		}
 	} else {
-		t, ok = ExtendWebhookLife(l, u, oauthToken.AccessToken, id)
+		t, ok = ExtendWebhookLife(r.Context(), l, u, oauthToken.AccessToken, id)
 		if !ok {
 			c.AbortServerError("failed to extend webhook life")
 			return

--- a/integrations/auth0/oauth.go
+++ b/integrations/auth0/oauth.go
@@ -71,7 +71,7 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Tests OAuth0's Management API.
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s/api/v2/roles", d), nil)
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, fmt.Sprintf("https://%s/api/v2/roles", d), nil)
 	if err != nil {
 		l.Error("Failed to create HTTP request", zap.Error(err))
 		c.AbortServerError("request creation error")

--- a/integrations/google/connections/connections.go
+++ b/integrations/google/connections/connections.go
@@ -81,10 +81,16 @@ func ConnTest(cvars sdkservices.Vars) sdkintegrations.OptFn {
 		}
 
 		// Make a simple API call to verify credentials.
-		resp, err := client.Get("https://www.googleapis.com/oauth2/v2/userinfo?alt=json")
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://www.googleapis.com/oauth2/v2/userinfo?alt=json", nil)
 		if err != nil {
 			return sdktypes.NewStatus(sdktypes.StatusCodeError, err.Error()), nil
 		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return sdktypes.NewStatus(sdktypes.StatusCodeError, err.Error()), nil
+		}
+
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {

--- a/integrations/hubspot/client.go
+++ b/integrations/hubspot/client.go
@@ -79,7 +79,7 @@ func connTest(i *integration) sdkintegrations.OptFn {
 
 		token := vs.GetValueByString("oauth_RefreshToken")
 		url := "https://api.hubapi.com/oauth/v1/refresh-tokens/" + token
-		req, err := http.NewRequest(http.MethodGet, url, nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			return sdktypes.NewStatus(sdktypes.StatusCodeError, err.Error()), nil
 		}

--- a/integrations/hubspot/oauth.go
+++ b/integrations/hubspot/oauth.go
@@ -49,7 +49,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Test the OAuth token's usability and get authoritative installation details.
-	req, err := http.NewRequest(http.MethodGet, "https://api.hubapi.com/crm/v3/owners/", nil)
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, "https://api.hubapi.com/crm/v3/owners/", nil)
 	if err != nil {
 		l.Error("Failed to create HTTP request", zap.Error(err))
 		c.AbortServerError("request creation error")

--- a/internal/backend/auth/authhttpmiddleware/authmiddleware_test.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware_test.go
@@ -54,7 +54,7 @@ func assertCalledWithUser(t *testing.T, expected sdktypes.UserID, given *sdktype
 }
 
 func newRequest(authHeader string, cookies []*http.Cookie) *http.Request {
-	req := kittehs.Must1(http.NewRequest(http.MethodGet, "/", nil))
+	req := kittehs.Must1(http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
 
 	if authHeader != "" {
 		req.Header.Set("Authorization", authHeader)

--- a/internal/backend/cron/jira.go
+++ b/internal/backend/cron/jira.go
@@ -171,7 +171,7 @@ func (cr *Cron) renewJiraEventWatchActivity(ctx context.Context, cid sdktypes.Co
 		)
 	}
 
-	newExp, ok := jira.ExtendWebhookLife(l, u, t.AccessToken, id)
+	newExp, ok := jira.ExtendWebhookLife(ctx, l, u, t.AccessToken, id)
 	if !ok {
 		l.Error("failed to renew Jira event watch")
 		return fmt.Errorf("failed to renew Jira event watch: %s", cid.String())

--- a/internal/backend/usagereporter/dataposter.go
+++ b/internal/backend/usagereporter/dataposter.go
@@ -2,12 +2,13 @@ package usagereporter
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 )
 
 func post(endpoint string, data []byte) error {
-	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(data))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("constructing request: %w", err)
 	}


### PR DESCRIPTION
Added noctx linter and fixed context propagation issues

Changes:
- Added noctx linter to golangci.yaml to detect missing context propagation in HTTP requests
- Fixed context propagation in integrations (Asana, Jira, Google, Auth0, HubSpot) by:
  - Using http.NewRequestWithContext instead of http.NewRequest
  - Propagating context from HTTP handlers using r.Context()
  - Replacing http.Client.Get with proper context-aware requests
- Added context propagation in backend services where needed using context.Background()

Testing:
- Manually tested by creating connections for affected integrations
- Verified connection tests (connTest) work correctly with new context changes
- Would appreciate guidance on testing strategy for backend context changes, specifically for internal/backend/usagereporter/dataposter.go if needed

ref: INT-191
