### PR TITLE
feat(session-test): test that sessions are invoking specific actions

### DIFF
--- a/cmd/ak/cmd/sessions/session.go
+++ b/cmd/ak/cmd/sessions/session.go
@@ -14,9 +14,7 @@ import (
 )
 
 // Default flag value shared by the "start", "restart", and "watch" subcommands.
-const (
-	defaultPollInterval = 1 * time.Second
-)
+const defaultPollInterval = 250 * time.Millisecond
 
 var (
 	// Flags shared by the "list" and "start" subcommands.

--- a/cmd/ak/cmd/sessions/test.go
+++ b/cmd/ak/cmd/sessions/test.go
@@ -193,7 +193,8 @@ var testCmd = common.StandardCommand(&cobra.Command{
 
 			if expected != actual {
 				edits := myers.ComputeEdits(span.URIFromPath("want"), expected, actual)
-				errs = append(errs, errors.New(fmt.Sprint("calls:\n", gotextdiff.ToUnified("want", "got", expected, edits))))
+				diff := gotextdiff.ToUnified("want", "got", expected, edits)
+				errs = append(errs, errors.New(fmt.Sprint("calls:\n", diff)))
 			}
 		}
 

--- a/internal/kittehs/strings.go
+++ b/internal/kittehs/strings.go
@@ -114,3 +114,28 @@ func (w *IndentedStringWriter) Write(p []byte) (n int, err error) {
 
 	return
 }
+
+func StringWithoutComments(s string) string {
+	var (
+		buf strings.Builder
+		in  bool
+	)
+
+	for _, r := range s {
+		if in {
+			if r == '\n' {
+				in = false
+			}
+			continue
+		}
+
+		if r == '#' {
+			in = true
+			continue
+		}
+
+		buf.WriteRune(r)
+	}
+
+	return buf.String()
+}

--- a/internal/kittehs/strings_test.go
+++ b/internal/kittehs/strings_test.go
@@ -82,3 +82,19 @@ func TestNormalizeURL(t *testing.T) {
 		})
 	}
 }
+
+func TestStringWithoutComments(t *testing.T) {
+	tests := []struct{ in, out string }{
+		{"", ""},
+		{"#meow", ""},
+		{"#meow\nwoof", "woof"},
+		{"meow", "meow"},
+		{"meow\nwoof", "meow\nwoof"},
+		{"meow\n# woof", "meow\n"},
+		{"meow\n# woof\noink", "meow\noink"},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.out, StringWithoutComments(test.in))
+	}
+}

--- a/internal/kittehs/strings_test.go
+++ b/internal/kittehs/strings_test.go
@@ -95,6 +95,8 @@ func TestStringWithoutComments(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.out, StringWithoutComments(test.in))
+		t.Run(test.in, func(t *testing.T) {
+			assert.Equal(t, test.out, StringWithoutComments(test.in))
+		})
 	}
 }

--- a/sdk/sdktypes/code_location.go
+++ b/sdk/sdktypes/code_location.go
@@ -9,9 +9,10 @@ import (
 )
 
 const (
-	symbolSeparator = ","
-	pathSeparator   = ":"
-	rowColSeparator = "."
+	symbolSeparator  = ","
+	pathSeparator    = ":"
+	altPathSeparator = " "
+	rowColSeparator  = "."
 )
 
 type CodeLocation struct {
@@ -80,6 +81,10 @@ func ParseCodeLocation(s string) (CodeLocation, error) {
 	}
 
 	path, after, ok := strings.Cut(s, pathSeparator)
+	if !ok {
+		path, after, ok = strings.Cut(s, altPathSeparator)
+	}
+
 	if !ok {
 		return CodeLocationFromProto(&CodeLocationPB{Path: path})
 	}

--- a/tests/sessions/activity_calling_catch.txtar
+++ b/tests/sessions/activity_calling_catch.txtar
@@ -1,8 +1,11 @@
 [None, "floating-point division by zero"]
 
--- main.star:main --
+-- main.star main --
 def foo():
     return catch(lambda: 1/0)
     
 def main():
     print(activity(foo).run())
+
+-- calls.txt --
+foo

--- a/tests/sessions/activity_from_builtin.txtar
+++ b/tests/sessions/activity_from_builtin.txtar
@@ -1,8 +1,11 @@
 6
 
--- main.star:main --
+-- main.star main --
 lena = activity(len)
 
 def main():
     ret = lena.run("george")
     print(ret)
+
+-- calls.txt --
+len

--- a/tests/sessions/activity_from_func.txtar
+++ b/tests/sessions/activity_from_func.txtar
@@ -1,9 +1,12 @@
 hello, george
 
--- main.star:main --
+-- main.star main --
 def foo(name):
     return "hello, " + name
 
 def main():
     ret = activity(foo).run("george")
     print(ret)
+
+-- calls.txt --
+foo

--- a/tests/sessions/activity_global.txtar
+++ b/tests/sessions/activity_global.txtar
@@ -2,3 +2,5 @@
 
 -- main.star --
 print(catch(activity(len).run, "george"))
+
+-- calls.txt --

--- a/tests/sessions/activity_hard_failure.txtar
+++ b/tests/sessions/activity_hard_failure.txtar
@@ -1,9 +1,12 @@
 3
 done
 
--- main.star:main --
+-- main.star main --
 load("testtools", "fail_activity")
 
 def main():
     print(fail_activity(n=3, hard=True))
     print("done")
+
+-- calls.txt --
+fail_activity

--- a/tests/sessions/activity_nested.txtar
+++ b/tests/sessions/activity_nested.txtar
@@ -1,9 +1,12 @@
 (None, "nested activities are not supported")
 
--- main.star:main --
+-- main.star main --
 def foo(name):
     return activity(len).run(name)
 
 def main():
     ret = catch(activity(foo).run, "george")
     print(ret)
+
+-- calls.txt --
+foo

--- a/tests/sessions/activity_soft_failure.txtar
+++ b/tests/sessions/activity_soft_failure.txtar
@@ -1,9 +1,12 @@
 (None, "soft test error")
 done
 
--- main.star:main --
+-- main.star main --
 load("testtools", "fail_activity")
 
 def main():
     print(catch(lambda: fail_activity(n=1)))
     print("done")
+
+-- calls.txt --
+fail_activity

--- a/tests/sessions/activity_with_prints.txtar
+++ b/tests/sessions/activity_with_prints.txtar
@@ -1,7 +1,7 @@
 meow, world
 5
 
--- main.star:main --
+-- main.star main --
 def foo(name):
     print("meow, " + name)
     return len(name)
@@ -9,3 +9,7 @@ def foo(name):
 def main():
     ret = activity(foo).run("world")
     print(ret)
+
+
+-- calls.txt --
+foo

--- a/tests/sessions/python_activity.txtar
+++ b/tests/sessions/python_activity.txtar
@@ -13,3 +13,6 @@ def main(event):
 @autokitteh.activity
 def foo(x):
     print(x)
+
+-- calls.txt --
+foo

--- a/tests/sessions/python_sleep.txtar
+++ b/tests/sessions/python_sleep.txtar
@@ -1,10 +1,13 @@
 sleeping
 woke up
 
--- main.py:main --
+-- main.py main --
 from time import sleep
 
 def main(event):
     print("sleeping")
     sleep(0.1)
     print("woke up")
+
+-- calls.txt --
+# no activites are run, sleep is a naked call

--- a/tests/sessions/python_sleep.txtar
+++ b/tests/sessions/python_sleep.txtar
@@ -10,4 +10,4 @@ def main(event):
     print("woke up")
 
 -- calls.txt --
-# no activites are run, sleep is a naked call
+# no activities are run, sleep is a naked call


### PR DESCRIPTION
if a `calls.txt` is present in the txtar, compare a list of run call names to given list

also:
- speed up polling for session logs by decreasing the poll interval. should speed up ci.
- allow a space in code location string, this allows vscode to color better txtar stuff