### PR TITLE
fix: connstatus false positive

### DIFF
--- a/integrations/auth0/client.go
+++ b/integrations/auth0/client.go
@@ -56,11 +56,7 @@ func connStatus(i *integration) sdkintegrations.OptFn {
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		}
 		if at.Value() == integrations.OAuth {
-			token := vs.GetValueByString("oauth_AccessToken")
-			if token == "" {
-				return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
-			}
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
+			return common.CheckLegacyOAuthToken(vs)
 		}
 
 		return sdktypes.NewStatus(sdktypes.StatusCodeError, "Bad auth type"), nil

--- a/integrations/common/vars.go
+++ b/integrations/common/vars.go
@@ -38,6 +38,11 @@ func EncodeOAuthData(t *oauth2.Token) OAuthData {
 	}
 }
 
+// IsOAuthTokenEmpty returns true if the OAuth 2.0 token is empty.
+func IsOAuthTokenEmpty(vs sdktypes.Vars) bool {
+	return vs.GetValue(OAuthAccessTokenVar) == ""
+}
+
 // ReadConnectionVars returns the connection's variables, or
 // an error if the connection is not initialized or accessible.
 func ReadConnectionVars(ctx context.Context, vars sdkservices.Vars, cid sdktypes.ConnectionID) (sdktypes.Vars, sdktypes.Status, error) {

--- a/integrations/common/vars.go
+++ b/integrations/common/vars.go
@@ -18,6 +18,8 @@ var (
 	OAuthExpiryVar       = sdktypes.NewSymbol("oauth_expiry")
 	OAuthRefreshTokenVar = sdktypes.NewSymbol("oauth_refresh_token")
 	OAuthTokenTypeVar    = sdktypes.NewSymbol("oauth_token_type")
+
+	LegacyOAuthAccessTokenVar = sdktypes.NewSymbol("oauth_AccessToken")
 )
 
 // OAuthData contains OAuth 2.0 token details.
@@ -28,6 +30,24 @@ type OAuthData struct {
 	TokenType    string `var:"oauth_token_type"`
 }
 
+// CheckOAuthToken returns a warning status if OAuthAccessTokenVar is missing in sdktypes.Vars; otherwise, it returns OK.
+// It depends on sdktypes.Vars being preloaded with OAuthAccessTokenVar, which isn't validated.
+func CheckOAuthToken(vs sdktypes.Vars) (sdktypes.Status, error) {
+	if vs.GetValue(OAuthAccessTokenVar) == "" {
+		return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
+	}
+	return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
+}
+
+// CheckOAuthToken returns a warning status if LegacyOAuthAccessTokenVar is missing in sdktypes.Vars; otherwise, it returns OK.
+// It depends on sdktypes.Vars being preloaded with LegacyOAuthAccessTokenVar, which isn't validated.
+func CheckLegacyOAuthToken(vs sdktypes.Vars) (sdktypes.Status, error) {
+	if vs.GetValue(LegacyOAuthAccessTokenVar) == "" {
+		return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
+	}
+	return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
+}
+
 // EncodeOAuthData encodes an OAuth 2.0 token into AutoKitteh connection variables.
 func EncodeOAuthData(t *oauth2.Token) OAuthData {
 	return OAuthData{
@@ -36,11 +56,6 @@ func EncodeOAuthData(t *oauth2.Token) OAuthData {
 		RefreshToken: t.RefreshToken,
 		TokenType:    t.TokenType,
 	}
-}
-
-// IsOAuthTokenEmpty returns true if the OAuth 2.0 token is empty.
-func IsOAuthTokenEmpty(vs sdktypes.Vars) bool {
-	return vs.GetValue(OAuthAccessTokenVar) == ""
 }
 
 // ReadConnectionVars returns the connection's variables, or

--- a/integrations/common/vars.go
+++ b/integrations/common/vars.go
@@ -30,8 +30,8 @@ type OAuthData struct {
 	TokenType    string `var:"oauth_token_type"`
 }
 
-// CheckOAuthToken returns a warning status if OAuthAccessTokenVar is missing in sdktypes.Vars; otherwise, it returns OK.
-// It depends on sdktypes.Vars being preloaded with OAuthAccessTokenVar, which isn't validated.
+// CheckOAuthToken returns a warning status if [OAuthAccessTokenVar] is missing in [sdktypes.Vars]; otherwise,
+// it returns OK. It depends on [sdktypes.Vars] being preloaded with [OAuthAccessTokenVar], which isn't validated.
 func CheckOAuthToken(vs sdktypes.Vars) (sdktypes.Status, error) {
 	if vs.GetValue(OAuthAccessTokenVar) == "" {
 		return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil

--- a/integrations/common/vars.go
+++ b/integrations/common/vars.go
@@ -39,8 +39,8 @@ func CheckOAuthToken(vs sdktypes.Vars) (sdktypes.Status, error) {
 	return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
 }
 
-// CheckOAuthToken returns a warning status if LegacyOAuthAccessTokenVar is missing in sdktypes.Vars; otherwise, it returns OK.
-// It depends on sdktypes.Vars being preloaded with LegacyOAuthAccessTokenVar, which isn't validated.
+// CheckLegacyOAuthToken returns a warning status if [LegacyOAuthAccessTokenVar] is missing in [sdktypes.Vars]; otherwise,
+// it returns OK. It depends on [sdktypes.Vars] being preloaded with [LegacyOAuthAccessTokenVar], which isn't validated.
 func CheckLegacyOAuthToken(vs sdktypes.Vars) (sdktypes.Status, error) {
 	if vs.GetValue(LegacyOAuthAccessTokenVar) == "" {
 		return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil

--- a/integrations/github/client.go
+++ b/integrations/github/client.go
@@ -59,7 +59,10 @@ func connStatus(i *integration) sdkintegrations.OptFn {
 
 		switch at.Value() {
 		case integrations.OAuth, integrations.OAuthDefault:
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using GitHub app"), nil
+			if vs.Get(vars.InstallID).IsValid() {
+				return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using GitHub app"), nil
+			}
+			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.PAT:
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using PAT + webhook"), nil
 		default:

--- a/integrations/google/connections/connections.go
+++ b/integrations/google/connections/connections.go
@@ -10,13 +10,12 @@ import (
 	"golang.org/x/oauth2/google"
 
 	"go.autokitteh.dev/autokitteh/integrations"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/google/vars"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
-
-var AccessToken = sdktypes.NewSymbol("oauth_AccessToken")
 
 // connStatus is an optional connection status check provided by
 // the integration to AutoKitteh. The possible results are "Init
@@ -42,10 +41,7 @@ func ConnStatus(cvars sdkservices.Vars) sdkintegrations.OptFn {
 		case integrations.JSONKey:
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using JSON key"), nil
 		case integrations.OAuth:
-			if vs.GetValue(AccessToken) == "" {
-				return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
-			}
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
+			return common.CheckLegacyOAuthToken(vs)
 		default:
 			return sdktypes.NewStatus(sdktypes.StatusCodeError, "Bad auth type"), nil
 		}

--- a/integrations/google/connections/connections.go
+++ b/integrations/google/connections/connections.go
@@ -16,6 +16,8 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
+var AccessToken = sdktypes.NewSymbol("oauth_AccessToken")
+
 // connStatus is an optional connection status check provided by
 // the integration to AutoKitteh. The possible results are "Init
 // required" (the connection is not usable yet) and "Using X".
@@ -40,6 +42,9 @@ func ConnStatus(cvars sdkservices.Vars) sdkintegrations.OptFn {
 		case integrations.JSONKey:
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using JSON key"), nil
 		case integrations.OAuth:
+			if vs.GetValue(AccessToken) == "" {
+				return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
+			}
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
 		default:
 			return sdktypes.NewStatus(sdktypes.StatusCodeError, "Bad auth type"), nil

--- a/integrations/height/checks.go
+++ b/integrations/height/checks.go
@@ -24,10 +24,7 @@ func status(v sdkservices.Vars) sdkintegrations.OptFn {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
-			if common.IsOAuthTokenEmpty(vs) {
-				return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
-			}
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
+			return common.CheckOAuthToken(vs)
 		case integrations.APIKey:
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using API key"), nil
 		default:

--- a/integrations/height/checks.go
+++ b/integrations/height/checks.go
@@ -24,6 +24,9 @@ func status(v sdkservices.Vars) sdkintegrations.OptFn {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
+			if common.IsOAuthTokenEmpty(vs) {
+				return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
+			}
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
 		case integrations.APIKey:
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using API key"), nil

--- a/integrations/hubspot/client.go
+++ b/integrations/hubspot/client.go
@@ -51,11 +51,7 @@ func connStatus(i *integration) sdkintegrations.OptFn {
 		}
 
 		if at.Value() == integrations.OAuth {
-			token := vs.GetValueByString("oauth_AccessToken")
-			if token == "" {
-				return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
-			}
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
+			return common.CheckLegacyOAuthToken(vs)
 		}
 
 		return sdktypes.NewStatus(sdktypes.StatusCodeError, "Bad auth type"), nil

--- a/integrations/linear/checks.go
+++ b/integrations/linear/checks.go
@@ -24,10 +24,7 @@ func status(v sdkservices.Vars) sdkintegrations.OptFn {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
-			if common.IsOAuthTokenEmpty(vs) {
-				return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
-			}
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
+			return common.CheckOAuthToken(vs)
 		case integrations.APIKey:
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using API key"), nil
 		default:

--- a/integrations/linear/checks.go
+++ b/integrations/linear/checks.go
@@ -24,6 +24,9 @@ func status(v sdkservices.Vars) sdkintegrations.OptFn {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
+			if common.IsOAuthTokenEmpty(vs) {
+				return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
+			}
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
 		case integrations.APIKey:
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using API key"), nil

--- a/integrations/microsoft/connection/checks.go
+++ b/integrations/microsoft/connection/checks.go
@@ -32,10 +32,7 @@ func Status(v sdkservices.Vars) sdkintegrations.OptFn {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
-			if common.IsOAuthTokenEmpty(vs) {
-				return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
-			}
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
+			return common.CheckOAuthToken(vs)
 		case integrations.DaemonApp:
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using daemon app"), nil
 		default:

--- a/integrations/microsoft/connection/checks.go
+++ b/integrations/microsoft/connection/checks.go
@@ -32,6 +32,9 @@ func Status(v sdkservices.Vars) sdkintegrations.OptFn {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
+			if common.IsOAuthTokenEmpty(vs) {
+				return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
+			}
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
 		case integrations.DaemonApp:
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using daemon app"), nil

--- a/integrations/salesforce/checks.go
+++ b/integrations/salesforce/checks.go
@@ -24,10 +24,7 @@ func status(v sdkservices.Vars) sdkintegrations.OptFn {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
-			if common.IsOAuthTokenEmpty(vs) {
-				return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
-			}
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
+			return common.CheckOAuthToken(vs)
 		default:
 			return sdktypes.NewStatus(sdktypes.StatusCodeError, "Bad auth type"), nil
 		}

--- a/integrations/salesforce/checks.go
+++ b/integrations/salesforce/checks.go
@@ -24,6 +24,9 @@ func status(v sdkservices.Vars) sdkintegrations.OptFn {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
+			if common.IsOAuthTokenEmpty(vs) {
+				return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
+			}
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
 		default:
 			return sdktypes.NewStatus(sdktypes.StatusCodeError, "Bad auth type"), nil

--- a/integrations/slack/checks.go
+++ b/integrations/slack/checks.go
@@ -27,10 +27,7 @@ func status(v sdkservices.Vars) sdkintegrations.OptFn {
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		// TODO(INT-267): Remove [integrations.OAuth] once the web UI is migrated too.
 		case integrations.OAuth, integrations.OAuthDefault, integrations.OAuthPrivate:
-			if common.IsOAuthTokenEmpty(vs) {
-				return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
-			}
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
+			return common.CheckOAuthToken(vs)
 		case integrations.SocketMode:
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using Socket Mode"), nil
 		default:

--- a/integrations/slack/checks.go
+++ b/integrations/slack/checks.go
@@ -27,6 +27,9 @@ func status(v sdkservices.Vars) sdkintegrations.OptFn {
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		// TODO(INT-267): Remove [integrations.OAuth] once the web UI is migrated too.
 		case integrations.OAuth, integrations.OAuthDefault, integrations.OAuthPrivate:
+			if common.IsOAuthTokenEmpty(vs) {
+				return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
+			}
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
 		case integrations.SocketMode:
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using Socket Mode"), nil

--- a/integrations/zoom/checks.go
+++ b/integrations/zoom/checks.go
@@ -24,6 +24,9 @@ func status(v sdkservices.Vars) sdkintegrations.OptFn {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
+			if common.IsOAuthTokenEmpty(vs) {
+				return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
+			}
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
 		case integrations.ServerToServer:
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using S2S"), nil

--- a/integrations/zoom/checks.go
+++ b/integrations/zoom/checks.go
@@ -24,10 +24,7 @@ func status(v sdkservices.Vars) sdkintegrations.OptFn {
 		case "":
 			return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
 		case integrations.OAuthDefault, integrations.OAuthPrivate:
-			if common.IsOAuthTokenEmpty(vs) {
-				return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
-			}
-			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
+			return common.CheckOAuthToken(vs)
 		case integrations.ServerToServer:
 			return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using S2S"), nil
 		default:


### PR DESCRIPTION
Introduces a common function to validate that an OAuth access token isn’t empty, confirming successful OAuth flow. A separate check was added for Google due to differing variable names. 
I haven’t tested the connStatus for every integration (lack of OAuth apps), but since it worked on Slack, I assume it works for the rest. 

refs: INT-225