### PR TITLE
refactor(CI): improve build time & isolation

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -31,7 +31,6 @@ jobs:
 
   go-system-tests:
     name: Go system tests
-    needs: [go-unit-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -32,7 +32,7 @@ jobs:
   go-system-tests:
     name: Go system tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 
-      - name: Build
-        run: go build -trimpath ./cmd/ak
+      - name: Build AK
+        run: go build -trimpath -o bin/ak ./cmd/ak
 
       - name: Test
         run: gotestsum -f testname -- -trimpath ./tests/system

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -1,20 +1,18 @@
-# Continuous Integration workflow for Go projects. For more information see:
 # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 # https://golangci-lint.run/usage/install#github-actions
 
-name: Continuous Integration - Go
+name: CI - Go
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
+  push:
+    branches: [main]
 
 jobs:
-  build-and-test:
-    name: Build + unit tests
+  go-unit-tests:
+    name: Go build + unit tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -24,16 +22,33 @@ jobs:
           go-version-file: go.mod
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
-      - name: Download modules
-        run: go mod download
+
       - name: Build
-        run: make build bin
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11" # Should be in sync with runtimes/pythonrt/pythonrt.go:minPyVersion
+        run: go build -trimpath ./...
+
       - name: Test
-        run: make test-unit
+        run: gotestsum -f testname -- -trimpath $(go list ./... | grep -v -E "autokitteh/tests|runtimes/python")
+
+  go-system-tests:
+    name: Go system tests
+    needs: [go-unit-tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Build
+        run: go build -trimpath ./cmd/ak
+
+      - name: Test
+        run: gotestsum -f testname -- -trimpath ./tests/system
 
   static-analysis:
     name: Static analysis
@@ -130,10 +145,11 @@ jobs:
 
   publish_docker_image:
     needs:
+      - go-unit-tests
+      - go-system-tests
       - test-sessions
       - test-runs
       - static-analysis
-      - build-and-test
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -25,7 +25,7 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
 
       - name: Test
-        run: gotestsum -f testname -- -trimpath ./runtimes/pythonrt/...
+        run: gotestsum -f testname -- -trimpath ./runtimes/pythonrt
 
   python-unit-tests:
     name: Python unit tests

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,14 +1,34 @@
-name: Continuous Integration - Python
+name: CI - Python
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
+  push:
+    branches: [main]
 
 jobs:
-  build-and-test-python:
-    name: Build + unit tests
+  python-runtime-go-tests:
+    name: Python runtime Go tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Test
+        run: gotestsum -f testname -- -trimpath ./runtimes/pythonrt/...
+
+  python-unit-tests:
+    name: Python unit tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -21,7 +41,7 @@ jobs:
       - name: Test
         run: cd runtimes/pythonrt && make ci
 
-  test-python-sessions:
+  python-session-tests:
     name: Python Session tests
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ clean:
 .PHONY: bin
 bin: bin/ak
 
-.PHONY: bin/ak
 bin/ak:
 	$(GO) build --tags "${TAGS}" -o "$@" -ldflags="$(LDFLAGS)" $(GO_BUILD_OPTS) ./cmd/$(shell basename $@)
 
@@ -121,20 +120,6 @@ test-dbgorm:
 		echo running for $$dbtype; \
 	go test -v ./internal/backend/db/dbgorm -dbtype $$dbtype ; \
 	done
-
-# Skip a few Go unit-tests under "runtimes/pythonrt/" - either because they
-# fails due to missing Python deps, or because they are very slow (20-30 sec).
-# Note that this affects only Go CI in GitHub (which runs "make test-unit"),
-# but not manual runs of "make" (which depend on "test-race"), or Python CI
-# in GitHub (which uses "runtimes/pythonrt/Makefile").
-.PHONY: test-unit
-test-unit:
-	$(GOTEST) ./... -skip "(pyExports|pySvc|createVEnv)"
-
-# Subset of "test-unit", for simplicity.
-.PHONY: test-system
-test-system:
-	$(GOTEST) ./tests/system
 
 .PHONY: test-runs
 test-runs:


### PR DESCRIPTION
Part 1 of refactoring CI: don't run any more or less, just segment it differently, enable caching, and avoid duplication.

- Go:
  - Don't use `make bin/ak` - it blocks caching (due to timestamp-based build flags)
  - Split between unit tests and long-running system tests
  - Don't run session tests in unit-tests job, already running in other jobs
  - Don't run `go mod download` - useful in the past, but not anymore with better caching
- Python: move Python runtime's Go tests to Python workflow (due to Python dependency)

Stats:

- Go in main: 12m32s
  - https://github.com/autokitteh/autokitteh/actions/runs/13466518794/job/37633353273
- Go in this PR: 2m52s + 7m42s = 10m34s
  - https://github.com/autokitteh/autokitteh/actions/runs/13477279622/job/37657993992?pr=1108
  - https://github.com/autokitteh/autokitteh/actions/runs/13477279622/job/37658023378?pr=1108

Refs: ENG-2014