### PR TITLE
feat: get rid of the `__ctor` field in value unwrap

### DIFF
--- a/sdk/sdktypes/value_unwrap.go
+++ b/sdk/sdktypes/value_unwrap.go
@@ -81,9 +81,13 @@ func (w *ValueWrapper) unwrap(v Value) (any, error) {
 		ctor, fields := v.Ctor(), v.Fields()
 		m := make(map[string]any, len(fields)+1)
 		var err error
-		if m[ctorFieldName], err = w.Unwrap(ctor); err != nil {
-			return nil, fmt.Errorf("ctor: %w", err)
+
+		if w.UnwrapStructCtor {
+			if m[ctorFieldName], err = w.Unwrap(ctor); err != nil {
+				return nil, fmt.Errorf("ctor: %w", err)
+			}
 		}
+
 		for n, v := range fields {
 			if m[n], err = w.Unwrap(v); err != nil {
 				return nil, fmt.Errorf("field %q: %w", n, err)

--- a/sdk/sdktypes/value_wrapper.go
+++ b/sdk/sdktypes/value_wrapper.go
@@ -42,6 +42,9 @@ type ValueWrapper struct {
 	// Unwrap: transform duration into microseconds, do not convert to string.
 	RawDuration bool
 
+	// Unwrap: if true, add a "__ctor" field to struct values.
+	UnwrapStructCtor bool
+
 	// Unwrap: Transform value before unwrapping. If returns InvalidValue, ignore value.
 	Preunwrap func(Value) (Value, error)
 


### PR DESCRIPTION
it's annoying, needed mostly for debugging. turn it off by default.