### PR TITLE
prep sessions for tempokitteh

### DIFF
--- a/internal/backend/sessions/sessioncalls/call.go
+++ b/internal/backend/sessions/sessioncalls/call.go
@@ -29,6 +29,10 @@ func (cs *calls) invoke(ctx context.Context, callv sdktypes.Value, args []sdktyp
 		// The executor is an integration, and not a pure function or a session module that must run in a session workflow,
 		// so it can run in any worker and using a stateless integration.
 
+		if cs.svcs == nil || cs.svcs.Integrations == nil {
+			return sdktypes.InvalidSessionCallAttemptResult, errors.New("no integrations")
+		}
+
 		var err error
 		if caller, err = cs.svcs.Integrations.Attach(ctx, iid); err != nil {
 			return sdktypes.InvalidSessionCallAttemptResult, fmt.Errorf("get integration: %w", err)

--- a/internal/backend/sessions/sessioncalls/calls.go
+++ b/internal/backend/sessions/sessioncalls/calls.go
@@ -77,13 +77,13 @@ func New(l *zap.Logger, config Config, svcs *sessionsvcs.Svcs) Calls {
 	}
 }
 
-func (cs *calls) StartWorkers(ctx context.Context, temporal client.Client) error {
-	if temporal == nil {
-		temporal = cs.svcs.Temporal.TemporalClient()
+func (cs *calls) StartWorkers(ctx context.Context, temporalClient client.Client) error {
+	if temporalClient == nil {
+		temporalClient = cs.svcs.Temporal.TemporalClient()
 	}
 
-	cs.generalWorker = temporalclient.NewWorker(cs.l.Named("sessionscallsworker"), temporal, generalTaskQueueName, cs.config.GeneralWorker)
-	cs.uniqueWorker = temporalclient.NewWorker(cs.l.Named("sessionscallsworker"), temporal, UniqueWorkerCallTaskQueueName(), cs.config.UniqueWorker)
+	cs.generalWorker = temporalclient.NewWorker(cs.l.Named("sessionscallsworker"), temporalClient, generalTaskQueueName, cs.config.GeneralWorker)
+	cs.uniqueWorker = temporalclient.NewWorker(cs.l.Named("sessionscallsworker"), temporalClient, UniqueWorkerCallTaskQueueName(), cs.config.UniqueWorker)
 
 	cs.registerActivities()
 

--- a/internal/backend/sessions/sessions.go
+++ b/internal/backend/sessions/sessions.go
@@ -62,7 +62,7 @@ func (s *sessions) StartWorkers(ctx context.Context) error {
 		return fmt.Errorf("workflow workflows: %w", err)
 	}
 
-	if err := s.calls.StartWorkers(ctx); err != nil {
+	if err := s.calls.StartWorkers(ctx, nil); err != nil {
 		return fmt.Errorf("activity workflows: %w", err)
 	}
 

--- a/internal/backend/sessions/sessionworkflows/workflow.go
+++ b/internal/backend/sessions/sessionworkflows/workflow.go
@@ -403,6 +403,9 @@ func (w *sessionWorkflow) removeEventSubscription(wctx workflow.Context, signalI
 	delete(w.lastReadEventSeqForSignal, signalID)
 }
 
+// Executes the actual workflow logic - running the program.
+// `globals` is a map of global variables to be passed to the program.
+// Its keys must be valid symbol names and all the values must be valid.
 func (w *sessionWorkflow) run(wctx workflow.Context, l *zap.Logger, globals map[string]sdktypes.Value) (prints []sdkservices.SessionPrint, retVal sdktypes.Value, err error) {
 	sid := w.data.Session.ID()
 

--- a/sdk/sdktypes/build_export.go
+++ b/sdk/sdktypes/build_export.go
@@ -3,6 +3,7 @@ package sdktypes
 import (
 	"errors"
 
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	runtimesv1 "go.autokitteh.dev/autokitteh/proto/gen/go/autokitteh/runtimes/v1"
 )
 
@@ -42,3 +43,9 @@ func (r BuildExport) WithLocation(loc CodeLocation) BuildExport {
 func (r BuildExport) WithSymbol(sym Symbol) BuildExport {
 	return BuildExport{r.forceUpdate(func(pb *BuildExportPB) { pb.Symbol = sym.String() })}
 }
+
+func (r BuildExport) Location() CodeLocation {
+	return kittehs.Must1(CodeLocationFromProto(r.read().Location))
+}
+
+func (r BuildExport) Symbol() Symbol { return NewSymbol(r.read().Symbol) }


### PR DESCRIPTION
bundled minor changes as prep for tempokitteh:
- add accessors to `BuildExport`
- specify parent policy for temporal, currently to not terminate child workflows when parent completes
- prep sessioncalls to be reused without need for various services