### PR TITLE
fix(history): properly decode activity data

### DIFF
--- a/internal/backend/cron/cron.go
+++ b/internal/backend/cron/cron.go
@@ -81,7 +81,7 @@ func (cr *Cron) Start(ctx context.Context, c sdkservices.Connections, v sdkservi
 	cr.oauth = o
 
 	// Configure a worker for the internal maintenance workflow.
-	w := temporalclient.NewWorker(cr.logger, cr.temporal.Temporal(), taskQueueName, cr.cfg.Worker)
+	w := temporalclient.NewWorker(cr.logger, cr.temporal.TemporalClient(), taskQueueName, cr.cfg.Worker)
 	if w == nil {
 		return nil
 	}
@@ -124,13 +124,13 @@ func (cr *Cron) Start(ctx context.Context, c sdkservices.Connections, v sdkservi
 }
 
 func (cr *Cron) scheduleAlreadyCreated(ctx context.Context) (client.ScheduleHandle, bool) {
-	h := cr.temporal.Temporal().ScheduleClient().GetHandle(ctx, scheduleID)
+	h := cr.temporal.TemporalClient().ScheduleClient().GetHandle(ctx, scheduleID)
 	_, err := h.Describe(ctx)
 	return h, err == nil
 }
 
 func (cr *Cron) createSchedule(ctx context.Context) error {
-	handle, err := cr.temporal.Temporal().ScheduleClient().Create(ctx, client.ScheduleOptions{
+	handle, err := cr.temporal.TemporalClient().ScheduleClient().Create(ctx, client.ScheduleOptions{
 		ID:      scheduleID,
 		Spec:    scheduleSpec,
 		Action:  scheduleAction,

--- a/internal/backend/dispatcher/dispatcher.go
+++ b/internal/backend/dispatcher/dispatcher.go
@@ -28,7 +28,7 @@ type Svcs struct {
 	fx.In
 
 	db.DB
-	temporalclient.LazyTemporalClient
+	Temporal temporalclient.Client
 
 	sdkservices.Connections
 	sdkservices.Deployments
@@ -75,7 +75,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, event sdktypes.Event, opts *s
 		"process_id":       fixtures.ProcessID(),
 	}
 
-	r, err := d.svcs.LazyTemporalClient().ExecuteWorkflow(
+	r, err := d.svcs.Temporal.TemporalClient().ExecuteWorkflow(
 		ctx,
 		d.cfg.Workflow.ToStartWorkflowOptions(
 			taskQueueName,
@@ -132,7 +132,7 @@ func (d *Dispatcher) Redispatch(ctx context.Context, eventID sdktypes.EventID, o
 }
 
 func (d *Dispatcher) Start(context.Context) error {
-	w := temporalclient.NewWorker(d.sl.Desugar(), d.svcs.LazyTemporalClient(), taskQueueName, d.cfg.Worker)
+	w := temporalclient.NewWorker(d.sl.Desugar(), d.svcs.Temporal.TemporalClient(), taskQueueName, d.cfg.Worker)
 	if w == nil {
 		return nil
 	}

--- a/internal/backend/sessions/sessioncalls/calls.go
+++ b/internal/backend/sessions/sessioncalls/calls.go
@@ -76,8 +76,9 @@ func New(l *zap.Logger, config Config, svcs *sessionsvcs.Svcs) Calls {
 }
 
 func (cs *calls) StartWorkers(ctx context.Context) error {
-	cs.generalWorker = temporalclient.NewWorker(cs.l.Named("sessionscallsworker"), cs.svcs.Temporal(), generalTaskQueueName, cs.config.GeneralWorker)
-	cs.uniqueWorker = temporalclient.NewWorker(cs.l.Named("sessionscallsworker"), cs.svcs.Temporal(), uniqueWorkerCallTaskQueueName(), cs.config.UniqueWorker)
+	tc := cs.svcs.Temporal.TemporalClient()
+	cs.generalWorker = temporalclient.NewWorker(cs.l.Named("sessionscallsworker"), tc, generalTaskQueueName, cs.config.GeneralWorker)
+	cs.uniqueWorker = temporalclient.NewWorker(cs.l.Named("sessionscallsworker"), tc, uniqueWorkerCallTaskQueueName(), cs.config.UniqueWorker)
 
 	cs.registerActivities()
 

--- a/internal/backend/sessions/sessionsvcs/svcs.go
+++ b/internal/backend/sessions/sessionsvcs/svcs.go
@@ -23,5 +23,5 @@ type Svcs struct {
 	Vars         sdkservices.Vars
 
 	RedisClient *redis.Client
-	Temporal    temporalclient.LazyTemporalClient
+	Temporal    temporalclient.Client
 }

--- a/internal/backend/sessions/sessionworkflows/activities.go
+++ b/internal/backend/sessions/sessionworkflows/activities.go
@@ -252,7 +252,7 @@ func (ws *workflows) terminateSessionWorkflow(wctx workflow.Context, params term
 }
 
 func (ws *workflows) terminateWorkflowActivity(ctx context.Context, sid sdktypes.SessionID, reason string) error {
-	err := ws.svcs.Temporal().TerminateWorkflow(ctx, workflowID(sid), "", reason)
+	err := ws.svcs.Temporal.TemporalClient().TerminateWorkflow(ctx, workflowID(sid), "", reason)
 	if err != nil {
 		// might happen multiple times for some reason, give it a chance to update the state later on.
 		var notFound *serviceerror.NotFound

--- a/internal/backend/sessions/sessionworkflows/workflows_test.go
+++ b/internal/backend/sessions/sessionworkflows/workflows_test.go
@@ -14,6 +14,7 @@ import (
 
 	"go.autokitteh.dev/autokitteh/internal/backend/db"
 	"go.autokitteh.dev/autokitteh/internal/backend/sessions/sessionsvcs"
+	"go.autokitteh.dev/autokitteh/internal/backend/temporalclient"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
@@ -38,6 +39,13 @@ func (m *mockDB) UpdateSessionState(ctx context.Context, sessionID sdktypes.Sess
 	args := m.Called(sessionID, state)
 	return args.Error(0)
 }
+
+type fakeTemporalClient struct {
+	temporalclient.Client
+	t client.Client
+}
+
+func (f fakeTemporalClient) Temporal() client.Client { return f.t }
 
 type mockTemporalClient struct {
 	client.Client
@@ -72,7 +80,7 @@ func setup(t *testing.T) (*workflows, *mockDB, *mockTemporalClient) {
 		l: zaptest.NewLogger(t),
 		svcs: &sessionsvcs.Svcs{
 			DB:       &db,
-			Temporal: func() client.Client { return &tc },
+			Temporal: fakeTemporalClient{t: &tc},
 		},
 	}
 

--- a/internal/backend/sessions/sessionworkflows/workflows_test.go
+++ b/internal/backend/sessions/sessionworkflows/workflows_test.go
@@ -45,7 +45,7 @@ type fakeTemporalClient struct {
 	t client.Client
 }
 
-func (f fakeTemporalClient) Temporal() client.Client { return f.t }
+func (f fakeTemporalClient) TemporalClient() client.Client { return f.t }
 
 type mockTemporalClient struct {
 	client.Client

--- a/internal/backend/svc/svc.go
+++ b/internal/backend/svc/svc.go
@@ -184,12 +184,12 @@ func makeFxOpts(cfg *Config, opts RunOptions) []fx.Option {
 		Component(
 			"temporalclient",
 			temporalclient.Configs,
-			fx.Provide(func(cfg *temporalclient.Config, z *zap.Logger) (temporalclient.Client, temporalclient.LazyTemporalClient, error) {
+			fx.Provide(func(cfg *temporalclient.Config, z *zap.Logger) (temporalclient.Client, error) {
 				if opts.TemporalClient == nil {
 					return temporalclient.New(cfg, z)
 				}
 
-				return temporalclient.NewFromClient(&cfg.Monitor, z, opts.TemporalClient)
+				return temporalclient.NewFromTemporalClient(&cfg.Monitor, z, opts.TemporalClient)
 			}),
 			fx.Invoke(func(lc fx.Lifecycle, c temporalclient.Client) {
 				HookOnStart(lc, c.Start)


### PR DESCRIPTION
- use temporal's data convertor instead of naively using json. this takes care of proper codec/encryption.
- get rid of LazyTemporalClient, just use the temporalclient.Client.TemporalClient instead. This is a mouthful and I hate it, if you have other naming suggestions, feel free and I'll take care of it in a future change.