### PR TITLE
refactor(google drive): differentiate between new connection and existing for watch renewal

### DIFF
--- a/integrations/google/drive/client.go
+++ b/integrations/google/drive/client.go
@@ -154,11 +154,10 @@ func (a api) watchEvents(ctx context.Context, connID sdktypes.ConnectionID, user
 	addr := os.Getenv("WEBHOOK_ADDRESS")
 	watchID := connID.String() + "/events"
 	req := client.Changes.Watch(startToken.StartPageToken, &drive.Channel{
-		Id:      watchID,
-		Token:   userEmail + "/" + watchID,
-		Address: fmt.Sprintf("https://%s/googledrive/notif", addr),
-		Type:    "web_hook",
-		// Expiration: time.Now().Add(time.Hour*24*7).Unix() * 1000,
+		Id:         watchID,
+		Token:      userEmail + "/" + watchID,
+		Address:    fmt.Sprintf("https://%s/googledrive/notif", addr),
+		Type:       "web_hook",
 		Expiration: time.Now().Add(time.Hour*24).Unix() * 1000,
 	})
 

--- a/integrations/google/drive/client.go
+++ b/integrations/google/drive/client.go
@@ -155,10 +155,10 @@ func (a api) watchEvents(ctx context.Context, connID sdktypes.ConnectionID, user
 	watchID := connID.String() + "/events"
 	req := client.Changes.Watch(startToken.StartPageToken, &drive.Channel{
 		Id:         watchID,
-		Token:      userEmail + "/" + watchID,
+		Token:      userEmail + "/events",
 		Address:    fmt.Sprintf("https://%s/googledrive/notif", addr),
 		Type:       "web_hook",
-		Expiration: time.Now().Add(time.Hour*24).Unix() * 1000,
+		Expiration: time.Now().Add(time.Hour*24*7).Unix() * 1000,
 	})
 
 	// check if the channel already exists


### PR DESCRIPTION
**Testing**: Manually tested by running a Google Drive project. Created a new file using a workflow, which initiated a new Drive watch. Set the cron job to run every minute and configured the expiration to 24 hours to ensure renewal was triggered each time.

The behavior was as expected—no errors related to an existing channel were triggered.