### PR TITLE
add indexes on events / sessions

### DIFF
--- a/internal/backend/db/dbgorm/gorm_test.go
+++ b/internal/backend/db/dbgorm/gorm_test.go
@@ -424,11 +424,11 @@ func (f *dbFixture) newConnection(args ...any) scheme.Connection {
 func (f *dbFixture) newEvent(args ...any) scheme.Event {
 	f.eventSequence++
 	e := scheme.Event{
-		EventID: newTestID(),
-		Base:    scheme.Base{CreatedAt: now},
-		Seq:     uint64(f.eventSequence),
-		Data:    kittehs.Must1(json.Marshal(struct{}{})),
-		Memo:    kittehs.Must1(json.Marshal(struct{}{})),
+		EventID:   newTestID(),
+		CreatedAt: now,
+		Seq:       uint64(f.eventSequence),
+		Data:      kittehs.Must1(json.Marshal(struct{}{})),
+		Memo:      kittehs.Must1(json.Marshal(struct{}{})),
 	}
 	for _, a := range args {
 		switch a := a.(type) {

--- a/internal/backend/db/dbgorm/scheme/records.go
+++ b/internal/backend/db/dbgorm/scheme/records.go
@@ -209,7 +209,7 @@ func ParseEvent(e Event) (sdktypes.Event, error) {
 		EventType:     e.EventType,
 		Data:          kittehs.TransformMapValues(data, sdktypes.ToProto),
 		Memo:          memo,
-		CreatedAt:     timestamppb.New(e.CreatedAt),
+		CreatedAt:     timestamppb.New(e.Base.CreatedAt),
 		Seq:           e.Seq,
 		DestinationId: did.String(),
 	})
@@ -380,7 +380,7 @@ func ParseSession(s Session) (sdktypes.Session, error) {
 		EventId:      sdktypes.NewIDFromUUIDPtr[sdktypes.EventID](s.EventID).String(),
 		Entrypoint:   ep.ToProto(),
 		Inputs:       kittehs.TransformMapValues(inputs, sdktypes.ToProto),
-		CreatedAt:    timestamppb.New(s.CreatedAt),
+		CreatedAt:    timestamppb.New(s.Base.CreatedAt),
 		UpdatedAt:    timestamppb.New(s.UpdatedAt),
 		State:        sessionsv1.SessionStateType(s.CurrentStateType),
 		Memo:         memo,

--- a/internal/backend/db/dbgorm/scheme/records.go
+++ b/internal/backend/db/dbgorm/scheme/records.go
@@ -174,6 +174,9 @@ type Event struct {
 	Trigger    *Trigger    `gorm:"constraint:OnDelete:SET NULL"`
 
 	Project *Project
+
+	// Redeclare here to create an index on created_at for sessions specifically
+	CreatedAt time.Time `gorm:"index"`
 }
 
 func (Event) IDFieldName() string { return "event_id" }
@@ -342,6 +345,9 @@ type Session struct {
 	Deployment *Deployment
 	Project    *Project
 	Event      *Event `gorm:"references:EventID;constraint:OnDelete:SET NULL"`
+
+	// Redeclare here to create an index on created_at for sessions specifically
+	CreatedAt time.Time `gorm:"index"`
 }
 
 func (Session) IDFieldName() string { return "session_id" }

--- a/migrations/postgres/20250212092300_add-created-at-index-for-sessions-and-events.sql
+++ b/migrations/postgres/20250212092300_add-created-at-index-for-sessions-and-events.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- create index "idx_events_created_at" to table: "events"
+CREATE INDEX "idx_events_created_at" ON "events" ("created_at");
+-- create index "idx_sessions_created_at" to table: "sessions"
+CREATE INDEX "idx_sessions_created_at" ON "sessions" ("created_at");
+
+-- +goose Down
+-- reverse: create index "idx_sessions_created_at" to table: "sessions"
+DROP INDEX "idx_sessions_created_at";
+-- reverse: create index "idx_events_created_at" to table: "events"
+DROP INDEX "idx_events_created_at";

--- a/migrations/postgres/atlas.sum
+++ b/migrations/postgres/atlas.sum
@@ -1,4 +1,4 @@
-h1:8HW6Er1iZ+Mv1BZUUjlJdk8NgVuFH1RJ268yO+Pzjig=
+h1:s6F87AdYgsTv/xSg+eMxGl+RePrwbWmFiqF9K5zQyFw=
 20240704121932_baseline.sql h1:1JS9FYe08Ef0wTpJIeeL4wIqHc8E/RXhuqmTI/FwkzY=
 20240714051207_no-db-user.sql h1:tx0AwepNeeL/XWD74sLRGwisrkNs4lyH/H4BG/663FQ=
 20240727114921_project-not-nil-name.sql h1:ZG3tDLzQSxd81S4BDe/IOMktltkurwyuFwu5gkqQvrA=
@@ -23,3 +23,4 @@ h1:8HW6Er1iZ+Mv1BZUUjlJdk8NgVuFH1RJ268yO+Pzjig=
 20250115043311_roles.sql h1:2vOyiwmhONipyQ+KwGu4kq0ZMpGPiwzCZbs8oW4YANs=
 20250120101358_events-sessions-hard-delete.sql h1:MszF4KAzves68R2sHxS1KmZ7gkNFrPNdvfjgS76qC0Y=
 20250212061806_kill-old-fields.sql h1:uOY1KWJ8C73tWmC70UyRnICeWlCrSJBcgoz3J7Sd+Cw=
+20250212092300_add-created-at-index-for-sessions-and-events.sql h1:4pFid3Qyv+kRivExZ32rTAqyYOKXT68wfv2MrqjmRvg=

--- a/migrations/sqlite/20250212092243_add-created-at-index-for-sessions-and-events.sql
+++ b/migrations/sqlite/20250212092243_add-created-at-index-for-sessions-and-events.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- create index "idx_events_created_at" to table: "events"
+CREATE INDEX `idx_events_created_at` ON `events` (`created_at`);
+-- create index "idx_sessions_created_at" to table: "sessions"
+CREATE INDEX `idx_sessions_created_at` ON `sessions` (`created_at`);
+
+-- +goose Down
+-- reverse: create index "idx_sessions_created_at" to table: "sessions"
+DROP INDEX `idx_sessions_created_at`;
+-- reverse: create index "idx_events_created_at" to table: "events"
+DROP INDEX `idx_events_created_at`;

--- a/migrations/sqlite/atlas.sum
+++ b/migrations/sqlite/atlas.sum
@@ -1,4 +1,4 @@
-h1:MiapDRtyl56wvmAhS4pZML3dquFgl0I/4XHAKHb3yBE=
+h1:0LU9sTbVHz+8upJ1C/tmasiLKgD/0qEUAkHYxhn7Z2Y=
 20240704121927_baseline.sql h1:Urgmm304lCno+ou4WguUjFGiqu2PYoIOlswHpSL1lRg=
 20240714051159_no-db-user.sql h1:FRReTH5AzKrGU3qp0laWWzkgiBc5693KZIpgrjY81d8=
 20240727114913_project-not-nil-name.sql h1:tRZh+O1yx/QZuytlirQJA0f9Ga/m3FDNM9yE5eJDv1I=
@@ -23,3 +23,4 @@ h1:MiapDRtyl56wvmAhS4pZML3dquFgl0I/4XHAKHb3yBE=
 20250115043308_roles.sql h1:xsAO5IFQSyqwa1UFKfbbQXSj8BbyJxvyiqPKobixibE=
 20250120101352_events-sessions-hard-delete.sql h1:jRm2MISL4eqIeL3e0tr7dmRwYbGG9xS9XFZMUaPaNTY=
 20250212061802_kill-old-fields.sql h1:OVNT5Zr2+mgmmwEpuMoGJIHAyvbiXogYVkqDtOiTWRk=
+20250212092243_add-created-at-index-for-sessions-and-events.sql h1:/lm3X5+QOtq/FLEId/N53cR0juY9g6ukWTk9MMllDLY=


### PR DESCRIPTION
we need to query events and sessions by created_at field so we can delete them in a fast way without scanning the entire table