### PR TITLE
fix(salesforce): specify `eventType` and fix dispatch isolation bug

### DIFF
--- a/integrations/salesforce/events.go
+++ b/integrations/salesforce/events.go
@@ -10,8 +10,8 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-func (h handler) dispatchEvent(payload map[string]any, topic string) {
-	akEvent, err := h.transformEvent(payload, topic)
+func (h handler) dispatchEvent(payload map[string]any, eventType string) {
+	akEvent, err := h.transformEvent(payload, eventType)
 	if err != nil {
 		h.logger.Error("failed to transform event", zap.Error(err))
 		return

--- a/integrations/salesforce/subscription.go
+++ b/integrations/salesforce/subscription.go
@@ -24,24 +24,24 @@ var (
 
 // subscribe creates a new gRPC client and subscribes to a generic Salesforce Change Data Capture channel.
 // https://developer.salesforce.com/docs/platform/pub-sub-api/references/methods/subscribe-rpc.html
-func (h handler) subscribe(instanceURL, orgID string, cid sdktypes.ConnectionID) {
+func (h handler) subscribe(client_id, orgID string, cid sdktypes.ConnectionID) {
 	// Prevent duplication due to race conditions.
 	mu.Lock()
 	defer mu.Unlock()
 
-	if _, ok := pubSubClients[instanceURL]; ok {
+	if _, ok := pubSubClients[client_id]; ok {
 		return
 	}
 
 	l := h.logger.With(zap.String("connection_id", cid.String()))
 	ctx := context.Background()
-	conn, err := initConn(l, h.bearerToken(ctx, l, cid), instanceURL, orgID)
+	conn, err := initConn(l, h.bearerToken(ctx, l, cid), client_id, orgID)
 	if err != nil {
 		return
 	}
 
 	client := pb.NewPubSubClient(conn)
-	pubSubClients[instanceURL] = &client
+	pubSubClients[client_id] = &client
 
 	// https://developer.salesforce.com/docs/atlas.en-us.platform_events.meta/platform_events/platform_events_objects_change_data_capture.htm
 	go h.eventLoop(ctx, client, "/data/ChangeEvents", cid)
@@ -49,7 +49,7 @@ func (h handler) subscribe(instanceURL, orgID string, cid sdktypes.ConnectionID)
 
 // eventLoop processes incoming messages, and automatically renews the subscription.
 // https://developer.salesforce.com/docs/platform/pub-sub-api/guide/pub-sub-features.html
-func (h handler) eventLoop(ctx context.Context, client pb.PubSubClient, topicName string, cid sdktypes.ConnectionID) {
+func (h handler) eventLoop(ctx context.Context, client pb.PubSubClient, subscribeTopic string, cid sdktypes.ConnectionID) {
 	l := h.logger.With(zap.String("connection_id", cid.String()))
 	const defaultBatchSize = int32(100)
 	numLeftToReceive := 0
@@ -63,7 +63,7 @@ func (h handler) eventLoop(ctx context.Context, client pb.PubSubClient, topicNam
 	// Start receiving messages.
 	for {
 		if numLeftToReceive <= 0 {
-			n, err := renewSubscription(l, stream, defaultBatchSize, topicName)
+			n, err := renewSubscription(l, stream, defaultBatchSize, subscribeTopic)
 			if err != nil {
 				l.Error("failed to renew Salesforce events subscription", zap.Error(err))
 				continue
@@ -98,7 +98,19 @@ func (h handler) eventLoop(ctx context.Context, client pb.PubSubClient, topicNam
 				continue
 			}
 
-			h.dispatchEvent(data, topicName)
+			// Extract changed entity name for the event type.
+			header, ok := data["ChangeEventHeader"].(map[string]any)
+			if !ok {
+				l.Error("ChangeEventHeader is not a map in event data")
+				continue
+			}
+			entityName, ok := header["entityName"].(string)
+			if !ok {
+				l.Error("entityName is not a string in ChangeEventHeader")
+				continue
+			}
+
+			h.dispatchEvent(data, entityName)
 		}
 	}
 }

--- a/integrations/salesforce/subscription.go
+++ b/integrations/salesforce/subscription.go
@@ -2,6 +2,7 @@ package salesforce
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	pb "github.com/developerforce/pub-sub-api/go/proto"
@@ -110,7 +111,7 @@ func (h handler) eventLoop(ctx context.Context, client pb.PubSubClient, subscrib
 				continue
 			}
 
-			h.dispatchEvent(data, entityName)
+			h.dispatchEvent(data, strings.ToLower(entityName))
 		}
 	}
 }

--- a/integrations/salesforce/vars.go
+++ b/integrations/salesforce/vars.go
@@ -3,6 +3,7 @@ package salesforce
 import "go.autokitteh.dev/autokitteh/sdk/sdktypes"
 
 var (
+	clientIDVar    = sdktypes.NewSymbol("private_client_id")
 	instanceURLVar = sdktypes.NewSymbol("instance_url")
 	orgIDVar       = sdktypes.NewSymbol("organization_id")
 )


### PR DESCRIPTION
**Considerations**: One option I considered for `eventType` was combining the change type (which can be extracted from the sfdc event) with the event type. For example, instead of `account`, it would be `create_account`.  

I decided against this because it would prevent users from receiving all events related to a Salesforce entity. They can always filter for a specific change type if needed.  

**Testing**: Successfully received Salesforce events.  

_Refs: INT-321_