### PR TITLE
refactor(CI): bring back "go mod download"

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -92,7 +92,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           # Keep the same version in "/Makefile"!
-          # See: https://github.com/golangci/golangci-lint
+          # See: https://github.com/golangci/golangci-lint/releases
           version: v1.64.5
           # https://github.com/golangci/golangci-lint-action/issues/308
           args: --timeout=7m

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - name: Download Go modules
+        run: go mod download
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 
@@ -41,6 +43,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - name: Download Go modules
+        run: go mod download
 
       - name: Build AK
         run: go build -trimpath -o bin/ak ./cmd/ak
@@ -59,6 +63,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - name: Download Go modules
+        run: go mod download
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 
@@ -87,9 +93,9 @@ jobs:
         with:
           # Keep the same version in "/Makefile"!
           # See: https://github.com/golangci/golangci-lint
-          version: v1.63.1
+          version: v1.64.5
           # https://github.com/golangci/golangci-lint-action/issues/308
-          args: --timeout=5m
+          args: --timeout=7m
 
   verify-docker-builds:
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Download Go modules
+        run: go mod download
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 
@@ -40,7 +42,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12" # Should be in sync with runtimes/pythonrt/pythonrt.go:minPyVersion
+          python-version: "3.12"
+
       - name: Test
         run: cd runtimes/pythonrt && make ci
 
@@ -59,6 +62,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Download Go modules
+        run: go mod download
 
       - name: Build AK
         run: go build -trimpath -o bin/ak ./cmd/ak

--- a/.github/workflows/starlark.yml
+++ b/.github/workflows/starlark.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - name: Download Go modules
+        run: go mod download
 
       - name: Build AK
         run: go build -trimpath -o bin/ak ./cmd/ak

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ golangci_lint=$(shell which golangci-lint)
 $(OUTDIR)/tools/golangci-lint:
 	mkdir -p $(OUTDIR)/tools
 ifeq ($(golangci_lint),)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(OUTDIR)/tools" v1.63.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(OUTDIR)/tools" v1.64.5
 else
 	ln -fs $(golangci_lint) $(OUTDIR)/tools/golangci-lint
 endif

--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,9 @@ gofmt-check:
 
 golangci_lint=$(shell which golangci-lint)
 
-# https://golangci-lint.run/usage/install/#local-installation
-# Keep the same version in "/.github/workflows/ci-go.yml"!
-# See: https://github.com/golangci/golangci-lint
+# Based on: https://golangci-lint.run/welcome/install/#other-ci
+# Keep the same version in "/.github/workflows/go.yml"!
+# See: https://github.com/golangci/golangci-lint/releases
 $(OUTDIR)/tools/golangci-lint:
 	mkdir -p $(OUTDIR)/tools
 ifeq ($(golangci_lint),)


### PR DESCRIPTION
It does have some potential time-saving impact in the first time you run checks for a new PR: somewhere between 5 and 50 seconds.

Also update golangci-lint version on the way.

Ref: ENG-2014, #1108