### PR TITLE
refactor(CI): Docker images

### DIFF
--- a/.github/workflows/docker-main.yml
+++ b/.github/workflows/docker-main.yml
@@ -27,9 +27,6 @@ jobs:
           echo "${GITHUB_REF_NAME}" > .version
           echo "${GITHUB_SHA}" > .commit
 
-      - name: Fetch web platform
-        run: make webplatform
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/docker-main.yml
+++ b/.github/workflows/docker-main.yml
@@ -1,44 +1,16 @@
-# See also "main-branch.yml" and "manual-docker-image.yml" for Docker images.
-# https://github.com/marketplace/actions/goreleaser-action
+# See also "docker-pr.yml", "manual-docker-image.yml", and "release.yml".
 # https://github.com/marketplace/actions/configure-aws-credentials-action-for-github-actions
 # https://github.com/marketplace/actions/amazon-ecr-login-action-for-github-actions
 # https://github.com/marketplace/actions/build-and-push-docker-images
 
-name: Release
+name: CI - Docker (main)
 
-# https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
 
 jobs:
-  goreleaser:
-    name: GoReleaser
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Fetch web platform
-        run: make webplatform
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          version: latest
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{secrets.HOMEBREW_TAP_TOKEN}}
-
-  publish-stable-docker-image:
+  publish-latest-docker-image:
     name: Publish Docker image
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -74,6 +46,6 @@ jobs:
         with:
           context: .
           platforms: linux/amd64
-          tags: ${{steps.login-ecr.outputs.registry}}/autokitteh:${{github.ref_name}},${{steps.login-ecr.outputs.registry}}/autokitteh:stable
+          tags: ${{steps.login-ecr.outputs.registry}}/autokitteh:latest
           push: true
           provenance: false

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -15,15 +15,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup version info
-        run: |
-          # These are consumed in the Dockerfile.
-          echo "${GITHUB_REF_NAME}" > .version
-          echo "${GITHUB_SHA}" > .commit
-
-      - name: Fetch web platform
-        run: make webplatform
-
       - name: Build but don't push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -1,0 +1,34 @@
+# See also "docker-main.yml", "manual-docker-image.yml", and "release.yml".
+# https://github.com/marketplace/actions/build-and-push-docker-images
+
+name: CI - Docker (PRs)
+
+on:
+  pull_request:
+
+jobs:
+  test-docker-build:
+    name: Test Docker build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup version info
+        run: |
+          # These are consumed in the Dockerfile.
+          echo "${GITHUB_REF_NAME}" > .version
+          echo "${GITHUB_SHA}" > .commit
+
+      - name: Fetch web platform
+        run: make webplatform
+
+      - name: Build but don't push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          tags: autokitteh:latest
+          push: false
+          provenance: false

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Test
         run: gotestsum -f github-actions -- -trimpath ./tests/system/...
 
-  static-analysis:
-    name: Static analysis
+  go-static-analysis:
+    name: Go static analysis
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -88,6 +88,7 @@ jobs:
 
       - name: Detect unformatted Go
         run: make gofmt-check
+
       - name: Run Go linters
         uses: golangci/golangci-lint-action@v6
         with:
@@ -96,66 +97,3 @@ jobs:
           version: v1.64.5
           # https://github.com/golangci/golangci-lint-action/issues/308
           args: --timeout=7m
-
-  verify-docker-builds:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    if: github.ref != 'refs/heads/main'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup version info
-        run: |
-          # These are consumed in the Dockerfile.
-          echo "${GITHUB_REF#refs/tags/}" > .version
-          echo "${GITHUB_SHA}" > .commit
-      - name: Verify Image Builds
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          platforms: linux/amd64
-          tags: autokitteh:latest
-          push: false
-          provenance: false
-
-  publish_docker_image:
-    needs:
-      - go-unit-tests
-      - go-session-tests
-      - go-system-tests
-      - static-analysis
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    if: github.ref == 'refs/heads/main'
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup version info
-        run: |
-          # These are consumed in the Dockerfile.
-          echo "${GITHUB_REF#refs/tags/}" > .version
-          echo "${GITHUB_SHA}" > .commit
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_GITHUB_ROLE }}
-          role-session-name: Github_Action_Release_Autokitteh
-          aws-region: us-east-1
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Build And Push
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          platforms: linux/amd64
-          tags: ${{ steps.login-ecr.outputs.registry }}/autokitteh:latest
-          push: true
-          provenance: false

--- a/.github/workflows/manual-docker-image.yml
+++ b/.github/workflows/manual-docker-image.yml
@@ -16,7 +16,7 @@ on:
         description: version to push
 
 jobs:
-  publish-docker-image:
+  publish_docker_image:
     name: Publish Docker image
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/manual-docker-image.yml
+++ b/.github/workflows/manual-docker-image.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Fetch web platform
-        run: make webplatform
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/manual-docker-image.yml
+++ b/.github/workflows/manual-docker-image.yml
@@ -1,9 +1,11 @@
+# See also "docker-*.yml" and "release.yml" for Docker images CI.
+# https://github.com/marketplace/actions/configure-aws-credentials-action-for-github-actions
+# https://github.com/marketplace/actions/amazon-ecr-login-action-for-github-actions
+# https://github.com/marketplace/actions/build-and-push-docker-images
+
 name: manual_docker_image
 
 run-name: Publish image autokitteh:${{inputs.version}} to ECR
-
-env:
-  WORKING_DIRECTORY: .
 
 on:
   workflow_dispatch:
@@ -14,33 +16,36 @@ on:
         description: version to push
 
 jobs:
-  publish_docker_image:
+  publish-docker-image:
+    name: Publish Docker image
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     permissions:
       id-token: write
       contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+
+      - name: Fetch web platform
+        run: make webplatform
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_GITHUB_ROLE }}
+          role-to-assume: ${{secrets.AWS_GITHUB_ROLE}}
           role-session-name: Github_Action_Release_Autokitteh
           aws-region: us-east-1
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
-      - name: Fetch web platform
-        run: make webplatform
-      - name: Build And Push
-        uses: docker/build-push-action@v4
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64
-          tags: ${{ steps.login-ecr.outputs.registry }}/autokitteh:${{inputs.version}}
+          tags: ${{steps.login-ecr.outputs.registry}}/autokitteh:${{inputs.version}}
           push: true
           provenance: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,6 @@ jobs:
           echo "${GITHUB_REF_NAME}" > .version
           echo "${GITHUB_SHA}" > .commit
 
-      - name: Fetch web platform
-        run: make webplatform
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
1. Split Docker jobs out of the Go workflow: they're not related to Go, and we won't see an unexecuted job in every PR and merge-to-main now

2. Note that the job to publish the image when the PR is merged to main wasn't triggered as expected: the `if` means that the job got triggered when the `needs` jobs end, regardless of their success or failure.

   ```yaml
   needs:
     - go-unit-tests
     - go-session-tests
     - go-system-tests
     - static-analysis
   if: github.ref == 'refs/heads/main'
   ```

   (If we want to block, we can use AutoKitteh - we have a sample exactly for the scenario of 
   triggering a workflow when a group of other workflows are successful)

3. Remove `with: fetch-depth: 0` from `checkout` - it means full history, not just the latest commit (which is the default behavior) - it's needed only in Go Releaser

4. `release.yml`: changed trigger from `push: tags: "v*"` to `release: types: [published]` (see https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release)

5. `WORKING_DIRECTORY` removed: not needed since we use the root dir of a monorepo

6. `${GITHUB_REF#refs/tags/}` --> `${GITHUB_REF_NAME}` (same thing, without string substitution, which doesn't even work if the ref isn't a tag)

7. Change timeout from 30 minutes to 10 (it always takes 5 minutes to finish in all modes)

8. Misc version updates of GitHub Actions and cosmetic tweaks

Refs: ENG-2014