### PR TITLE
refactor(CI): session tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,6 +30,24 @@ jobs:
       - name: Test
         run: gotestsum -f testname -- -trimpath $(go list ./... | grep -v -E "autokitteh/tests|runtimes/python")
 
+  go-session-tests:
+    name: Go session tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build AK
+        run: go build -trimpath -o bin/ak ./cmd/ak
+
+      - name: Test
+        run: PYTHON=skip ./tests/sessions/run.sh
+
   go-system-tests:
     name: Go system tests
     runs-on: ubuntu-latest
@@ -73,24 +91,6 @@ jobs:
           # https://github.com/golangci/golangci-lint-action/issues/308
           args: --timeout=5m
 
-  test-sessions:
-    name: Session tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12" # Should be in sync with runtimes/pythonrt/pythonrt.go:minPyVersion
-      - name: Session tests
-        run: make bin/ak test-sessions
-
   verify-docker-builds:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -117,8 +117,8 @@ jobs:
   publish_docker_image:
     needs:
       - go-unit-tests
+      - go-session-tests
       - go-system-tests
-      - test-sessions
       - static-analysis
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -58,6 +58,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12" # Should be in sync with runtimes/pythonrt/pythonrt.go:minPyVersion
-      - name: Python Session tests
-        run: PYTHON=only make bin/ak test-sessions
+          python-version: "3.12"
+
+      - name: Build AK
+        run: go build -trimpath -o bin/ak ./cmd/ak
+
+      - name: Test
+        run: PYTHON=only ./tests/sessions/run.sh

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ test-starlark: bin/ak
 	./tests/starlark/run.sh
 
 .PHONY: test-sessions
-test-sessions:
+test-sessions: bin/ak
 	./tests/sessions/run.sh
 
 .PHONY: test-dbgorm


### PR DESCRIPTION
Fix 1: `make test-sessions` didn't depend on `bin/ak` - this is a mistake because it requires it, and we can't just assume that it's up-to-date.

But... Fix 2: this means we also need to build AK and run `run.sh` directly in the Go and Python CI workflows, to make GitHub caching effective like in #1108, and avoid building AK twice.

Refs: ENG-2014