### PR TITLE
fix: improve timestamp parsing

### DIFF
--- a/integrations/common/migrations.go
+++ b/integrations/common/migrations.go
@@ -72,7 +72,9 @@ func MigrateDateTimeToRFC3339(ctx context.Context, v sdkservices.Vars, vsid sdkt
 		return nil
 	}
 
+	// Remove unnecessary suffixes: sub-seconds and "PST m=+3759.281638293".
 	s = regexp.MustCompile(` [A-Z].*`).ReplaceAllString(s, "")
+	s = regexp.MustCompile(`\.\d+`).ReplaceAllString(s, "")
 	t, err := time.Parse("2006-01-02 15:04:05 -0700", s)
 	if err != nil {
 		return err

--- a/integrations/common/migrations.go
+++ b/integrations/common/migrations.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"regexp"
 	"time"
 
 	"go.autokitteh.dev/autokitteh/integrations"
@@ -31,8 +30,8 @@ func RenameVar(ctx context.Context, v sdkservices.Vars, vsid sdktypes.VarScopeID
 	return v.Delete(ctx, vsid, old)
 }
 
-// MigrateAuthType migrates a connection's "auth_type" variable from the old
-// "oauth" value to the new "oauthDefault". It is assumed that the variable exists.
+// MigrateAuthType migrates a connection's "auth_type" variable from the
+// old "oauth" value to the new "oauthDefault". Otherwise, it has no effect.
 func MigrateAuthType(ctx context.Context, v sdkservices.Vars, vsid sdktypes.VarScopeID) error {
 	vs, err := v.Get(ctx, vsid, AuthTypeVar)
 	if err != nil {
@@ -72,10 +71,7 @@ func MigrateDateTimeToRFC3339(ctx context.Context, v sdkservices.Vars, vsid sdkt
 		return nil
 	}
 
-	// Remove unnecessary suffixes: sub-seconds and "PST m=+3759.281638293".
-	s = regexp.MustCompile(` [A-Z].*`).ReplaceAllString(s, "")
-	s = regexp.MustCompile(`\.\d+`).ReplaceAllString(s, "")
-	t, err := time.Parse("2006-01-02 15:04:05 -0700", s)
+	t, err := ParseGoTimestamp(s)
 	if err != nil {
 		return err
 	}

--- a/integrations/common/migrations_test.go
+++ b/integrations/common/migrations_test.go
@@ -1,0 +1,111 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.autokitteh.dev/autokitteh/integrations"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+func TestRenameVar(t *testing.T) {
+	vars := newFakeVars()
+	vsid := sdktypes.NewVarScopeID(sdktypes.NewConnectionID())
+	ctx := context.Background()
+
+	v := sdktypes.NewVar(sdktypes.NewSymbol("a")).SetValue("a")
+	require.NoError(t, vars.Set(ctx, v.WithScopeID(vsid)))
+	v = sdktypes.NewVar(sdktypes.NewSymbol("b")).SetValue("b")
+	require.NoError(t, vars.Set(ctx, v.WithScopeID(vsid)))
+
+	err := RenameVar(ctx, vars, vsid, sdktypes.NewSymbol("b"), sdktypes.NewSymbol("c"))
+	require.NoError(t, err)
+
+	v = vars.data[vsid][sdktypes.NewSymbol("a")]
+	assert.True(t, v.IsValid())
+	v = vars.data[vsid][sdktypes.NewSymbol("b")]
+	assert.False(t, v.IsValid())
+	v = vars.data[vsid][sdktypes.NewSymbol("c")]
+	assert.True(t, v.IsValid())
+}
+
+func TestMigrateAuthType(t *testing.T) {
+	vars := newFakeVars()
+	tests := []struct {
+		initial string
+		want    string
+	}{
+		{
+			initial: integrations.OAuth,
+			want:    integrations.OAuthDefault,
+		},
+		{
+			initial: integrations.OAuthDefault,
+			want:    integrations.OAuthDefault,
+		},
+		{
+			initial: "other",
+			want:    "other",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.initial, func(t *testing.T) {
+			vsid := sdktypes.NewVarScopeID(sdktypes.NewConnectionID())
+			ctx := context.Background()
+
+			v := sdktypes.NewVar(AuthTypeVar).SetValue(tt.initial)
+			require.NoError(t, vars.Set(ctx, v.WithScopeID(vsid)))
+
+			require.NoError(t, MigrateAuthType(ctx, vars, vsid))
+
+			assert.Equal(t, tt.want, vars.data[vsid][AuthTypeVar].Value())
+		})
+	}
+}
+
+func TestMigrateDateTimeToRFC3339(t *testing.T) {
+	vars := newFakeVars()
+	tests := []struct {
+		name    string
+		initial string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "already_rfc3339",
+			initial: "2025-02-28T11:22:33Z",
+			want:    "2025-02-28T11:22:33Z",
+		},
+		{
+			name:    "time_string",
+			initial: "2025-02-28 11:22:33 -0800",
+			want:    "2025-02-28T19:22:33Z",
+		},
+		{
+			name:    "invalid_format",
+			initial: "invalid_format",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vsid := sdktypes.NewVarScopeID(sdktypes.NewConnectionID())
+			ctx := context.Background()
+
+			v := sdktypes.NewVar(OAuthExpiryVar).SetValue(tt.initial)
+			require.NoError(t, vars.Set(ctx, v.WithScopeID(vsid)))
+
+			err := MigrateDateTimeToRFC3339(ctx, vars, vsid, OAuthExpiryVar)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, vars.data[vsid][OAuthExpiryVar].Value())
+		})
+	}
+}

--- a/integrations/common/time.go
+++ b/integrations/common/time.go
@@ -1,0 +1,15 @@
+package common
+
+import (
+	"regexp"
+	"time"
+)
+
+// ParseGoTimestamp parses a [time.Time.String] string.
+// It ignores unnecessary suffixes: sub-seconds and extra timezone details.
+// Local example: "2025-02-28 10:04:21.024 -0800 PST m=+3759.281638293".
+func ParseGoTimestamp(ts string) (time.Time, error) {
+	ts = regexp.MustCompile(` [A-Z].*`).ReplaceAllString(ts, "")
+	ts = regexp.MustCompile(`\.\d+`).ReplaceAllString(ts, "")
+	return time.Parse("2006-01-02 15:04:05 -0700", ts)
+}

--- a/integrations/common/time.go
+++ b/integrations/common/time.go
@@ -9,7 +9,10 @@ import (
 // It ignores unnecessary suffixes: sub-seconds and extra timezone details.
 // Local example: "2025-02-28 10:04:21.024 -0800 PST m=+3759.281638293".
 func ParseGoTimestamp(ts string) (time.Time, error) {
+	// Get rid of the " PST m=..." suffix (keep the numeric timezone).
 	ts = regexp.MustCompile(` [A-Z].*`).ReplaceAllString(ts, "")
+	// Get rid of the timestamp's sub-second suffix
+	// (it's both unnecessary and nondeterministic).
 	ts = regexp.MustCompile(`\.\d+`).ReplaceAllString(ts, "")
 	return time.Parse("2006-01-02 15:04:05 -0700", ts)
 }

--- a/integrations/common/time_test.go
+++ b/integrations/common/time_test.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestParseGoTimestamp(t *testing.T) {
+	tests := []struct {
+		name    string
+		ts      string
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name: "minimal",
+			ts:   "2006-01-02 15:04:05 -0700",
+			want: time.Date(2006, 1, 2, 15, 4, 5, 0, time.FixedZone("", -7*60*60)),
+		},
+		{
+			name: "go_playground",
+			ts:   "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
+			want: time.Date(2009, 11, 10, 23, 0, 0, 0, time.FixedZone("", 0)),
+		},
+		{
+			name: "with_milliseconds",
+			ts:   "2009-11-10 23:00:00.123 +0000 UTC m=+0.000000001",
+			want: time.Date(2009, 11, 10, 23, 0, 0, 0, time.FixedZone("", 0)),
+		},
+		{
+			name: "with_nanoseconds",
+			ts:   "2009-11-10 23:00:00.123456789 +0000 UTC m=+0.000000001",
+			want: time.Date(2009, 11, 10, 23, 0, 0, 0, time.FixedZone("", 0)),
+		},
+		{
+			name:    "rfc_3339",
+			ts:      "2023-10-10T10:10:10Z",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseGoTimestamp(tt.ts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseGoTimestamp() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseGoTimestamp() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/integrations/common/time_test.go
+++ b/integrations/common/time_test.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"reflect"
 	"testing"
 	"time"
 )
@@ -30,8 +29,8 @@ func TestParseGoTimestamp(t *testing.T) {
 		},
 		{
 			name: "with_nanoseconds",
-			ts:   "2009-11-10 23:00:00.123456789 +0000 UTC m=+0.000000001",
-			want: time.Date(2009, 11, 10, 23, 0, 0, 0, time.FixedZone("", 0)),
+			ts:   "2025-02-28 11:22:33.123456789 -0800 PST m=+0.000199937",
+			want: time.Date(2025, 2, 28, 11, 22, 33, 123456789, time.FixedZone("", -8*60*60)),
 		},
 		{
 			name:    "rfc_3339",
@@ -46,8 +45,8 @@ func TestParseGoTimestamp(t *testing.T) {
 				t.Errorf("ParseGoTimestamp() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ParseGoTimestamp() = %v, want %v", got, tt.want)
+			if got.Format(time.RFC3339) != tt.want.Format(time.RFC3339) {
+				t.Errorf("ParseGoTimestamp() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/integrations/common/vars.go
+++ b/integrations/common/vars.go
@@ -56,9 +56,9 @@ func CheckOAuthToken(vs sdktypes.Vars) (sdktypes.Status, error) {
 	return sdktypes.NewStatus(sdktypes.StatusCodeOK, "Using OAuth 2.0"), nil
 }
 
-// CheckLegacyOAuthToken returns a warning status if [LegacyOAuthAccessTokenVar] is missing in [sdktypes.Vars]; otherwise,
-// it returns OK. It depends on [sdktypes.Vars] being preloaded with [LegacyOAuthAccessTokenVar], which isn't validated.
-// This is reused in connection status and test functions of all integrations.
+// CheckLegacyOAuthToken returns a warning status if [LegacyOAuthAccessTokenVar] is
+// missing in [sdktypes.Vars]; otherwise, it returns OK. It depends on [sdktypes.Vars]
+// being preloaded with [LegacyOAuthAccessTokenVar], which isn't validated.
 func CheckLegacyOAuthToken(vs sdktypes.Vars) (sdktypes.Status, error) {
 	if vs.GetValue(LegacyOAuthAccessTokenVar) == "" {
 		return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil

--- a/integrations/common/vars_test.go
+++ b/integrations/common/vars_test.go
@@ -16,8 +16,7 @@ type fakeVarsService struct {
 
 var _ sdkservices.Vars = &fakeVarsService{}
 
-// TODO(INT-227): rename back to "newFakeVars" when #1151 is merged.
-func NewFakeVars() *fakeVarsService {
+func newFakeVars() *fakeVarsService {
 	return &fakeVarsService{
 		data: make(map[sdktypes.VarScopeID]map[sdktypes.Symbol]sdktypes.Var),
 	}

--- a/internal/backend/cron/jira.go
+++ b/internal/backend/cron/jira.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"regexp"
 	"strconv"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"go.autokitteh.dev/autokitteh/integrations/atlassian/jira"
+	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authcontext"
 	"go.autokitteh.dev/autokitteh/internal/backend/temporalclient"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
@@ -199,12 +199,8 @@ func (cr *Cron) deleteInvalidWatchID(ctx context.Context, cid sdktypes.Connectio
 }
 
 func parseTimeSafely(s string) time.Time {
-	// Remove unnecessary suffixes: sub-seconds and "PST m=+3759.281638293".
-	s = regexp.MustCompile(` [A-Z].*`).ReplaceAllString(s, "")
-	s = regexp.MustCompile(`\.\d+`).ReplaceAllString(s, "")
-
 	// Go time format.
-	if t, err := time.Parse("2006-01-02 15:04:05 -0700", s); err == nil {
+	if t, err := common.ParseGoTimestamp(s); err == nil {
 		return t
 	}
 

--- a/internal/backend/cron/jira.go
+++ b/internal/backend/cron/jira.go
@@ -199,11 +199,12 @@ func (cr *Cron) deleteInvalidWatchID(ctx context.Context, cid sdktypes.Connectio
 }
 
 func parseTimeSafely(s string) time.Time {
-	// Remove unnecessary suffixes, e.g. "PST m=+3759.281638293".
-	s = regexp.MustCompile(`\s+[A-Z].*`).ReplaceAllString(s, "")
+	// Remove unnecessary suffixes: sub-seconds and "PST m=+3759.281638293".
+	s = regexp.MustCompile(` [A-Z].*`).ReplaceAllString(s, "")
+	s = regexp.MustCompile(`\.\d+`).ReplaceAllString(s, "")
 
 	// Go time format.
-	if t, err := time.Parse("2006-01-02 15:04:05.999999999 -0700", s); err == nil {
+	if t, err := time.Parse("2006-01-02 15:04:05 -0700", s); err == nil {
 		return t
 	}
 


### PR DESCRIPTION
Improvement in parsing of Go timestamps (`time.Time.String()`). Related to INT-277, but not a fix for it.

Also added unit tests for some shared integrations functions related to data migrations.

For additional context, see https://github.com/autokitteh/autokitteh/pull/1151#discussion_r1976560850 and the full files being modified.