### PR TITLE
refactor(salesforce): retrieve `instance_url` from token exchange response instead of user input

### DIFF
--- a/integrations/salesforce/save.go
+++ b/integrations/salesforce/save.go
@@ -79,11 +79,10 @@ func (h handler) savePrivateOAuth(r *http.Request, vsid sdktypes.VarScopeID) err
 	app := privateOAuth{
 		ClientID:     r.FormValue("client_id"),
 		ClientSecret: r.FormValue("client_secret"),
-		InstanceURL:  r.FormValue("instance_url"),
 	}
 
 	// Sanity check: all the required details were provided, and are valid.
-	if app.ClientID == "" || app.ClientSecret == "" || app.InstanceURL == "" {
+	if app.ClientID == "" || app.ClientSecret == "" {
 		return errors.New("missing private OAuth 2.0 details")
 	}
 

--- a/integrations/salesforce/vars.go
+++ b/integrations/salesforce/vars.go
@@ -31,5 +31,4 @@ func newOAuthData(t *oauth2.Token) oauthData {
 type privateOAuth struct {
 	ClientID     string `var:"private_client_id"`
 	ClientSecret string `var:"private_client_secret,secret"`
-	InstanceURL  string `var:"private_instance_url"`
 }

--- a/internal/backend/oauth/oauth.go
+++ b/internal/backend/oauth/oauth.go
@@ -758,6 +758,22 @@ func (o *oauth) Exchange(ctx context.Context, integration string, cid sdktypes.C
 	if err != nil {
 		return nil, fmt.Errorf("failed to exchange code: %w", err)
 	}
+
+	if integration == "salesforce" {
+		instanceURL, ok := token.Extra("instance_url").(string)
+		if !ok {
+			return nil, errors.New("instance_url not found in token")
+		}
+
+		sid := sdktypes.NewVarScopeID(cid)
+		v := sdktypes.NewVar(sdktypes.NewSymbol("private_instance_url")).WithScopeID(sid).SetValue(instanceURL)
+
+		if err := o.vars.Set(authcontext.SetAuthnSystemUser(ctx), v); err != nil {
+			return nil, err
+		}
+
+	}
+
 	return token, nil
 }
 

--- a/internal/backend/oauth/oauth.go
+++ b/internal/backend/oauth/oauth.go
@@ -759,21 +759,6 @@ func (o *oauth) Exchange(ctx context.Context, integration string, cid sdktypes.C
 		return nil, fmt.Errorf("failed to exchange code: %w", err)
 	}
 
-	if integration == "salesforce" {
-		instanceURL, ok := token.Extra("instance_url").(string)
-		if !ok {
-			return nil, errors.New("instance_url not found in token")
-		}
-
-		sid := sdktypes.NewVarScopeID(cid)
-		v := sdktypes.NewVar(sdktypes.NewSymbol("private_instance_url")).WithScopeID(sid).SetValue(instanceURL)
-
-		if err := o.vars.Set(authcontext.SetAuthnSystemUser(ctx), v); err != nil {
-			return nil, err
-		}
-
-	}
-
 	return token, nil
 }
 

--- a/internal/backend/oauth/webhook.go
+++ b/internal/backend/oauth/webhook.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"golang.org/x/oauth2"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
@@ -157,7 +158,7 @@ func (s *svc) exchange(w http.ResponseWriter, r *http.Request) {
 	l.Info("OAuth token exchange successful")
 
 	// Pass the OAuth data back to the originating integration.
-	oauthData, err := sdkintegrations.OAuthData{Token: token, Params: r.URL.Query()}.Encode()
+	oauthData, err := sdkintegrations.OAuthData{Token: token, Params: r.URL.Query(), Extra: getExtra(token)}.Encode()
 	if err != nil {
 		abort(w, r, intg, sub[1], sub[2], "OAuth token encoding error")
 		return
@@ -208,4 +209,12 @@ func transformState(state string) string {
 		return state
 	}
 	return "con_" + state
+}
+
+func getExtra(token *oauth2.Token) map[string]interface{} {
+	extra := make(map[string]interface{})
+	if v := token.Extra("instance_url"); v != nil {
+		extra["instance_url"] = v // salesforce
+	}
+	return extra
 }

--- a/runtimes/pythonrt/py-sdk/autokitteh/salesforce.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/salesforce.py
@@ -25,7 +25,7 @@ def salesforce_client(connection: str, **kwargs) -> Salesforce:
     check_connection_name(connection)
 
     token = os.getenv(connection + "__oauth_access_token")
-    instance_url = os.getenv(connection + "__private_instance_url")
+    instance_url = os.getenv(connection + "__instance_url")
     if not token or not instance_url:
         raise ConnectionInitError(connection)
 

--- a/sdk/sdkintegrations/oauth.go
+++ b/sdk/sdkintegrations/oauth.go
@@ -12,6 +12,7 @@ import (
 type OAuthData struct {
 	Token  *oauth2.Token
 	Params url.Values
+	Extra  map[string]interface{}
 }
 
 func (d OAuthData) Encode() (string, error) { return kittehs.EncodeURLData(d) }

--- a/web/static/salesforce/index.html
+++ b/web/static/salesforce/index.html
@@ -80,11 +80,6 @@
             required
           />
         </div>
-
-        <div class="form-group">
-          <label for="instance_url">Instance URL <i>(required)</i></label>
-          <input type="text" name="instance_url" required />
-        </div>
       </div>
 
       <button type="submit" class="submit-btn" id="submit">


### PR DESCRIPTION
**testing**: successfully authenticated salesforce and ran a simple workflow using our python sdk