### PR TITLE
fix: optimize withProjectOrgID join so events listing is faster

### DIFF
--- a/internal/backend/db/dbgorm/helpers.go
+++ b/internal/backend/db/dbgorm/helpers.go
@@ -45,7 +45,7 @@ func withProjectOrgID(q *gorm.DB, oid sdktypes.OrgID, table string) *gorm.DB {
 		return q
 	}
 
-	return q.Joins(fmt.Sprintf("INNER JOIN projects ON %s.project_id = projects.project_id AND projects.org_id = ?", table), oid.UUIDValue()).Distinct()
+	return q.Joins(fmt.Sprintf("RIGHT JOIN projects ON %s.project_id = projects.project_id AND projects.org_id = ?", table), oid.UUIDValue())
 }
 
 func based(ctx context.Context) scheme.Base {


### PR DESCRIPTION
no need for distinct since the results always has some id in each row use right join on projects so the optimizer knows to use the correct index instead of fetching both tables and join later