### PR TITLE
fix(integrations): validate before saving api key in chatgpt

### DIFF
--- a/integrations/chatgpt/save.go
+++ b/integrations/chatgpt/save.go
@@ -44,7 +44,13 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	apiKey := r.Form.Get("key")
+	if err := validateApiKey(apiKey); err != nil {
+		c.AbortBadRequest("invalid API key")
+		return
+	}
+
 	c.Finalize(sdktypes.NewVars().
-		Set(apiKeyVar, r.Form.Get("key"), true).
+		Set(apiKeyVar, apiKey, true).
 		Set(authTypeVar, integrations.Init, false))
 }


### PR DESCRIPTION
This bug was reported by @haimzlato, where running ChatGPT in production with an invalid ID caused an infinite loop. I was unable to reproduce this issue locally or on the latest production version. However, I did address a related issue: the lack of API key validation.

**Testing**: Manually tested both success and failure cases locally.