### PR TITLE
fix: better error handling in pythonrt so runner wont stuck

### DIFF
--- a/runtimes/pythonrt/runner/main.py
+++ b/runtimes/pythonrt/runner/main.py
@@ -464,7 +464,6 @@ class Runner(pb.runner_rpc.RunnerService):
             self.worker.Done(req)
         except Exception as err:
             log.error("on_event: done send error: %r", err)
-        
 
     @mark_no_activity
     def ak_print(self, *objects, sep=" ", end="\n", file=None, flush=False):

--- a/runtimes/pythonrt/runner/main.py
+++ b/runtimes/pythonrt/runner/main.py
@@ -454,7 +454,7 @@ class Runner(pb.runner_rpc.RunnerService):
                 req.result.custom.data = data
                 req.result.custom.value.CopyFrom(values.safe_wrap(result.value))
         except (TypeError, pickle.PickleError) as err:
-                    req.error = f"can't pickle {result.value} - {err}"
+            req.error = f"can't pickle {result.value} - {err}"
         except Exception as err:
             req.error = f"unexpected error: {err}"
             log.exception("on_event: %r", err)

--- a/runtimes/pythonrt/runner/main.py
+++ b/runtimes/pythonrt/runner/main.py
@@ -450,11 +450,10 @@ class Runner(pb.runner_rpc.RunnerService):
                 tb = pb_traceback(result.traceback)
                 req.traceback.extend(tb)
             else:
-                try:
-                    data = pickle.dumps(result)
-                    req.result.custom.data = data
-                    req.result.custom.value.CopyFrom(values.safe_wrap(result.value))
-                except (TypeError, pickle.PickleError) as err:
+                data = pickle.dumps(result)
+                req.result.custom.data = data
+                req.result.custom.value.CopyFrom(values.safe_wrap(result.value))
+        except (TypeError, pickle.PickleError) as err:
                     req.error = f"can't pickle {result.value} - {err}"
         except Exception as err:
             req.error = f"unexpected error: {err}"


### PR DESCRIPTION
- added more try except blocks around pickling of errors

- made sure runner will exit even if it couldn't call worker.Done for some reason

There is still an exception with pickling we should figure out, but this will at least make the code always end