### PR TITLE
bug(python): Catch BaseException instead of Exception

### DIFF
--- a/runtimes/pythonrt/runner/main.py
+++ b/runtimes/pythonrt/runner/main.py
@@ -412,13 +412,14 @@ class Runner(pb.runner_rpc.RunnerService):
         value = error = tb = None
         try:
             value = fn(*args, **kw)
-            if isinstance(value, Exception):
-                set_exception_args(value)
-        except Exception as err:
+        except BaseException as err:
             log.error("%s raised: %s", func_name, err)
             tb = TracebackException.from_exception(err)
             error = err
             set_exception_args(error)
+
+        if isinstance(value, Exception):
+            set_exception_args(value)
 
         if not is_pickleable(error):
             log.info("non pickleable: %r", error)


### PR DESCRIPTION
Some function (sys.exit for example) raise exceptions that do not inherit from Exception.

Fixes: ENG-2028