### PR TITLE
feat: prevent some sdk functions from running as activities

### DIFF
--- a/cmd/ak/cmd/sessions/session.go
+++ b/cmd/ak/cmd/sessions/session.go
@@ -14,9 +14,7 @@ import (
 )
 
 // Default flag value shared by the "start", "restart", and "watch" subcommands.
-const (
-	defaultPollInterval = 1 * time.Second
-)
+const defaultPollInterval = 250 * time.Millisecond
 
 var (
 	// Flags shared by the "list" and "start" subcommands.

--- a/internal/kittehs/strings.go
+++ b/internal/kittehs/strings.go
@@ -114,3 +114,28 @@ func (w *IndentedStringWriter) Write(p []byte) (n int, err error) {
 
 	return
 }
+
+func StringWithoutComments(s string) string {
+	var (
+		buf strings.Builder
+		in  bool
+	)
+
+	for _, r := range s {
+		if in {
+			if r == '\n' {
+				in = false
+			}
+			continue
+		}
+
+		if r == '#' {
+			in = true
+			continue
+		}
+
+		buf.WriteRune(r)
+	}
+
+	return buf.String()
+}

--- a/internal/kittehs/strings_test.go
+++ b/internal/kittehs/strings_test.go
@@ -82,3 +82,19 @@ func TestNormalizeURL(t *testing.T) {
 		})
 	}
 }
+
+func TestStringWithoutComments(t *testing.T) {
+	tests := []struct{ in, out string }{
+		{"", ""},
+		{"#meow", ""},
+		{"#meow\nwoof", "woof"},
+		{"meow", "meow"},
+		{"meow\nwoof", "meow\nwoof"},
+		{"meow\n# woof", "meow\n"},
+		{"meow\n# woof\noink", "meow\noink"},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.out, StringWithoutComments(test.in))
+	}
+}

--- a/runtimes/pythonrt/py-sdk/autokitteh/asana.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/asana.py
@@ -4,8 +4,10 @@ import asana
 
 from .connections import check_connection_name
 from .errors import ConnectionInitError
+from .decorators import _noactivity
 
 
+@_noactivity
 def asana_client(connection: str) -> asana.ApiClient:
     """Initialize an Asana client, based on an AutoKitteh connection.
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/atlassian.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/atlassian.py
@@ -9,11 +9,13 @@ from requests_oauthlib import OAuth2Session
 
 from .connections import check_connection_name
 from .errors import AtlassianOAuthError, ConnectionInitError, EnvVarError
+from .decorators import _noactivity
 
 
 __TOKEN_URL = "https://auth.atlassian.com/oauth/token"
 
 
+@_noactivity
 def jira_client(connection: str, **kwargs) -> Jira:
     """Initialize an Atlassian Jira client, based on an AutoKitteh connection.
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/auth0.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/auth0.py
@@ -2,10 +2,12 @@ import os
 
 from .connections import check_connection_name
 from .errors import ConnectionInitError
+from .decorators import _noactivity
 
 from auth0.management import Auth0
 
 
+@_noactivity
 def auth0_client(connection: str, **kwargs) -> Auth0:
     """Initialize an Auth0 client, based on an AutoKitteh connection.
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/aws.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/aws.py
@@ -5,8 +5,10 @@ import os
 import boto3
 
 from .connections import check_connection_name
+from .decorators import _noactivity
 
 
+@_noactivity
 def boto3_client(connection: str, service: str, region: str = "", **kwargs):
     """Initialize a Boto3 (AWS SDK) client, based on an AutoKitteh connection.
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/decorators.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/decorators.py
@@ -17,3 +17,14 @@ def activity(fn: callable) -> callable:
     """
     setattr(fn, ACTIVITY_ATTR, True)
     return fn
+
+
+def _noactivity(fn: callable) -> callable:
+    """Decorator to mark a function as not a Temporal activity.
+
+    For SDK internal use only - as this does not prevent from a function
+    called from outside the sdk to run as an activity or starting other activities.
+    """
+
+    setattr(fn, ACTIVITY_ATTR, False)
+    return fn

--- a/runtimes/pythonrt/py-sdk/autokitteh/discord.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/discord.py
@@ -4,8 +4,10 @@ import discord
 
 from .connections import check_connection_name
 from .errors import ConnectionInitError
+from .decorators import _noactivity
 
 
+@_noactivity
 def discord_client(connection: str, intents=None, **kwargs) -> discord.Client:
     """Initialize a Discord client, based on an AutoKitteh connection.
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/github.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/github.py
@@ -8,8 +8,10 @@ from github import Auth, Consts, Github, GithubIntegration
 
 from .connections import check_connection_name, encode_jwt
 from .errors import ConnectionInitError
+from .decorators import _noactivity
 
 
+@_noactivity
 def github_client(connection: str, **kwargs) -> Github:
     """Initialize a GitHub client, based on an AutoKitteh connection.
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/google.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/google.py
@@ -14,8 +14,10 @@ from googleapiclient.discovery import build
 
 from .connections import check_connection_name, refresh_oauth
 from .errors import ConnectionInitError, OAuthRefreshError
+from .decorators import _noactivity
 
 
+@_noactivity
 def gmail_client(connection: str, **kwargs):
     """Initialize a Gmail client, based on an AutoKitteh connection.
 
@@ -46,6 +48,7 @@ def gmail_client(connection: str, **kwargs):
     return build("gmail", "v1", credentials=creds, **kwargs)
 
 
+@_noactivity
 def google_calendar_client(connection: str, **kwargs):
     """Initialize a Google Calendar client, based on an AutoKitteh connection.
 
@@ -75,6 +78,7 @@ def google_calendar_client(connection: str, **kwargs):
     return build("calendar", "v3", credentials=creds, **kwargs)
 
 
+@_noactivity
 def google_drive_client(connection: str, **kwargs):
     """Initialize a Google Drive client, based on an AutoKitteh connection.
 
@@ -103,6 +107,7 @@ def google_drive_client(connection: str, **kwargs):
     return build("drive", "v3", credentials=creds, **kwargs)
 
 
+@_noactivity
 def google_forms_client(connection: str, **kwargs):
     """Initialize a Google Forms client, based on an AutoKitteh connection.
 
@@ -133,6 +138,7 @@ def google_forms_client(connection: str, **kwargs):
     return build("forms", "v1", credentials=creds, **kwargs)
 
 
+@_noactivity
 def gemini_client(connection: str, **kwargs) -> genai.GenerativeModel:
     """Initialize a Gemini generative AI client, based on an AutoKitteh connection.
 
@@ -167,6 +173,7 @@ def gemini_client(connection: str, **kwargs) -> genai.GenerativeModel:
     return genai.GenerativeModel(**kwargs)
 
 
+@_noactivity
 def google_sheets_client(connection: str, **kwargs):
     """Initialize a Google Sheets client, based on an AutoKitteh connection.
 
@@ -194,6 +201,7 @@ def google_sheets_client(connection: str, **kwargs):
     return build("sheets", "v4", credentials=creds, **kwargs)
 
 
+@_noactivity
 def google_creds(integration: str, connection: str, scopes: list[str], **kwargs):
     """Initialize credentials for a Google APIs client, for service discovery.
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/height.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/height.py
@@ -3,8 +3,10 @@
 from requests import Session
 
 from .oauth2_session import OAuth2Session
+from .decorators import _noactivity
 
 
+@_noactivity
 def height_client(connection: str) -> Session:
     """Initialize an Height client, based on an AutoKitteh connection.
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/hubspot.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/hubspot.py
@@ -6,8 +6,10 @@ from hubspot import HubSpot
 
 from .connections import check_connection_name, refresh_oauth
 from .errors import ConnectionInitError, OAuthRefreshError
+from .decorators import _noactivity
 
 
+@_noactivity
 def hubspot_client(connection: str, **kwargs) -> HubSpot:
     """Initialize a HubSpot client, based on an AutoKitteh connection.
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/microsoft.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/microsoft.py
@@ -9,12 +9,14 @@ from msgraph import GraphServiceClient
 
 from .connections import check_connection_name, refresh_oauth
 from .errors import ConnectionInitError
+from .decorators import _noactivity
 
 
 # Default buffer time to refresh OAuth tokens before they expire.
 DEFAULT_REFRESH_BUFFER_TIME = timedelta(minutes=5)
 
 
+@_noactivity
 def teams_client(connection: str, **kwargs) -> GraphServiceClient:
     """Initialize a Microsoft Teams client, based on an AutoKitteh connection.
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/openai.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/openai.py
@@ -6,8 +6,10 @@ from openai import OpenAI
 
 from .connections import check_connection_name
 from .errors import ConnectionInitError
+from .decorators import _noactivity
 
 
+@_noactivity
 def openai_client(connection: str) -> OpenAI:
     """Initialize an OpenAI client, based on an AutoKitteh connection.
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/packages.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/packages.py
@@ -1,6 +1,7 @@
 import re
 import sys
 from subprocess import run
+from .decorators import _noactivity
 
 
 def _package_name(specifier):
@@ -40,6 +41,7 @@ def _install_package(specifier, import_name):
         )
 
 
+@_noactivity
 def install(*packages):
     """Install Python packages using pip.
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/salesforce.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/salesforce.py
@@ -6,8 +6,10 @@ from simple_salesforce import Salesforce
 
 from .connections import check_connection_name
 from .errors import ConnectionInitError
+from .decorators import _noactivity
 
 
+@_noactivity
 def salesforce_client(connection: str, **kwargs) -> Salesforce:
     """Initialize a Salesforce client, based on an AutoKitteh connection.
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/sdktest.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/sdktest.py
@@ -1,0 +1,28 @@
+from random import random
+
+from .decorators import activity, noactivity
+
+
+def test_default(*args, **kwargs):
+    return kwargs.get("ret")
+
+
+@activity
+def test_activity(*args, **kwargs):
+    return kwargs.get("ret")
+
+
+@noactivity
+def test_noactivity(*args, **kwargs):
+    return kwargs.get("ret")
+
+
+@noactivity
+def test_noactivity_internal_call(*args, **kwargs):
+    return test_default(*args, **kwargs)
+
+
+@noactivity
+def test_noactivity_external_call(*args, **kwargs):
+    _ = random()
+    return kwargs.get("ret")

--- a/runtimes/pythonrt/py-sdk/autokitteh/slack.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/slack.py
@@ -6,8 +6,10 @@ from slack_sdk.web.client import WebClient
 
 from .connections import check_connection_name
 from .errors import ConnectionInitError
+from .decorators import _noactivity
 
 
+@_noactivity
 def slack_client(connection: str, **kwargs) -> WebClient:
     """Initialize a Slack client, based on an AutoKitteh connection.
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/twilio.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/twilio.py
@@ -6,8 +6,10 @@ from twilio.rest import Client
 
 from .connections import check_connection_name
 from .errors import ConnectionInitError
+from .decorators import _noactivity
 
 
+@_noactivity
 def twilio_client(connection: str) -> Client:
     """Initialize a Twilio client, based on an AutoKitteh connection.
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/zoom.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/zoom.py
@@ -3,8 +3,10 @@
 from requests import Session
 
 from .oauth2_session import OAuth2Session
+from .decorators import _noactivity
 
 
+@_noactivity
 def zoom_client(connection: str) -> Session:
     """Initialize a Zoom client, based on an AutoKitteh connection.
 

--- a/runtimes/pythonrt/runner/call.py
+++ b/runtimes/pythonrt/runner/call.py
@@ -19,9 +19,18 @@ AK_FUNCS = {
 }
 
 
-def is_marked_activity(fn):
-    """Return true if function is marked as an activity."""
-    return getattr(fn, decorators.ACTIVITY_ATTR, False)
+def get_activity_attr(fn):
+    """Return true if function is marked as an activity.
+
+    Returns:
+    None - not explicitly set.
+    True - explicitly set as activity.
+    False - explicitly set as non-activity.
+    """
+    if hasattr(fn, decorators.ACTIVITY_ATTR):
+        return getattr(fn, decorators.ACTIVITY_ATTR)
+
+    return None
 
 
 def callable_name(fn):
@@ -83,8 +92,9 @@ class AKCall:
         if self.in_activity or self.loading:
             return False
 
-        if is_marked_activity(fn):
-            return True
+        a = get_activity_attr(fn)
+        if a is not None:
+            return a
 
         if is_deterministic(fn):
             return False

--- a/sdk/sdktypes/code_location.go
+++ b/sdk/sdktypes/code_location.go
@@ -9,9 +9,10 @@ import (
 )
 
 const (
-	symbolSeparator = ","
-	pathSeparator   = ":"
-	rowColSeparator = "."
+	symbolSeparator  = ","
+	pathSeparator    = ":"
+	altPathSeparator = " "
+	rowColSeparator  = "."
 )
 
 type CodeLocation struct {
@@ -80,6 +81,10 @@ func ParseCodeLocation(s string) (CodeLocation, error) {
 	}
 
 	path, after, ok := strings.Cut(s, pathSeparator)
+	if !ok {
+		path, after, ok = strings.Cut(s, altPathSeparator)
+	}
+
 	if !ok {
 		return CodeLocationFromProto(&CodeLocationPB{Path: path})
 	}

--- a/tests/sessions/activity_calling_catch.txtar
+++ b/tests/sessions/activity_calling_catch.txtar
@@ -1,8 +1,11 @@
 [None, "floating-point division by zero"]
 
--- main.star:main --
+-- main.star main --
 def foo():
     return catch(lambda: 1/0)
     
 def main():
     print(activity(foo).run())
+
+-- calls.txt --
+foo

--- a/tests/sessions/activity_from_builtin.txtar
+++ b/tests/sessions/activity_from_builtin.txtar
@@ -1,8 +1,11 @@
 6
 
--- main.star:main --
+-- main.star main --
 lena = activity(len)
 
 def main():
     ret = lena.run("george")
     print(ret)
+
+-- calls.txt --
+len

--- a/tests/sessions/activity_from_func.txtar
+++ b/tests/sessions/activity_from_func.txtar
@@ -1,9 +1,12 @@
 hello, george
 
--- main.star:main --
+-- main.star main --
 def foo(name):
     return "hello, " + name
 
 def main():
     ret = activity(foo).run("george")
     print(ret)
+
+-- calls.txt --
+foo

--- a/tests/sessions/activity_global.txtar
+++ b/tests/sessions/activity_global.txtar
@@ -2,3 +2,5 @@
 
 -- main.star --
 print(catch(activity(len).run, "george"))
+
+-- calls.txt --

--- a/tests/sessions/activity_hard_failure.txtar
+++ b/tests/sessions/activity_hard_failure.txtar
@@ -1,9 +1,12 @@
 3
 done
 
--- main.star:main --
+-- main.star main --
 load("testtools", "fail_activity")
 
 def main():
     print(fail_activity(n=3, hard=True))
     print("done")
+
+-- calls.txt --
+fail_activity

--- a/tests/sessions/activity_nested.txtar
+++ b/tests/sessions/activity_nested.txtar
@@ -1,9 +1,12 @@
 (None, "nested activities are not supported")
 
--- main.star:main --
+-- main.star main --
 def foo(name):
     return activity(len).run(name)
 
 def main():
     ret = catch(activity(foo).run, "george")
     print(ret)
+
+-- calls.txt --
+foo

--- a/tests/sessions/activity_soft_failure.txtar
+++ b/tests/sessions/activity_soft_failure.txtar
@@ -1,9 +1,12 @@
 (None, "soft test error")
 done
 
--- main.star:main --
+-- main.star main --
 load("testtools", "fail_activity")
 
 def main():
     print(catch(lambda: fail_activity(n=1)))
     print("done")
+
+-- calls.txt --
+fail_activity

--- a/tests/sessions/activity_with_prints.txtar
+++ b/tests/sessions/activity_with_prints.txtar
@@ -1,7 +1,7 @@
 meow, world
 5
 
--- main.star:main --
+-- main.star main --
 def foo(name):
     print("meow, " + name)
     return len(name)
@@ -9,3 +9,7 @@ def foo(name):
 def main():
     ret = activity(foo).run("world")
     print(ret)
+
+
+-- calls.txt --
+foo

--- a/tests/sessions/python_activity.txtar
+++ b/tests/sessions/python_activity.txtar
@@ -13,3 +13,6 @@ def main(event):
 @autokitteh.activity
 def foo(x):
     print(x)
+
+-- calls.txt --
+foo

--- a/tests/sessions/python_sdk_activity.txtar
+++ b/tests/sessions/python_sdk_activity.txtar
@@ -7,7 +7,7 @@ hiss
 -- main.py main --
 from random import random
 
-from autokitteh.decorators import noactivity, inhibit_activites
+from autokitteh.decorators import noactivity
 from autokitteh.sdktest import *
 
 def main(event):

--- a/tests/sessions/python_sdk_activity.txtar
+++ b/tests/sessions/python_sdk_activity.txtar
@@ -1,0 +1,32 @@
+oink
+meow
+woof
+moo
+hiss
+
+-- main.py main --
+from random import random
+
+from autokitteh.decorators import noactivity, inhibit_activites
+from autokitteh.sdktest import *
+
+def main(event):
+    # just to make sure random is called as an activity.
+    random()
+
+    print(test_default(ret="oink"))
+    print(test_activity(ret="meow"))
+    print(test_noactivity(ret="woof"))
+
+    # although test_default is called inside test_activity, it should not be 
+    # ran as an activity, as the loader does not scan the sdk.
+    print(test_noactivity_internal_call(ret="moo"))
+
+    # although random is called inside test_activity, it should not be ran as
+    # an activity, as the loader does not scan the sdk.
+    print(test_noactivity_external_call(ret="hiss"))
+
+-- calls.txt --
+random
+test_default
+test_activity

--- a/tests/sessions/python_sleep.txtar
+++ b/tests/sessions/python_sleep.txtar
@@ -1,10 +1,13 @@
 sleeping
 woke up
 
--- main.py:main --
+-- main.py main --
 from time import sleep
 
 def main(event):
     print("sleeping")
     sleep(0.1)
     print("woke up")
+
+-- calls.txt --
+# no activites are run, sleep is a naked call

--- a/tests/sessions/python_sleep.txtar
+++ b/tests/sessions/python_sleep.txtar
@@ -10,4 +10,4 @@ def main(event):
     print("woke up")
 
 -- calls.txt --
-# no activites are run, sleep is a naked call
+# no activities are run, sleep is a naked call


### PR DESCRIPTION
no need to run any of the sdk client init functions or the package install functions as activities, even if called in non-global scope.

this introduces a `@_noactivity` decorator for internal SDK use to achieve that.

based on https://github.com/autokitteh/autokitteh/pull/1096.