### PR TITLE
refactor: runtime start should be session id structure agnostic

### DIFF
--- a/runtimes/starlarkrt/internal/libs/ak/ak.go
+++ b/runtimes/starlarkrt/internal/libs/ak/ak.go
@@ -82,7 +82,7 @@ func start(th *starlark.Thread, bi *starlark.Builtin, args starlark.Tuple, kwarg
 		return nil, err
 	}
 
-	return starlark.String(sid.String()), nil
+	return starlark.String(sid), nil
 }
 
 func subscribe(th *starlark.Thread, bi *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -181,17 +181,12 @@ func IsDeploymentActive(th *starlark.Thread, bi *starlark.Builtin, args starlark
 
 func signal(th *starlark.Thread, bi *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var (
-		sid, name string
+		dst, name string
 		payload   starlark.Value
 	)
 
-	if err := starlark.UnpackArgs(bi.Name(), args, kwargs, "session_id", &sid, "name", &name, "payload?", &payload); err != nil {
+	if err := starlark.UnpackArgs(bi.Name(), args, kwargs, "dst", &dst, "name", &name, "payload?", &payload); err != nil {
 		return nil, err
-	}
-
-	sdkSessionID, err := sdktypes.ParseSessionID(sid)
-	if err != nil {
-		return nil, sdkerrors.NewInvalidArgumentError("session_id: %w", err)
 	}
 
 	v, err := values.FromTLS(th).FromStarlarkValue(payload)
@@ -201,7 +196,7 @@ func signal(th *starlark.Thread, bi *starlark.Builtin, args starlark.Tuple, kwar
 
 	tls := tls.Get(th)
 
-	if err := tls.Callbacks.Signal(tls.GoCtx, tls.RunID, sdkSessionID, name, v); err != nil {
+	if err := tls.Callbacks.Signal(tls.GoCtx, tls.RunID, dst, name, v); err != nil {
 		return nil, err
 	}
 

--- a/sdk/sdkservices/runtimes.go
+++ b/sdk/sdkservices/runtimes.go
@@ -57,7 +57,7 @@ type RunCallbacks struct {
 	Now                func(ctx context.Context, rid sdktypes.RunID) (time.Time, error)
 	Print              func(ctx context.Context, rid sdktypes.RunID, text string) error
 	Sleep              func(ctx context.Context, rid sdktypes.RunID, d time.Duration) error
-	Start              func(ctx context.Context, rid sdktypes.RunID, loc sdktypes.CodeLocation, inputs map[string]sdktypes.Value, memo map[string]string) (sdktypes.SessionID, error)
+	Start              func(ctx context.Context, rid sdktypes.RunID, loc sdktypes.CodeLocation, inputs map[string]sdktypes.Value, memo map[string]string) (string, error)
 
 	// Events
 	Subscribe   func(ctx context.Context, rid sdktypes.RunID, name, filter string) (string, error)
@@ -65,7 +65,7 @@ type RunCallbacks struct {
 	NextEvent   func(ctx context.Context, rid sdktypes.RunID, signalIDs []string, timeout time.Duration) (sdktypes.Value, error)
 
 	// Signals
-	Signal     func(ctx context.Context, rid sdktypes.RunID, sid sdktypes.SessionID, name string, payload sdktypes.Value) error
+	Signal     func(ctx context.Context, rid sdktypes.RunID, dst, name string, payload sdktypes.Value) error
 	NextSignal func(ctx context.Context, rid sdktypes.RunID, names []string, timeout time.Duration) (*RunSignal, error)
 }
 


### PR DESCRIPTION
`start` should not care about how a session id looks. motivation: in tempokitteh there is no session id, but a temporal workflow id.