### PR TITLE
refactor(integrations): tweaks across new-style integrations

### DIFF
--- a/integrations/common/vars.go
+++ b/integrations/common/vars.go
@@ -42,7 +42,7 @@ func EncodeOAuthData(t *oauth2.Token) OAuthData {
 // an error if the connection is not initialized or accessible.
 func ReadConnectionVars(ctx context.Context, vars sdkservices.Vars, cid sdktypes.ConnectionID) (sdktypes.Vars, sdktypes.Status, error) {
 	if !cid.IsValid() {
-		return nil, sdktypes.NewStatus(sdktypes.StatusCodeError, "Init required"), nil
+		return nil, sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 	}
 
 	vs, err := vars.Get(ctx, sdktypes.NewVarScopeID(cid))

--- a/integrations/height/checks.go
+++ b/integrations/height/checks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"go.autokitteh.dev/autokitteh/integrations"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
@@ -14,17 +15,12 @@ import (
 // ensures that the connection is at least theoretically usable.
 func status(v sdkservices.Vars) sdkintegrations.OptFn {
 	return sdkintegrations.WithConnectionStatus(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
-		if !cid.IsValid() {
-			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
+		vs, errStatus, err := common.ReadConnectionVars(ctx, v, cid)
+		if errStatus.IsValid() || err != nil {
+			return errStatus, err
 		}
 
-		vs, err := v.Get(ctx, sdktypes.NewVarScopeID(cid), authTypeVar)
-		if err != nil {
-			return sdktypes.InvalidStatus, err // This is abnormal.
-		}
-
-		authType := vs.GetValue(authTypeVar)
-		switch authType {
+		switch common.ReadAuthType(vs) {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
@@ -41,27 +37,23 @@ func status(v sdkservices.Vars) sdkintegrations.OptFn {
 // authentication credentials are valid and can be used to make API calls.
 func test(v sdkservices.Vars) sdkintegrations.OptFn {
 	return sdkintegrations.WithConnectionTest(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
-		if !cid.IsValid() {
-			return sdktypes.NewStatus(sdktypes.StatusCodeError, "Init required"), nil
+		vs, errStatus, err := common.ReadConnectionVars(ctx, v, cid)
+		if errStatus.IsValid() || err != nil {
+			return errStatus, err
 		}
 
-		vs, err := v.Get(ctx, sdktypes.NewVarScopeID(cid))
-		if err != nil {
-			return sdktypes.InvalidStatus, err // This is abnormal.
-		}
-
-		authType := vs.GetValue(authTypeVar)
-		switch authType {
+		switch common.ReadAuthType(vs) {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
 			// TODO(INT-235): Implement.
 		case integrations.APIKey:
-			// TODO: Implement.
+			// TODO(INT-235): Implement.
 		default:
 			return sdktypes.NewStatus(sdktypes.StatusCodeError, "Bad auth type"), nil
 		}
 
-		return sdktypes.NewStatus(sdktypes.StatusCodeOK, ""), nil
+		// TODO(INT-235): return sdktypes.NewStatus(sdktypes.StatusCodeOK, ""), nil
+		return sdktypes.NewStatus(sdktypes.StatusCodeError, "Not implemented"), nil
 	})
 }

--- a/integrations/height/oauth.go
+++ b/integrations/height/oauth.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
@@ -40,7 +41,7 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 	// https://developers.google.com/identity/protocols/oauth2/web-server#handlingresponse
 	e := r.FormValue("error")
 	if e != "" {
-		l.Warn("OAuth redirection reported an error", zap.Error(errors.New(e)))
+		l.Warn("OAuth redirection reported an error", zap.String("error", e))
 		c.AbortBadRequest(e)
 		return
 	}
@@ -54,7 +55,8 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Test the OAuth token's usability.
+	// Test the token's usability and get authoritative installation details.
+	// TODO: Reuse "checks.go".
 	ctx := r.Context()
 
 	vsid := sdktypes.NewVarScopeID(cid)
@@ -81,6 +83,6 @@ func (h handler) saveConnection(ctx context.Context, vsid sdktypes.VarScopeID, t
 		return errors.New("OAuth redirection missing token data")
 	}
 
-	vs := sdktypes.EncodeVars(newOAuthData(t))
+	vs := sdktypes.EncodeVars(common.EncodeOAuthData(t))
 	return h.vars.Set(ctx, vs.WithScopeID(vsid)...)
 }

--- a/integrations/height/vars.go
+++ b/integrations/height/vars.go
@@ -1,34 +1,10 @@
 package height
 
 import (
-	"time"
-
-	"golang.org/x/oauth2"
-
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-var (
-	authTypeVar = sdktypes.NewSymbol("auth_type")
-	apiKeyVar   = sdktypes.NewSymbol("api_key")
-)
-
-// oauthData contains OAuth 2.0 token details.
-type oauthData struct {
-	AccessToken  string `var:"oauth_access_token,secret"`
-	Expiry       string `var:"oauth_expiry"`
-	RefreshToken string `var:"oauth_refresh_token,secret"`
-	TokenType    string `var:"oauth_token_type"`
-}
-
-func newOAuthData(t *oauth2.Token) oauthData {
-	return oauthData{
-		AccessToken:  t.AccessToken,
-		Expiry:       t.Expiry.Format(time.RFC3339),
-		RefreshToken: t.RefreshToken,
-		TokenType:    t.TokenType,
-	}
-}
+var apiKeyVar = sdktypes.NewSymbol("api_key")
 
 // privateOAuth contains the user-provided details of a private Height OAuth 2.0 app.
 type privateOAuth struct {

--- a/integrations/linear/checks.go
+++ b/integrations/linear/checks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"go.autokitteh.dev/autokitteh/integrations"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
@@ -14,17 +15,12 @@ import (
 // ensures that the connection is at least theoretically usable.
 func status(v sdkservices.Vars) sdkintegrations.OptFn {
 	return sdkintegrations.WithConnectionStatus(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
-		if !cid.IsValid() {
-			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
+		vs, errStatus, err := common.ReadConnectionVars(ctx, v, cid)
+		if errStatus.IsValid() || err != nil {
+			return errStatus, err
 		}
 
-		vs, err := v.Get(ctx, sdktypes.NewVarScopeID(cid), authTypeVar)
-		if err != nil {
-			return sdktypes.InvalidStatus, err // This is abnormal.
-		}
-
-		authType := vs.GetValue(authTypeVar)
-		switch authType {
+		switch common.ReadAuthType(vs) {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
@@ -41,27 +37,23 @@ func status(v sdkservices.Vars) sdkintegrations.OptFn {
 // authentication credentials are valid and can be used to make API calls.
 func test(v sdkservices.Vars) sdkintegrations.OptFn {
 	return sdkintegrations.WithConnectionTest(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
-		if !cid.IsValid() {
-			return sdktypes.NewStatus(sdktypes.StatusCodeError, "Init required"), nil
+		vs, errStatus, err := common.ReadConnectionVars(ctx, v, cid)
+		if errStatus.IsValid() || err != nil {
+			return errStatus, err
 		}
 
-		vs, err := v.Get(ctx, sdktypes.NewVarScopeID(cid))
-		if err != nil {
-			return sdktypes.InvalidStatus, err // This is abnormal.
-		}
-
-		authType := vs.GetValue(authTypeVar)
-		switch authType {
+		switch common.ReadAuthType(vs) {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
-			// TODO: Implement.
+			// TODO(INT-269): Implement.
 		case integrations.APIKey:
-			// TODO: Implement.
+			// TODO(INT-269): Implement.
 		default:
 			return sdktypes.NewStatus(sdktypes.StatusCodeError, "Bad auth type"), nil
 		}
 
-		return sdktypes.NewStatus(sdktypes.StatusCodeOK, ""), nil
+		// TODO(INT-269): return sdktypes.NewStatus(sdktypes.StatusCodeOK, ""), nil
+		return sdktypes.NewStatus(sdktypes.StatusCodeError, "Not implemented"), nil
 	})
 }

--- a/integrations/linear/oauth.go
+++ b/integrations/linear/oauth.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
@@ -40,7 +41,7 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 	// https://developers.google.com/identity/protocols/oauth2/web-server#handlingresponse
 	e := r.FormValue("error")
 	if e != "" {
-		l.Warn("OAuth redirection reported an error", zap.Error(errors.New(e)))
+		l.Warn("OAuth redirection reported an error", zap.String("error", e))
 		c.AbortBadRequest(e)
 		return
 	}
@@ -54,7 +55,8 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Test the OAuth token's usability.
+	// Test the token's usability and get authoritative installation details.
+	// TODO: Reuse "checks.go".
 	ctx := r.Context()
 
 	vsid := sdktypes.NewVarScopeID(cid)
@@ -81,6 +83,6 @@ func (h handler) saveConnection(ctx context.Context, vsid sdktypes.VarScopeID, t
 		return errors.New("OAuth redirection missing token data")
 	}
 
-	vs := sdktypes.EncodeVars(newOAuthData(t))
+	vs := sdktypes.EncodeVars(common.EncodeOAuthData(t))
 	return h.vars.Set(ctx, vs.WithScopeID(vsid)...)
 }

--- a/integrations/linear/save.go
+++ b/integrations/linear/save.go
@@ -1,7 +1,6 @@
 package linear
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -11,6 +10,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/integrations"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
@@ -49,7 +49,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 
 	// Determine what to save and how to proceed.
 	vsid := sdktypes.NewVarScopeID(cid)
-	authType := h.saveAuthType(r.Context(), vsid, r.FormValue("auth_type"))
+	authType := common.SaveAuthType(r, h.vars, vsid)
 	l = l.With(zap.String("auth_type", authType))
 
 	switch authType {
@@ -73,7 +73,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 		}
 		if err := h.savePrivateOAuth(r, vsid); err != nil {
 			l.Error("save connection: " + err.Error())
-			c.AbortServerError(err.Error())
+			c.AbortBadRequest(err.Error())
 			return
 		}
 		startOAuth(w, r, c, l)
@@ -82,13 +82,13 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 	case integrations.APIKey:
 		if err := h.saveAPIKey(r, vsid); err != nil {
 			l.Error("save connection: " + err.Error())
-			c.AbortServerError(err.Error())
+			c.AbortBadRequest(err.Error())
 			return
 		}
 		urlPath, err := c.FinalURL()
 		if err != nil {
 			l.Error("save connection: failed to construct final URL", zap.Error(err))
-			c.AbortServerError("bad redirect URL")
+			c.AbortBadRequest("bad redirect URL")
 			return
 		}
 		http.Redirect(w, r, urlPath, http.StatusFound)
@@ -98,15 +98,6 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 		l.Warn("save connection: unexpected auth type")
 		c.AbortBadRequest(fmt.Sprintf("unexpected auth type %q", authType))
 	}
-}
-
-// saveAuthType saves the authentication type that the user selected for this connection.
-// This will be redundant if/when the only way to initialize connections is via the web UI.
-// Therefore, we do not care if this function fails to save it as a connection variable.
-func (h handler) saveAuthType(ctx context.Context, vsid sdktypes.VarScopeID, authType string) string {
-	v := sdktypes.NewVar(authTypeVar).SetValue(authType)
-	_ = h.vars.Set(ctx, v.WithScopeID(vsid))
-	return authType
 }
 
 // saveActor saves Linear's OAuth "actor" (user/app) parameter as a connection variable.
@@ -139,7 +130,7 @@ func (h handler) saveAPIKey(r *http.Request, vsid sdktypes.VarScopeID) error {
 		return errors.New("missing API key")
 	}
 
-	// TODO: Test the API key's usability.
+	// TODO: Test the API key's usability, reuse connection test.
 
 	v := sdktypes.NewVar(apiKeyVar).SetValue(apiKey).SetSecret(true)
 	return h.vars.Set(r.Context(), v.WithScopeID(vsid))

--- a/integrations/linear/vars.go
+++ b/integrations/linear/vars.go
@@ -1,35 +1,13 @@
 package linear
 
 import (
-	"time"
-
-	"golang.org/x/oauth2"
-
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 var (
-	authTypeVar = sdktypes.NewSymbol("auth_type")
-	actorVar    = sdktypes.NewSymbol("actor")
-	apiKeyVar   = sdktypes.NewSymbol("api_key")
+	actorVar  = sdktypes.NewSymbol("actor")
+	apiKeyVar = sdktypes.NewSymbol("api_key")
 )
-
-// oauthData contains OAuth 2.0 token details.
-type oauthData struct {
-	AccessToken  string `var:"oauth_access_token,secret"`
-	Expiry       string `var:"oauth_expiry"`
-	RefreshToken string `var:"oauth_refresh_token,secret"`
-	TokenType    string `var:"oauth_token_type"`
-}
-
-func newOAuthData(t *oauth2.Token) oauthData {
-	return oauthData{
-		AccessToken:  t.AccessToken,
-		Expiry:       t.Expiry.Format(time.RFC3339),
-		RefreshToken: t.RefreshToken,
-		TokenType:    t.TokenType,
-	}
-}
 
 // privateOAuth contains the user-provided details of a private Linear OAuth 2.0 app.
 type privateOAuth struct {

--- a/integrations/microsoft/connection/auth.go
+++ b/integrations/microsoft/connection/auth.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"go.autokitteh.dev/autokitteh/integrations"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authcontext"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
@@ -23,9 +24,9 @@ import (
 // connection variables. If it's stale, we refresh it first.
 func oauthToken(ctx context.Context, vs sdktypes.Vars, o sdkservices.OAuth) *oauth2.Token {
 	t1 := &oauth2.Token{
-		AccessToken:  vs.GetValue(oauthAccessTokenVar),
-		RefreshToken: vs.GetValue(oauthRefreshTokenVar),
-		TokenType:    vs.GetValue(oauthTokenTypeVar),
+		AccessToken:  vs.GetValue(common.OAuthAccessTokenVar),
+		RefreshToken: vs.GetValue(common.OAuthRefreshTokenVar),
+		TokenType:    vs.GetValue(common.OAuthTokenTypeVar),
 	}
 	if t1.Valid() {
 		return t1
@@ -111,7 +112,7 @@ func bearerToken(ctx context.Context, l *zap.Logger, svc Services, cid sdktypes.
 		return ""
 	}
 
-	switch authType := vs.GetValue(AuthTypeVar); authType {
+	switch authType := common.ReadAuthType(vs); authType {
 	case integrations.OAuthDefault:
 		return "Bearer " + oauthToken(ctx, vs, svc.OAuth).AccessToken
 

--- a/integrations/microsoft/connection/vars.go
+++ b/integrations/microsoft/connection/vars.go
@@ -1,42 +1,15 @@
 package connection
 
 import (
-	"time"
-
-	"golang.org/x/oauth2"
-
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 var (
-	AuthTypeVar = sdktypes.NewSymbol("auth_type")
-
-	oauthAccessTokenVar  = sdktypes.NewSymbol("oauth_access_token")
-	oauthRefreshTokenVar = sdktypes.NewSymbol("oauth_refresh_token")
-	oauthTokenTypeVar    = sdktypes.NewSymbol("oauth_token_type")
-
 	orgIDVar               = sdktypes.NewSymbol("org_id")
 	privateClientIDVar     = sdktypes.NewSymbol("private_client_id")
 	privateClientSecretVar = sdktypes.NewSymbol("private_client_secret")
 	privateTenantIDVar     = sdktypes.NewSymbol("private_tenant_id")
 )
-
-// OauthData contains OAuth 2.0 token details.
-type OAuthData struct {
-	AccessToken  string `var:"oauth_access_token,secret"`
-	Expiry       string `var:"oauth_expiry"`
-	RefreshToken string `var:"oauth_refresh_token,secret"`
-	TokenType    string `var:"oauth_token_type"`
-}
-
-func NewOAuthData(t *oauth2.Token) OAuthData {
-	return OAuthData{
-		AccessToken:  t.AccessToken,
-		Expiry:       t.Expiry.Format(time.RFC3339),
-		RefreshToken: t.RefreshToken,
-		TokenType:    t.TokenType,
-	}
-}
 
 // OrgInfo contains basic details about a Microsoft organization
 // (based on: https://learn.microsoft.com/en-us/graph/api/organization-get).

--- a/integrations/salesforce/checks.go
+++ b/integrations/salesforce/checks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"go.autokitteh.dev/autokitteh/integrations"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
@@ -14,17 +15,12 @@ import (
 // ensures that the connection is at least theoretically usable.
 func status(v sdkservices.Vars) sdkintegrations.OptFn {
 	return sdkintegrations.WithConnectionStatus(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
-		if !cid.IsValid() {
-			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
+		vs, errStatus, err := common.ReadConnectionVars(ctx, v, cid)
+		if errStatus.IsValid() || err != nil {
+			return errStatus, err
 		}
 
-		vs, err := v.Get(ctx, sdktypes.NewVarScopeID(cid), authTypeVar)
-		if err != nil {
-			return sdktypes.InvalidStatus, err // This is abnormal.
-		}
-
-		authType := vs.GetValue(authTypeVar)
-		switch authType {
+		switch common.ReadAuthType(vs) {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
@@ -37,9 +33,25 @@ func status(v sdkservices.Vars) sdkintegrations.OptFn {
 
 // test checks whether the connection is actually usable, i.e. the configured
 // authentication credentials are valid and can be used to make API calls.
-// TODO(INT-268): Implement this.
-func test(v sdkservices.Vars, o sdkservices.OAuth) sdkintegrations.OptFn {
+func test(v sdkservices.Vars) sdkintegrations.OptFn {
 	return sdkintegrations.WithConnectionTest(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
+		vs, errStatus, err := common.ReadConnectionVars(ctx, v, cid)
+		if errStatus.IsValid() || err != nil {
+			return errStatus, err
+		}
+
+		switch common.ReadAuthType(vs) {
+		case "":
+			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
+		case integrations.OAuthDefault, integrations.OAuthPrivate:
+			// TODO(INT-268): Implement.
+		case integrations.APIKey:
+			// TODO(INT-268): Implement.
+		default:
+			return sdktypes.NewStatus(sdktypes.StatusCodeError, "Bad auth type"), nil
+		}
+
+		// TODO(INT-235): return sdktypes.NewStatus(sdktypes.StatusCodeOK, ""), nil
 		return sdktypes.NewStatus(sdktypes.StatusCodeError, "Not implemented"), nil
 	})
 }

--- a/integrations/salesforce/integration.go
+++ b/integrations/salesforce/integration.go
@@ -15,9 +15,9 @@ var desc = common.Descriptor("salesforce", "Salesforce", "/static/images/salesfo
 
 // New defines an AutoKitteh integration, which
 // is registered when the AutoKitteh server starts.
-func New(v sdkservices.Vars, o sdkservices.OAuth) sdkservices.Integration {
+func New(v sdkservices.Vars) sdkservices.Integration {
 	return sdkintegrations.NewIntegration(
-		desc, sdkmodule.New(), status(v), test(v, o),
+		desc, sdkmodule.New(), status(v), test(v),
 		sdkintegrations.WithConnectionConfigFromVars(v))
 }
 

--- a/integrations/salesforce/vars.go
+++ b/integrations/salesforce/vars.go
@@ -1,32 +1,5 @@
 package salesforce
 
-import (
-	"time"
-
-	"golang.org/x/oauth2"
-
-	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-)
-
-var authTypeVar = sdktypes.NewSymbol("auth_type")
-
-// oauthData contains OAuth 2.0 token details.
-type oauthData struct {
-	AccessToken  string `var:"oauth_access_token,secret"`
-	Expiry       string `var:"oauth_expiry"`
-	RefreshToken string `var:"oauth_refresh_token,secret"`
-	TokenType    string `var:"oauth_token_type"`
-}
-
-func newOAuthData(t *oauth2.Token) oauthData {
-	return oauthData{
-		AccessToken:  t.AccessToken,
-		Expiry:       t.Expiry.Format(time.RFC3339),
-		RefreshToken: t.RefreshToken,
-		TokenType:    t.TokenType,
-	}
-}
-
 // privateOAuth contains the user-provided details of a private Salesforce OAuth 2.0 app.
 type privateOAuth struct {
 	ClientID     string `var:"private_client_id"`

--- a/integrations/slack/oauth.go
+++ b/integrations/slack/oauth.go
@@ -43,7 +43,7 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 	// https://developers.google.com/identity/protocols/oauth2/web-server#handlingresponse
 	e := r.FormValue("error")
 	if e != "" {
-		l.Warn("OAuth redirection reported an error", zap.Error(errors.New(e)))
+		l.Warn("OAuth redirection reported an error", zap.String("error", e))
 		c.AbortBadRequest(e)
 		return
 	}

--- a/integrations/slack/save.go
+++ b/integrations/slack/save.go
@@ -65,7 +65,7 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 	// First save the user-provided details of a private Slack OAuth v2 app,
 	// and only then redirect to the 3-legged OAuth 2.0 flow's starting point.
 	case integrations.OAuthPrivate:
-		if err := h.savePrivateOAuth(r, vsid); err != nil {
+		if err := h.savePrivateOAuthApp(r, vsid); err != nil {
 			l.Error("save connection: " + err.Error())
 			c.AbortBadRequest(err.Error())
 			return
@@ -93,9 +93,9 @@ func (h handler) handleSave(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// savePrivateOAuth saves the user-provided details of
-// a private Slack OAuth v2 app as connection variables.
-func (h handler) savePrivateOAuth(r *http.Request, vsid sdktypes.VarScopeID) error {
+// savePrivateOAuthApp saves the user-provided details
+// of a private Slack OAuth v2 app as connection variables.
+func (h handler) savePrivateOAuthApp(r *http.Request, vsid sdktypes.VarScopeID) error {
 	app := vars.PrivateOAuth{
 		ClientID:      r.FormValue("client_id"),
 		ClientSecret:  r.FormValue("client_secret"),

--- a/integrations/zoom/checks.go
+++ b/integrations/zoom/checks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"go.autokitteh.dev/autokitteh/integrations"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
@@ -14,17 +15,12 @@ import (
 // ensures that the connection is at least theoretically usable.
 func status(v sdkservices.Vars) sdkintegrations.OptFn {
 	return sdkintegrations.WithConnectionStatus(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
-		if !cid.IsValid() {
-			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
+		vs, errStatus, err := common.ReadConnectionVars(ctx, v, cid)
+		if errStatus.IsValid() || err != nil {
+			return errStatus, err
 		}
 
-		vs, err := v.Get(ctx, sdktypes.NewVarScopeID(cid), authTypeVar)
-		if err != nil {
-			return sdktypes.InvalidStatus, err // This is abnormal.
-		}
-
-		authType := vs.GetValue(authTypeVar)
-		switch authType {
+		switch common.ReadAuthType(vs) {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
@@ -41,17 +37,12 @@ func status(v sdkservices.Vars) sdkintegrations.OptFn {
 // authentication credentials are valid and can be used to make API calls.
 func test(v sdkservices.Vars) sdkintegrations.OptFn {
 	return sdkintegrations.WithConnectionTest(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
-		if !cid.IsValid() {
-			return sdktypes.NewStatus(sdktypes.StatusCodeError, "Init required"), nil
+		vs, errStatus, err := common.ReadConnectionVars(ctx, v, cid)
+		if errStatus.IsValid() || err != nil {
+			return errStatus, err
 		}
 
-		vs, err := v.Get(ctx, sdktypes.NewVarScopeID(cid))
-		if err != nil {
-			return sdktypes.InvalidStatus, err // This is abnormal.
-		}
-
-		authType := vs.GetValue(authTypeVar)
-		switch authType {
+		switch common.ReadAuthType(vs) {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:

--- a/integrations/zoom/oauth.go
+++ b/integrations/zoom/oauth.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
@@ -40,7 +41,7 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 	// https://developers.google.com/identity/protocols/oauth2/web-server#handlingresponse
 	e := r.FormValue("error")
 	if e != "" {
-		l.Warn("OAuth redirection reported an error", zap.Error(errors.New(e)))
+		l.Warn("OAuth redirection reported an error", zap.String("error", e))
 		c.AbortBadRequest(e)
 		return
 	}
@@ -54,7 +55,8 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Test the OAuth token's usability (reuse "checks.go").
+	// Test the token's usability and get authoritative installation details.
+	// TODO: Reuse "checks.go".
 	ctx := r.Context()
 
 	vsid := sdktypes.NewVarScopeID(cid)
@@ -81,6 +83,6 @@ func (h handler) saveConnection(ctx context.Context, vsid sdktypes.VarScopeID, t
 		return errors.New("OAuth redirection missing token data")
 	}
 
-	vs := sdktypes.EncodeVars(newOAuthData(t))
+	vs := sdktypes.EncodeVars(common.EncodeOAuthData(t))
 	return h.vars.Set(ctx, vs.WithScopeID(vsid)...)
 }

--- a/integrations/zoom/vars.go
+++ b/integrations/zoom/vars.go
@@ -1,32 +1,5 @@
 package zoom
 
-import (
-	"time"
-
-	"golang.org/x/oauth2"
-
-	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-)
-
-var authTypeVar = sdktypes.NewSymbol("auth_type")
-
-// oauthData contains OAuth 2.0 token details.
-type oauthData struct {
-	AccessToken  string `var:"oauth_access_token,secret"`
-	Expiry       string `var:"oauth_expiry"`
-	RefreshToken string `var:"oauth_refresh_token,secret"`
-	TokenType    string `var:"oauth_token_type"`
-}
-
-func newOAuthData(t *oauth2.Token) oauthData {
-	return oauthData{
-		AccessToken:  t.AccessToken,
-		Expiry:       t.Expiry.Format(time.RFC3339),
-		RefreshToken: t.RefreshToken,
-		TokenType:    t.TokenType,
-	}
-}
-
 // privateApp contains the user-provided details of a private
 // Zoom OAuth 2.0 app or Service-to-Service internal app.
 type privateApp struct {

--- a/web/static/microsoft/index.html
+++ b/web/static/microsoft/index.html
@@ -61,7 +61,7 @@
         <select name="auth_type" id="authType">
           <option value="oauthDefault">Default user-delegated app</option>
           <option value="oauthPrivate">Private user-delegated app</option>
-          <option value="daemonApp">Private daemon application</option>
+          <option value="daemonApp">Private daemon app</option>
         </select>
       </div>
 

--- a/web/static/microsoft/teams/index.html
+++ b/web/static/microsoft/teams/index.html
@@ -61,7 +61,7 @@
         <select name="auth_type" id="authType">
           <option value="oauthDefault">Default user-delegated app</option>
           <option value="oauthPrivate">Private user-delegated app</option>
-          <option value="daemonApp">Private daemon application</option>
+          <option value="daemonApp">Private daemon app</option>
         </select>
       </div>
 

--- a/web/static/slack/index.html
+++ b/web/static/slack/index.html
@@ -52,14 +52,14 @@
 
       <div class="form-group">
         <select name="auth_type" id="authType">
-          <option value="oauthDefault">Default OAuth v2</option>
-          <option value="oauthPrivate">Private OAuth v2</option>
-          <option value="socketMode">Private Socket Mode</option>
+          <option value="oauthDefault">Default OAuth v2 app</option>
+          <option value="oauthPrivate">Private OAuth v2 app</option>
+          <option value="socketMode">Private Socket Mode app</option>
         </select>
       </div>
 
       <div id="privateOauthSection" class="hidden">
-        <h2>Private OAuth v2</h2>
+        <h2>Private OAuth v2 App</h2>
 
         <div class="form-group">
           <label for="client_id">Client ID <i>(required)</i></label>
@@ -102,7 +102,7 @@
       </div>
 
       <div id="privateSocketModeSection" class="hidden">
-        <h2>Private Socket Mode</h2>
+        <h2>Private Socket Mode App</h2>
 
         <div class="form-group">
           <label for="bot_token">Bot token <i>("xoxb", required)</i></label>

--- a/web/static/zoom/index.html
+++ b/web/static/zoom/index.html
@@ -54,9 +54,9 @@
 
       <div class="form-group">
         <select name="auth_type" id="authType">
-          <option value="oauthDefault">Default OAuth 2.0</option>
-          <option value="oauthPrivate">Private OAuth 2.0</option>
-          <option value="serverToServer">Private Server-to-Server</option>
+          <option value="oauthDefault">Default OAuth 2.0 app</option>
+          <option value="oauthPrivate">Private OAuth 2.0 app</option>
+          <option value="serverToServer">Private Server-to-Server app</option>
         </select>
       </div>
 


### PR DESCRIPTION
1. Reuse new functions in https://github.com/autokitteh/autokitteh/tree/main/integrations/common based on #1082 
2. Tweak code snippets and comments across all new-style integrations - mostly cosmetic, but not entirely
3. `integrations/microsoft/save.go` - separate save functions for the 2 app types, because daemon apps do some extra stuff before saving the connections vars