### PR TITLE
feat(python): allow to inhibit activities using a decorator

### DIFF
--- a/runtimes/pythonrt/py-sdk/autokitteh/__init__.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/__init__.py
@@ -1,7 +1,7 @@
 """AutoKitteh Python SDK."""
 
 from .attr_dict import AttrDict
-from .decorators import activity
+from .decorators import activity, inhibit_activities
 from .event import Event
 from .events import next_event, subscribe, unsubscribe, start
 from . import errors
@@ -12,6 +12,7 @@ __all__ = [
     "Event",
     "activity",
     "errors",
+    "inhibit_activities",
     "next_event",
     "start",
     "subscribe",

--- a/runtimes/pythonrt/py-sdk/autokitteh/decorators.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/decorators.py
@@ -1,7 +1,7 @@
 """Decorator to mark a function as a Temporal activity."""
 
 ACTIVITY_ATTR = "__activity__"
-INHIBIT_ACTIVITIES_ATTR = "__inhibit_activities__"
+INHIBIT_ACTIVITIES_ATTR = "__ak_inhibit_activities__"
 
 
 def activity(fn: callable) -> callable:

--- a/runtimes/pythonrt/py-sdk/autokitteh/decorators.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/decorators.py
@@ -1,6 +1,7 @@
 """Decorator to mark a function as a Temporal activity."""
 
 ACTIVITY_ATTR = "__activity__"
+INHIBIT_ACTIVITIES_ATTR = "__inhibit_activities__"
 
 
 def activity(fn: callable) -> callable:
@@ -16,4 +17,20 @@ def activity(fn: callable) -> callable:
     https://docs.python.org/3/library/pickle.html#what-can-be-pickled-and-unpickled
     """
     setattr(fn, ACTIVITY_ATTR, True)
+    return fn
+
+
+def inhibit_activities(fn: callable) -> callable:
+    """Decorator to inhibit the execution of Temporal activities.
+
+    Functions using this decorator will not spawn activities even if otherwise
+    activities should have been launched. This is useful for performing operations
+    that are required to run even on replay (such as various clients creation) and
+    are completely deterministic. The function results are not cached and would be
+    rerun in case of replay.
+
+    CAVEAT: Do not use this on functions that take a long time to run (more than a second),
+    as they will cause the workflow to timeout.
+    """
+    setattr(fn, INHIBIT_ACTIVITIES_ATTR, True)
     return fn

--- a/runtimes/pythonrt/runner/call.py
+++ b/runtimes/pythonrt/runner/call.py
@@ -51,6 +51,7 @@ class AKCall:
         self.code_dir = code_dir.resolve()
 
         self.in_activity = False
+        self.activities_inhibitions = 0  # Can be stacked. 0 means no inhibition.
         self.loading = True  # Loading module
         self.module = None  # Module for "local" function, filled by "run"
 
@@ -70,7 +71,7 @@ class AKCall:
         return mod_dir.is_relative_to(self.code_dir)
 
     def should_run_as_activity(self, fn):
-        if self.in_activity or self.loading:
+        if self.in_activity or self.loading or self.activities_inhibitions:
             return False
 
         if is_marked_activity(fn):
@@ -101,12 +102,23 @@ class AKCall:
             fn = time.sleep if self.in_activity else self.runner.syscalls.ak_sleep
             return fn(seconds)
 
+        inhibit = getattr(func, decorators.INHIBIT_ACTIVITIES_ATTR, False)
+        if inhibit:
+            self.activities_inhibitions += 1
+            log.info(f"inhibiting activities: {self.activities_inhibitions}")
+
         full_name = full_func_name(func)
         if not self.should_run_as_activity(func):
             log.info(
-                "calling %s directly (in_activity=%s)", full_name, self.in_activity
+                f"calling {full_name} directly (in_activity={self.in_activity}, inhibitions={self.activities_inhibitions})",
             )
-            return func(*args, **kw)
+
+            try:
+                return func(*args, **kw)
+            finally:
+                if inhibit:
+                    log.info(f"uninhibiting activities: {self.activities_inhibitions}")
+                    self.activities_inhibitions -= 1
 
         log.info("ACTION: activity call %s", full_name)
         self.in_activity = True

--- a/tests/sessions/python_inhibitions.txtar
+++ b/tests/sessions/python_inhibitions.txtar
@@ -1,0 +1,44 @@
+bar
+baz
+bar
+goo
+baz
+goo
+bar
+
+-- main.py main --
+from autokitteh import inhibit_activities, activity
+
+def main(_):
+    bar()
+    single_inhibited()
+    bar()
+    nested_single_inhibited()
+    bar()
+
+@inhibit_activities
+def single_inhibited():
+    baz()
+
+@inhibit_activities
+def nested_single_inhibited():
+    goo()
+    single_inhibited()
+    goo()
+
+@activity
+def bar():
+    print("bar")
+
+@activity
+def baz():
+    print("baz")
+
+@activity
+def goo():
+    print("goo")
+
+-- calls.txt --
+bar
+bar
+bar


### PR DESCRIPTION
```
"""Decorator to inhibit the execution of Temporal activities.
    Functions using this decorator will not spawn activities even if otherwise
    activities should have been launched. This is useful for performing operations
    that are required to run even on replay (such as various clients creation) and
    are completely deterministic. The function results are not cached and would be
    rerun in case of replay.
    CAVEAT: Do not use this on functions that take a long time to run (more than a second),
    as they will cause the workflow to timeout.
    """
```

NOTE: There are oddities in python rn that prevent proper testing of this. See https://github.com/autokitteh/autokitteh/pull/1134.