### PR TITLE
feat: add session_id to parameters when starting a session

### DIFF
--- a/cmd/ak/cmd/sessions/test.go
+++ b/cmd/ak/cmd/sessions/test.go
@@ -31,6 +31,9 @@ var (
 
 	// File "/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result`
 	pyLibRe = regexp.MustCompile(`File ".*/lib/python3\.\d+/(.*\.py)", line (\d+), in (.*)`)
+
+	// Some python version like to put an annoying ^^^^ marker to show where the error is.
+	pyAnnoyingErrorLocationMarkerRe = regexp.MustCompile(`^\s*~*\^+$`)
 )
 
 func normalizePath(p string) string {
@@ -151,6 +154,11 @@ var testCmd = common.StandardCommand(&cobra.Command{
 			s := bufio.NewScanner(strings.NewReader(ps))
 			for s.Scan() {
 				line := normalizePath(s.Text())
+
+				if pyAnnoyingErrorLocationMarkerRe.MatchString(line) {
+					continue
+				}
+
 				prints.WriteString(line)
 				prints.WriteRune('\n')
 			}

--- a/internal/backend/sessions/sessionworkflows/workflow.go
+++ b/internal/backend/sessions/sessionworkflows/workflow.go
@@ -574,7 +574,12 @@ func (w *sessionWorkflow) run(wctx workflow.Context, l *zap.Logger) (prints []sd
 			return prints, err
 		}
 
-		if retVal, err = run.Call(ctx, callValue, nil, w.data.Session.Inputs()); err != nil {
+		inputs := map[string]sdktypes.Value{
+			"data":       sdktypes.NewDictValueFromStringMap(w.data.Session.Inputs()),
+			"session_id": sdktypes.NewStringValue(sid.String()),
+		}
+
+		if retVal, err = run.Call(ctx, callValue, nil, inputs); err != nil {
 			return prints, err
 		}
 	}

--- a/runtimes/pythonrt/pythonrt.go
+++ b/runtimes/pythonrt/pythonrt.go
@@ -175,10 +175,8 @@ const archiveKey = "code.tar"
 // All Python handler function get all event information.
 var pyModuleFunc = kittehs.Must1(sdktypes.ModuleFunctionFromProto(&sdktypes.ModuleFunctionPB{
 	Input: []*sdktypes.ModuleFunctionFieldPB{
-		{Name: "created_at"},
 		{Name: "data"},
-		{Name: "event_id"},
-		{Name: "integration_id"},
+		{Name: "session_id"},
 	},
 }))
 
@@ -529,7 +527,7 @@ func (py *pySvc) initialCall(ctx context.Context, funcName string, args []sdktyp
 	keys := slices.Collect(maps.Keys(event))
 	py.log.Info("event", zap.Any("keys", keys))
 
-	eventData, err := json.Marshal(map[string]any{"data": event})
+	eventData, err := json.Marshal(event)
 	if err != nil {
 		return sdktypes.InvalidValue, fmt.Errorf("marshal event: %w", err)
 	}

--- a/tests/sessions/python_activity_exception.txtar
+++ b/tests/sessions/python_activity_exception.txtar
@@ -4,18 +4,14 @@ error: division by zero
 Traceback (most recent call last):
    ak-runner
     value = fn(*args, **kw)
-            ^^^^^^^^^^^^^^^
   File "main.py", line 6, in main
     step()
    ak-runner
     return self.runner.call_in_activity(func, args, kw)
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ak-runner
     return fut.result()
-           ^^^^^^^^^^^^
   py-lib/concurrent/futures/_base.py, line XXX, in result
     return self.__get_result()
-           ^^^^^^^^^^^^^^^^^^^
   py-lib/concurrent/futures/_base.py, line XXX, in __get_result
     raise self._exception
 ZeroDivisionError: division by zero

--- a/tests/sessions/python_exception.txtar
+++ b/tests/sessions/python_exception.txtar
@@ -3,7 +3,6 @@ error: X()
 Traceback (most recent call last):
    ak-runner
     value = fn(*args, **kw)
-            ^^^^^^^^^^^^^^^
   File "main.py", line 4, in main
     raise X()
 main.X

--- a/tests/system/testdata/deployments/state.txtar
+++ b/tests/system/testdata/deployments/state.txtar
@@ -48,8 +48,8 @@ project:
       call: program.star:on_http_get
 
 -- program.star --
-def on_http_get(raw_url):
-    if raw_url.endswith('short'):
+def on_http_get(data):
+    if data['raw_url'].endswith('short'):
       print(ak.is_deployment_active())
       return
 

--- a/tests/system/testdata/end2end/http.txtar
+++ b/tests/system/testdata/end2end/http.txtar
@@ -33,9 +33,9 @@ project:
       call: program.star:on_http
 
 -- program.star --
-def on_http(method, body):
-    print(method)
-    print(body)
+def on_http(data):
+    print(data["method"])
+    print(data["body"])
 
 -- expected_without_path.json --
 {
@@ -53,10 +53,7 @@ def on_http(method, body):
                         "desc": {
                             "input": [
                                 {
-                                    "name": "method"
-                                },
-                                {
-                                    "name": "body"
+                                    "name": "data"
                                 }
                             ]
                         },
@@ -87,10 +84,7 @@ def on_http(method, body):
                         "desc": {
                             "input": [
                                 {
-                                    "name": "method"
-                                },
-                                {
-                                    "name": "body"
+                                    "name": "data"
                                 }
                             ]
                         },

--- a/tests/system/testdata/end2end/pyhttp.txtar
+++ b/tests/system/testdata/end2end/pyhttp.txtar
@@ -1,0 +1,64 @@
+# Deploy project with HTTP triggers that check session data.
+ak deploy --manifest project.yaml
+return code == 0
+
+# Send HTTP GET request to trigger deployment to start new session.
+http get /webhooks/00000000000000000000000003/
+resp code == 202
+
+wait 5s for session ses_00000000000000000000000007
+
+ak session log my_project --no-timestamps --page-size 1 --order desc -J
+return code == 0
+output equals_json file expected_without_path.json
+
+-- project.yaml --
+version: v1
+
+project:
+  name: my_project
+  triggers:
+    - name: http
+      type: webhook
+      call: program.py:on_http
+
+-- program.py --
+def on_http(event):
+    print(event.data["method"])
+    print(event.session_id)
+
+-- expected_without_path.json --
+{
+    "state": {
+        "completed": {
+            "prints": [
+                "GET",
+                "ses_00000000000000000000000007"
+            ],
+            "exports": {
+                "on_http": {
+                    "function": {
+                        "executor_id": "run_00000000000000000000000008",
+                        "name": "on_http",
+                        "desc": {
+                            "input": [
+                                {
+                                    "name": "event"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "return_value": {
+                "custom": {
+                    "executor_id": "run_00000000000000000000000008",
+                    "data": "gASVHgAAAAAAAACMCF9fbWFpbl9flIwGUmVzdWx0lJOUTk5Oh5SBlC4=",
+                    "value": {
+                        "nothing": {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/system/testdata/events/get.txtar
+++ b/tests/system/testdata/events/get.txtar
@@ -29,5 +29,5 @@ project:
       call: program.star:on_http
 
 -- program.star --
-def on_http(data, trigger, event):
+def on_http(data):
     pass

--- a/tests/system/testdata/events/list.txtar
+++ b/tests/system/testdata/events/list.txtar
@@ -35,5 +35,5 @@ project:
       call: program.star:on_http
 
 -- program.star --
-def on_http(data, trigger, event):
+def on_http(data):
     pass

--- a/tests/system/testdata/sessions/start.txtar
+++ b/tests/system/testdata/sessions/start.txtar
@@ -23,10 +23,10 @@ return code == 0
 output equals file last.txt
 
 -- main.star --
-def main(a, b, c):
-  print(a)
-  print(b)
-  print(c)
+def main(data):
+  print(data["a"])
+  print(data["b"])
+  print(data["c"])
   print("finished")
 
 -- last.txt --


### PR DESCRIPTION
this can work now:

```
def on_trigger(event):
  print(event.session_id)
  print(event.data)
```

sometimes the user might want to correlate the session id with data that is sent elsewhere. we might also can associate more data to the event other than the input data.