### PR TITLE
BUG-REPRO(ENG-2036): order matters when defining functions with `@activity`

### DIFF
--- a/tests/sessions/python_activity1.txtar
+++ b/tests/sessions/python_activity1.txtar
@@ -1,0 +1,24 @@
+main
+meow
+bar
+done
+
+-- main.py:main --
+import autokitteh
+
+def main(event: autokitteh.Event):
+    print("main")
+    foo("meow")
+    bar()
+    print("done")
+
+@autokitteh.activity
+def foo(x):
+    print(x)
+
+def bar():
+    foo("bar")
+
+-- calls.txt --
+foo
+foo

--- a/tests/sessions/python_activity2.txtar
+++ b/tests/sessions/python_activity2.txtar
@@ -1,18 +1,24 @@
 main
 meow
+bar
 done
 
 -- main.py:main --
 import autokitteh
 
-def main(event: autokitteh.Event):
-    print("main")
-    foo("meow")
-    print("done")
-
 @autokitteh.activity
 def foo(x):
     print(x)
 
+def bar():
+    foo("bar")
+
+def main(event: autokitteh.Event):
+    print("main")
+    foo("meow")
+    bar()
+    print("done")
+
 -- calls.txt --
+foo
 foo


### PR DESCRIPTION
for some reason `python_activity1.txtar` passed, but `python_activity2.txtar` fails. the only difference is the order of the function defintions.

to test in debugger, run:
```
$ ./bin/ak up -m dev (IN DEBUGGER)
$ ./bin/ak project create --name test
$ ./bin/ak session test ./tests/sessions/python_activity1.txtar --project test
$ ./bin/ak session test ./tests/sessions/python_activity2.txtar --project test
```

or:

```
TESTS="python_activity?.txtar" PYTHON=only make test-sessions
```
