### PR TITLE
fix(CI): obsolete bits in system tests

### DIFF
--- a/tests/system/ak_test.go
+++ b/tests/system/ak_test.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -35,9 +37,7 @@ const (
 
 func TestSuite(t *testing.T) {
 	akPath := setUpSuite(t)
-
 	tests := make(map[string]*testFile)
-
 	var exclusives []string
 
 	// Each .txtar file is a test-case, with potentially
@@ -90,12 +90,20 @@ func TestSuite(t *testing.T) {
 }
 
 func setUpSuite(t *testing.T) string {
-	akPath := buildAKBinary(t)
-
 	// https://docs.temporal.io/dev-guide/go/debugging
 	t.Setenv("TEMPORAL_DEBUG", "true")
 
-	return akPath
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+
+	path, err := filepath.Abs(filepath.Join(wd, "..", "..", "bin", "ak"))
+	if err != nil {
+		t.Fatalf("failed to construct ak binary file path: %v", err)
+	}
+
+	return path
 }
 
 func setUpTest(t *testing.T, akPath string, cfg map[string]any) string {

--- a/tests/system/ak_test.go
+++ b/tests/system/ak_test.go
@@ -100,7 +100,11 @@ func setUpSuite(t *testing.T) string {
 
 	path, err := filepath.Abs(filepath.Join(wd, "..", "..", "bin", "ak"))
 	if err != nil {
-		t.Fatalf("failed to construct ak binary file path: %v", err)
+		t.Fatalf("failed to construct ak path: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("failed to get ak file info: %v", err)
 	}
 
 	return path

--- a/tests/system/client.go
+++ b/tests/system/client.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
-	"testing"
 	"time"
 )
 
@@ -21,30 +19,6 @@ var (
 	sessionStateFinal = regexp.MustCompile(`state:SESSION_STATE_TYPE_(COMPLETED|ERROR|STOPPED)`)
 	sessionStateAll   = regexp.MustCompile(`state:SESSION_STATE_TYPE_`)
 )
-
-func buildAKBinary(t *testing.T) string {
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get current working directory: %v", err)
-	}
-	defer func() {
-		if err := os.Chdir(wd); err != nil {
-			t.Fatalf("failed to restore working directory: %v", err)
-		}
-	}()
-
-	akRootDir := filepath.Dir(filepath.Dir(wd))
-	if err := os.Chdir(akRootDir); err != nil {
-		t.Fatalf("failed to switch to parent directory: %v", err)
-	}
-
-	output, err := exec.Command("make", "ak").CombinedOutput()
-	if err != nil {
-		t.Fatalf("failed to build client: %v\n%s", err, output)
-	}
-
-	return filepath.Join(akRootDir, "bin", "ak")
-}
 
 func runClient(akPath string, args []string) (*akResult, error) {
 	// Running in a subprocess, not a goroutine (like the

--- a/tests/system/testdata/version.txtar
+++ b/tests/system/testdata/version.txtar
@@ -1,5 +1,0 @@
-# The AK client's compile-time version is set (!= "unset"),
-# i.e. the client was built by "make".
-ak version
-return code == 0
-output equals 'dev'


### PR DESCRIPTION
1. It's a waste of time to rebuild AK **inside** the system test suite, because both `make test-system` and the relevant GitHub CI workflows already build AK in advance, and taking advantage of the local/GitHub build cache

2. Remove the `version.txtar` system test - no longer relevant in the new CI where we don't set any version attributes in the binary file

Refs: ENG-2014