### PR TITLE
feat(slack,github): improve handling of event signatures

### DIFF
--- a/integrations/common/webhooks.go
+++ b/integrations/common/webhooks.go
@@ -1,0 +1,9 @@
+package common
+
+import (
+	"net/http"
+)
+
+func HTTPError(w http.ResponseWriter, code int) {
+	http.Error(w, http.StatusText(code), code)
+}

--- a/integrations/microsoft/event.go
+++ b/integrations/microsoft/event.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 
 	"go.uber.org/zap"
+
+	"go.autokitteh.dev/autokitteh/integrations/common"
 )
 
 // https://learn.microsoft.com/en-us/graph/api/resources/changenotificationcollection
@@ -39,7 +41,7 @@ func (h handler) handleEvent(w http.ResponseWriter, r *http.Request) {
 	var notifs changeNotifs
 	if err := json.NewDecoder(r.Body).Decode(&notifs); err != nil {
 		h.logger.Warn("MS change notif: failed to parse request body", zap.Error(err))
-		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		common.HTTPError(w, http.StatusBadRequest)
 		return
 	}
 

--- a/integrations/microsoft/lifecycle.go
+++ b/integrations/microsoft/lifecycle.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 
 	"go.uber.org/zap"
+
+	"go.autokitteh.dev/autokitteh/integrations/common"
 )
 
 // handleLifecycle receives asynchronous events ("lifecycle notifications") from
@@ -30,7 +32,7 @@ func (h handler) handleLifecycle(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		h.logger.Warn("MS lifecycle notif: failed to read request body", zap.Error(err))
-		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		common.HTTPError(w, http.StatusBadRequest)
 		return
 	}
 	l.Warn("TODO: handle MS lifecycle notif", zap.ByteString("body", body))

--- a/integrations/slack/events/http.go
+++ b/integrations/slack/events/http.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 
 	"go.uber.org/zap"
+
+	"go.autokitteh.dev/autokitteh/integrations/common"
 )
 
 func invalidEventError(l *zap.Logger, w http.ResponseWriter, body []byte, err error) {
@@ -17,5 +19,5 @@ func invalidEventError(l *zap.Logger, w http.ResponseWriter, body []byte, err er
 		// there's no way/need to write an HTTP error response.
 		return
 	}
-	http.Error(w, "Bad Request", http.StatusBadRequest)
+	common.HTTPError(w, http.StatusBadRequest)
 }

--- a/integrations/slack/webhooks/bot_events.go
+++ b/integrations/slack/webhooks/bot_events.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/internal/extrazap"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 	"go.autokitteh.dev/autokitteh/integrations/slack/events"
@@ -69,7 +70,7 @@ func (h handler) HandleBotEvent(w http.ResponseWriter, r *http.Request) {
 			zap.ByteString("json", body),
 			zap.Error(err),
 		)
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		common.HTTPError(w, http.StatusBadRequest)
 		return
 	}
 
@@ -85,7 +86,7 @@ func (h handler) HandleBotEvent(w http.ResponseWriter, r *http.Request) {
 			zap.ByteString("body", body),
 			zap.Any("callback", cb),
 		)
-		http.Error(w, "Not Implemented", http.StatusNotImplemented)
+		common.HTTPError(w, http.StatusNotImplemented)
 		return
 	}
 	slackEvent := f(l, w, body, cb)
@@ -96,7 +97,7 @@ func (h handler) HandleBotEvent(w http.ResponseWriter, r *http.Request) {
 	// Transform the received Slack event into an AutoKitteh event.
 	akEvent, err := transformEvent(l, slackEvent, cb.Event.Type)
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		common.HTTPError(w, http.StatusInternalServerError)
 		return
 	}
 
@@ -106,7 +107,7 @@ func (h handler) HandleBotEvent(w http.ResponseWriter, r *http.Request) {
 	cids, err := h.listConnectionIDs(ctx, cb.APIAppID, enterpriseID, cb.TeamID)
 	if err != nil {
 		l.Error("Failed to find connection IDs", zap.Error(err))
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		common.HTTPError(w, http.StatusInternalServerError)
 		return
 	}
 

--- a/integrations/slack/webhooks/interaction.go
+++ b/integrations/slack/webhooks/interaction.go
@@ -11,6 +11,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/internal/extrazap"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api/chat"
@@ -182,7 +183,7 @@ func (h handler) HandleInteraction(w http.ResponseWriter, r *http.Request) {
 			zap.ByteString("body", body),
 			zap.Error(err),
 		)
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		common.HTTPError(w, http.StatusBadRequest)
 		return
 	}
 	j = strings.TrimPrefix(j, "payload=")
@@ -192,14 +193,14 @@ func (h handler) HandleInteraction(w http.ResponseWriter, r *http.Request) {
 			zap.String("json", j),
 			zap.Error(err),
 		)
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		common.HTTPError(w, http.StatusBadRequest)
 		return
 	}
 
 	// Transform the received Slack event into an AutoKitteh event.
 	akEvent, err := transformEvent(l, payload, "interaction")
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		common.HTTPError(w, http.StatusInternalServerError)
 		return
 	}
 
@@ -212,7 +213,7 @@ func (h handler) HandleInteraction(w http.ResponseWriter, r *http.Request) {
 	cids, err := h.listConnectionIDs(ctx, payload.APIAppID, enterpriseID, payload.Team.ID)
 	if err != nil {
 		l.Error("Failed to find connection IDs", zap.Error(err))
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		common.HTTPError(w, http.StatusInternalServerError)
 		return
 	}
 

--- a/integrations/slack/webhooks/slash_command.go
+++ b/integrations/slack/webhooks/slash_command.go
@@ -8,6 +8,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/slack/api"
 )
 
@@ -71,7 +72,7 @@ func (h handler) HandleSlashCommand(w http.ResponseWriter, r *http.Request) {
 			zap.ByteString("body", body),
 			zap.Error(err),
 		)
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		common.HTTPError(w, http.StatusBadRequest)
 		return
 	}
 
@@ -107,7 +108,7 @@ func (h handler) HandleSlashCommand(w http.ResponseWriter, r *http.Request) {
 	// Transform the received Slack event into an AutoKitteh event.
 	akEvent, err := transformEvent(l, cmd, "slash_command")
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		common.HTTPError(w, http.StatusInternalServerError)
 		return
 	}
 
@@ -116,7 +117,7 @@ func (h handler) HandleSlashCommand(w http.ResponseWriter, r *http.Request) {
 	cids, err := h.listConnectionIDs(ctx, cmd.APIAppID, cmd.EnterpriseID, cmd.TeamID)
 	if err != nil {
 		l.Error("Failed to find connection IDs", zap.Error(err))
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		common.HTTPError(w, http.StatusInternalServerError)
 		return
 	}
 

--- a/integrations/slack/webhooks/webhook.go
+++ b/integrations/slack/webhooks/webhook.go
@@ -120,7 +120,7 @@ func (h handler) checkRequest(w http.ResponseWriter, r *http.Request, l *zap.Log
 
 	// Verify signature.
 	if !verifySignature(signingSecret, ts, sig, body) {
-		l.Error("signature verification failed",
+		l.Warn("signature verification failed",
 			zap.String("signature", sig),
 			zap.Bool("has_signing_secret", signingSecret != ""),
 			zap.String("app_id", aid),
@@ -154,7 +154,7 @@ func verifySignature(signingSecret, ts, want string, body []byte) bool {
 // Transform the received Slack event into an AutoKitteh event.
 func transformEvent(l *zap.Logger, slackEvent any, eventType string) (sdktypes.Event, error) {
 	l = l.With(
-		zap.String("eventType", eventType),
+		zap.String("event_type", eventType),
 		zap.Any("event", slackEvent),
 	)
 
@@ -195,8 +195,8 @@ func (h handler) dispatchAsyncEventsToConnections(ctx context.Context, cids []sd
 	for _, cid := range cids {
 		eid, err := h.dispatch(ctx, e.WithConnectionDestinationID(cid), nil)
 		l := l.With(
-			zap.String("connectionID", cid.String()),
-			zap.String("eventID", eid.String()),
+			zap.String("connection_id", cid.String()),
+			zap.String("event_id", eid.String()),
 		)
 		if err != nil {
 			l.Error("event dispatch failed", zap.Error(err))

--- a/integrations/twilio/webhooks/message.go
+++ b/integrations/twilio/webhooks/message.go
@@ -6,6 +6,7 @@ import (
 	"github.com/iancoleman/strcase"
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/internal/extrazap"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
@@ -30,7 +31,7 @@ func (h handler) HandleMessage(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		l.Warn("Failed to parse inbound HTTP request", zap.Error(err))
 		// Attack or network loss, so no need for user-friendliness.
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		common.HTTPError(w, http.StatusBadRequest)
 		return
 	}
 
@@ -55,7 +56,7 @@ func (h handler) HandleMessage(w http.ResponseWriter, r *http.Request) {
 			zap.Any("data", data),
 			zap.Error(err),
 		)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		common.HTTPError(w, http.StatusInternalServerError)
 		return
 	}
 
@@ -64,7 +65,7 @@ func (h handler) HandleMessage(w http.ResponseWriter, r *http.Request) {
 	cids, err := h.vars.FindConnectionIDs(ctx, h.integrationID, sdktypes.NewSymbol("account_sid"), aid)
 	if err != nil {
 		l.Error("Failed to find connection IDs", zap.Error(err))
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		common.HTTPError(w, http.StatusInternalServerError)
 		return
 	}
 

--- a/internal/backend/auth/authloginhttpsvc/github.go
+++ b/internal/backend/auth/authloginhttpsvc/github.go
@@ -44,7 +44,7 @@ func registerGithubOAuthRoutes(mux *http.ServeMux, cfg oauth2Config, onSuccess f
 		}
 
 		if gu.Login == nil || gu.ID == nil || gu.Name == nil || gu.Email == nil {
-			http.Error(w, "github user missing data", http.StatusInternalServerError)
+			http.Error(w, "GitHub user missing data", http.StatusInternalServerError)
 			return
 		}
 

--- a/internal/backend/auth/authloginhttpsvc/google.go
+++ b/internal/backend/auth/authloginhttpsvc/google.go
@@ -45,7 +45,7 @@ func registerGoogleOAuthRoutes(mux *http.ServeMux, cfg oauth2Config, onSuccess f
 		}
 
 		if gu.Id == "" || gu.Name == "" || gu.Email == "" {
-			http.Error(w, "google user missing data", http.StatusInternalServerError)
+			http.Error(w, "Google user missing data", http.StatusInternalServerError)
 			return
 		}
 


### PR DESCRIPTION
tl;dr - need more & better logging for signature verification errors.

Refactor `getCustomOAuthSigningSecret()` to handle all OAuth signing secrets. Ensure that all related methods pass `appID`, `enterpriseID`, `teamID` (in this order).

When reading connection vars from the DB for this, read only the signing secret, not all vars.

In case of signature verification errors, log these details: received signature, whether or not the signing secret is an empty string (server or connection config error), app ID, enterprise ID, team ID. None of these details is sensitive.

Cosmetic tweaks:

- New function for standard reporting of HTTP errors
- Changing log messages to be lower-cased, unlike comments - to standardize logging style across AK
- Rename `getCustomOAuthSigningSecret()` ("get" not idiomatic, "custom" is an old term)

Refs: INT-286