### PR TITLE
chore(ci): fix typos workflow - ignore intentional typo

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -6,3 +6,6 @@ extend-exclude = [
     "runtimes/pythonrt/build_test.go",
     "sdk/sdktypes/integration_id_test.go"
 ]
+
+[default.extend-identifiers]
+typ = "typ"

--- a/integrations/slack/integration.go
+++ b/integrations/slack/integration.go
@@ -116,7 +116,6 @@ func migrateOldConnectionVars(l *zap.Logger, v sdkservices.Vars) {
 
 		pairs := []struct{ old, new string }{
 			{"Key", "install_ids"},
-			{"oauth_TokenTyp", "oauth_TokenType"},
 
 			{"oauth_AccessToken", "oauth_access_token"},
 			{"oauth_Expiry", "oauth_expiry"},


### PR DESCRIPTION
The typos tool recently started complaining about "typ" - which we intentionally use sometimes instead of the reserved keyword "type".

The removal from the Slack data migration code is OK because that typo doesn't exist anymore.

Attention: I set this PR to auto-merge once approved.