### PR TITLE
feat: Delete events when soft deleting project

### DIFF
--- a/internal/backend/db/dbgorm/projects.go
+++ b/internal/backend/db/dbgorm/projects.go
@@ -48,6 +48,16 @@ func (gdb *gormdb) deleteProject(ctx context.Context, projectID uuid.UUID) error
 	return gdb.writeTransaction(ctx, func(tx *gormdb) error { return tx.deleteProjectAndDependents(ctx, projectID) })
 }
 
+func (gdb *gormdb) deleteSessionsAndEvents(ctx context.Context, projectID uuid.UUID) error {
+	if err := gdb.writer.WithContext(ctx).
+		Where("project_id = ?", projectID).
+		Delete(&scheme.Session{}).Error; err != nil {
+		return err
+	}
+
+	return gdb.writer.WithContext(ctx).Where("project_id = ?", projectID).Delete(&scheme.Event{}).Error
+}
+
 func (gdb *gormdb) deleteProjectVars(ctx context.Context, id uuid.UUID) error {
 	// NOTE: should be transactional
 	db := gdb.writer.WithContext(ctx)
@@ -110,6 +120,10 @@ func (gdb *gormdb) deleteProjectAndDependents(ctx context.Context, projectID uui
 	}
 
 	if err = gdb.deleteProjectVars(ctx, projectID); err != nil {
+		return err
+	}
+
+	if err = gdb.deleteSessionsAndEvents(ctx, projectID); err != nil {
 		return err
 	}
 

--- a/internal/backend/db/dbgorm/projects.go
+++ b/internal/backend/db/dbgorm/projects.go
@@ -48,13 +48,7 @@ func (gdb *gormdb) deleteProject(ctx context.Context, projectID uuid.UUID) error
 	return gdb.writeTransaction(ctx, func(tx *gormdb) error { return tx.deleteProjectAndDependents(ctx, projectID) })
 }
 
-func (gdb *gormdb) deleteSessionsAndEvents(ctx context.Context, projectID uuid.UUID) error {
-	if err := gdb.writer.WithContext(ctx).
-		Where("project_id = ?", projectID).
-		Delete(&scheme.Session{}).Error; err != nil {
-		return err
-	}
-
+func (gdb *gormdb) deleteProjectEvents(ctx context.Context, projectID uuid.UUID) error {
 	return gdb.writer.WithContext(ctx).Where("project_id = ?", projectID).Delete(&scheme.Event{}).Error
 }
 
@@ -123,7 +117,7 @@ func (gdb *gormdb) deleteProjectAndDependents(ctx context.Context, projectID uui
 		return err
 	}
 
-	if err = gdb.deleteSessionsAndEvents(ctx, projectID); err != nil {
+	if err = gdb.deleteProjectEvents(ctx, projectID); err != nil {
 		return err
 	}
 

--- a/internal/backend/db/dbgorm/projects_test.go
+++ b/internal/backend/db/dbgorm/projects_test.go
@@ -147,6 +147,19 @@ func TestGetProjectDeployments(t *testing.T) {
 	// 	kittehs.Transform(ds, func(d DeploymentState) sdktypes.UUID { return d.DeploymentID }))
 }
 
+func TestDeleteEventWhenProjectDeleted(t *testing.T) {
+	f := preProjectTest(t)
+
+	p := f.newProject()
+	e := f.newEvent(p)
+	f.createProjectsAndAssert(t, p)
+	f.createEventsAndAssert(t, e)
+
+	assert.NoError(t, f.gormdb.deleteProject(f.ctx, p.ProjectID))
+	f.assertProjectDeleted(t, p)
+	f.assertEventsDeleted(t, e)
+}
+
 func TestDeleteProjectAndDependents(t *testing.T) {
 	f := preProjectTest(t)
 


### PR DESCRIPTION
This PR addresses the issue where an event could still be accessed after its associated project had been deleted. The fix ensures that when a project is deleted, all related events are also removed.

Introduced `deleteProjectEvents` to delete sessions and events when soft deleting a project.



refs: ENG-1949