### PR TITLE
feat(sessions): speed up prints

### DIFF
--- a/cmd/ak/cmd/sessions/log.go
+++ b/cmd/ak/cmd/sessions/log.go
@@ -11,14 +11,11 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-var (
-	// skip       int
-	printsOnly bool
-	logOrder   string
-)
+// skip       int
+var logOrder string
 
 var logCmd = common.StandardCommand(&cobra.Command{
-	Use:   "log [sessions ID | project] [--fail] [--skip <N>] [--no-timestamps] [--prints-only]",
+	Use:   "log [sessions ID | project] [--fail] [--skip <N>] [--no-timestamps]",
 	Short: "Get session runtime logs (prints, calls, errors, state changes)",
 	Args:  cobra.ExactArgs(1),
 
@@ -54,7 +51,6 @@ func init() {
 	// Command-specific flags.
 	// logCmd.Flags().IntVarP(&skip, "skip", "s", 0, "number of entries to skip")
 	logCmd.Flags().BoolVarP(&noTimestamps, "no-timestamps", "n", false, "omit timestamps from watch output")
-	logCmd.Flags().BoolVarP(&printsOnly, "prints-only", "p", false, "output only session print messages")
 	logCmd.Flags().StringVarP(&logOrder, "order", "o", "desc", "logs order can be asc or desc")
 	logCmd.Flags().StringVar(&nextPageToken, "next-page-token", "", "provide the returned page token to get next")
 	logCmd.Flags().IntVar(&pageSize, "page-size", 20, "page size")
@@ -92,30 +88,6 @@ func printLogs(logs []sdktypes.SessionLogRecord) {
 	for _, r := range logs {
 		if noTimestamps {
 			r = r.WithoutTimestamp().WithProcessID("")
-		}
-
-		msg := ""
-		if printsOnly {
-			if p, ok := r.GetPrint(); ok {
-				s, err := p.ToString()
-				if err != nil {
-					s = fmt.Sprintf("error converting print to string: %v", err.Error())
-				}
-				msg = s
-			} else if state := r.GetState(); state.IsValid() && state.Type() == sdktypes.SessionStateTypeError {
-				if stateErr := state.GetError(); stateErr.IsValid() {
-					pe := stateErr.GetProgramError()
-					msg = "Error: " + pe.ErrorString()
-				}
-			}
-
-			if msg != "" {
-				if !noTimestamps {
-					fmt.Printf("[%s] ", r.Timestamp().String())
-				}
-				fmt.Println(msg)
-			}
-			continue
 		}
 
 		if !quiet {

--- a/cmd/ak/cmd/sessions/prints.go
+++ b/cmd/ak/cmd/sessions/prints.go
@@ -35,10 +35,10 @@ var printsCmd = common.StandardCommand(&cobra.Command{
 			}
 
 			if !noTimestamps {
-				fmt.Printf("[%s] ", p.Timestamp.String())
+				fmt.Fprintf(cmd.OutOrStdout(), "[%s] ", p.Timestamp.String())
 			}
 
-			fmt.Println(text)
+			fmt.Fprintln(cmd.OutOrStdout(), text)
 		}
 
 		return nil

--- a/cmd/ak/cmd/sessions/prints.go
+++ b/cmd/ak/cmd/sessions/prints.go
@@ -1,0 +1,53 @@
+package sessions
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"go.autokitteh.dev/autokitteh/cmd/ak/common"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+var printsCmd = common.StandardCommand(&cobra.Command{
+	Use:   "prints [sessions ID | project] [--fail] [--no-timestamps]",
+	Short: "Get session prints",
+	Args:  cobra.ExactArgs(1),
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sid, err := acquireSessionID(args[0])
+		if err = common.AddNotFoundErrIfCond(err, sid.IsValid()); err != nil {
+			return common.ToExitCodeWithSkipNotFoundFlag(cmd, err, "session")
+		}
+
+		ctx, done := common.LimitedContext()
+		defer done()
+
+		prints, err := sessions().GetPrints(ctx, sid, sdktypes.PaginationRequest{})
+		if err != nil {
+			return fmt.Errorf("get log: %w", err)
+		}
+
+		for _, p := range prints.Prints {
+			text, err := p.Value.ToString()
+			if err != nil {
+				text = fmt.Sprintf("error converting print to string: %v", err.Error())
+			}
+
+			if !noTimestamps {
+				fmt.Printf("[%s] ", p.Timestamp.String())
+			}
+
+			fmt.Println(text)
+		}
+
+		return nil
+	},
+})
+
+func init() {
+	// Command-specific flags.
+	printsCmd.Flags().BoolVarP(&noTimestamps, "no-timestamps", "n", false, "omit timestamps from watch output")
+
+	common.AddFailIfNotFoundFlag(printsCmd)
+}

--- a/cmd/ak/cmd/sessions/session.go
+++ b/cmd/ak/cmd/sessions/session.go
@@ -45,6 +45,7 @@ func init() {
 	sessionCmd.AddCommand(getCmd)
 	sessionCmd.AddCommand(listCmd)
 	sessionCmd.AddCommand(logCmd)
+	sessionCmd.AddCommand(printsCmd)
 	sessionCmd.AddCommand(restartCmd)
 	sessionCmd.AddCommand(startCmd)
 	sessionCmd.AddCommand(stopCmd)

--- a/cmd/ak/cmd/sessions/watch.go
+++ b/cmd/ak/cmd/sessions/watch.go
@@ -21,7 +21,7 @@ var (
 )
 
 var watchCmd = common.StandardCommand(&cobra.Command{
-	Use:   "watch [sessions ID | project] [--fail] [--end-state <state>] [--end-print-re <re>] [--timeout <duration>] [--poll-interval <duration>] [--no-timestamps] [--quiet] [--prints-only] [--wait-created]",
+	Use:   "watch [sessions ID | project] [--fail] [--end-state <state>] [--end-print-re <re>] [--timeout <duration>] [--poll-interval <duration>] [--no-timestamps] [--quiet] [--wait-created]",
 	Short: "Watch session runtime logs (prints, calls, errors, state changes)",
 	Args:  cobra.ExactArgs(1),
 
@@ -50,7 +50,6 @@ func init() {
 	watchCmd.Flags().DurationVarP(&pollInterval, "poll-interval", "i", defaultPollInterval, "poll interval")
 	watchCmd.Flags().BoolVarP(&noTimestamps, "no-timestamps", "n", false, "omit timestamps from output")
 	watchCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "don't print anything, just wait to finish")
-	watchCmd.Flags().BoolVarP(&printsOnly, "just-prints", "p", false, "output only session print messages")
 
 	watchCmd.Flags().BoolVar(&waitCreated, "wait-created", false, "wait for session to exist")
 

--- a/internal/backend/sessions/sessionworkflows/activities.go
+++ b/internal/backend/sessions/sessionworkflows/activities.go
@@ -27,7 +27,6 @@ const (
 	getSessionStopReasonActivityName        = "get_session_stop_reason"
 	getSignalEventActivityName              = "get_signal_event"
 	removeSignalActivityName                = "remove_signal"
-	addSessionPrintActivityName             = "add_session_print_value"
 	deactivateDrainedDeploymentActivityName = "deactivate_drained_deployment"
 	getDeploymentStateActivityName          = "get_deployment_state"
 	createSessionActivityName               = "create_session"
@@ -70,11 +69,6 @@ func (ws *workflows) registerActivities() {
 	)
 
 	ws.worker.RegisterActivityWithOptions(
-		ws.addSessionPrintActivity,
-		activity.RegisterOptions{Name: addSessionPrintActivityName},
-	)
-
-	ws.worker.RegisterActivityWithOptions(
 		ws.deactivateDrainedDeploymentActivity,
 		activity.RegisterOptions{Name: deactivateDrainedDeploymentActivityName},
 	)
@@ -105,10 +99,6 @@ func (ws *workflows) getDeploymentStateActivity(ctx context.Context, did sdktype
 	}
 
 	return d.State(), nil
-}
-
-func (ws *workflows) addSessionPrintActivity(ctx context.Context, sid sdktypes.SessionID, v sdktypes.Value, callSeq uint32) error {
-	return temporalclient.TranslateError(ws.svcs.DB.AddSessionPrint(ctx, sid, v, callSeq), "%v: add session print", sid)
 }
 
 func (ws *workflows) removeSignalActivity(ctx context.Context, sigid uuid.UUID) error {

--- a/internal/backend/sessions/sessionworkflows/history.go
+++ b/internal/backend/sessions/sessionworkflows/history.go
@@ -263,24 +263,6 @@ func parseTemporalHistoryEvent(l *zap.Logger, t time.Time, event *historypb.Hist
 
 			return sdktypes.NewStateSessionLogRecord(t, state), nil
 
-		case addSessionPrintActivityName:
-			if types != 0 && types&sdktypes.PrintSessionLogRecordType == 0 {
-				return sdktypes.InvalidSessionLogRecord, nil
-			}
-
-			payloads := attrs.Input.GetPayloads()
-			if len(payloads) != 3 {
-				l.Error("unexpected number of payloads for activity task print event", zap.Int("payloads", len(payloads)))
-				return sdktypes.InvalidSessionLogRecord, nil
-			}
-
-			var v sdktypes.Value
-			if err := dc.FromPayload(payloads[1], &v); err != nil {
-				return sdktypes.InvalidSessionLogRecord, temporalclient.TranslateError(err, "unmarshal print text")
-			}
-
-			return sdktypes.NewPrintSessionLogRecord(t, v, 0), nil
-
 		default:
 			return sdktypes.InvalidSessionLogRecord, nil
 		}

--- a/internal/backend/sessions/sessionworkflows/printer.go
+++ b/internal/backend/sessions/sessionworkflows/printer.go
@@ -5,8 +5,12 @@ import (
 
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/internal/backend/db"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
+
+const maxPrints = 1024
 
 // printer is a helper to save session prints to the database.
 // It allows for non blocking writes to be performed by calling the
@@ -14,9 +18,15 @@ import (
 // in order to consistently get all written data the `Finalize` method
 // must be called.
 type printer struct {
-	all  []sdkservices.SessionPrint // do not get prints from here, use Finalize() instead.
-	ch   chan *print
-	done chan struct{}
+	l   *zap.Logger
+	db  db.DB
+	sid sdktypes.SessionID
+
+	all      []sdkservices.SessionPrint // do not get prints from here, use Finalize() instead.
+	overflow bool                       // true if exceeded max prints.
+
+	ch   chan *print   // prints queue to be saved.
+	done chan struct{} // closed when printer needs to shut down.
 }
 
 type print struct {
@@ -26,15 +36,10 @@ type print struct {
 	activityCallSeq uint32
 }
 
-// Safe to call event if Finalize has been called.
-func (p *printer) Close() {
-	if p.ch != nil {
-		close(p.ch)
-	}
-}
-
+// Must be called in order to stop the printer goroutine, otherwise
+// will leak them.
 func (p *printer) Finalize() []sdkservices.SessionPrint {
-	p.Close()
+	close(p.ch)
 	<-p.done
 	return p.all
 }
@@ -42,26 +47,37 @@ func (p *printer) Finalize() []sdkservices.SessionPrint {
 func (p *printer) Print(sp sdkservices.SessionPrint, activityCallSeq uint32, isReplay bool) {
 	p.all = append(p.all, sp)
 
+	if len(p.all) > maxPrints {
+		if !p.overflow {
+			p.l.Warn("too many prints", zap.Int("max", maxPrints))
+		}
+
+		p.overflow = true
+		p.all = p.all[1:]
+	}
+
 	if !isReplay {
 		p.ch <- &print{SessionPrint: sp, activityCallSeq: activityCallSeq}
 	}
 }
 
 func (w *sessionWorkflow) newPrinter() *printer {
-	pr := &printer{ch: make(chan *print, 32), done: make(chan struct{})}
+	pr := &printer{ch: make(chan *print, 32), done: make(chan struct{}), l: w.l, db: w.ws.svcs.DB, sid: w.data.Session.ID()}
 
+	return pr
+}
+
+func (pr *printer) Start() {
 	go func() {
 		ctx := context.Background()
 
 		for p := range pr.ch {
-			if err := w.ws.svcs.DB.AddSessionPrint(ctx, w.data.Session.ID(), p.Value, p.activityCallSeq); err != nil {
-				w.l.Error("failed to add session print", zap.Error(err))
+			if err := pr.db.AddSessionPrint(ctx, pr.sid, p.Value, p.activityCallSeq); err != nil {
+				pr.l.Error("failed to add session print", zap.Error(err))
 			}
 		}
 
 		close(pr.done)
 		pr.ch = nil
 	}()
-
-	return pr
 }

--- a/internal/backend/sessions/sessionworkflows/printer.go
+++ b/internal/backend/sessions/sessionworkflows/printer.go
@@ -1,0 +1,67 @@
+package sessionworkflows
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
+)
+
+// printer is a helper to save session prints to the database.
+// It allows for non blocking writes to be performed by calling the
+// `Print` method. The saving is done in a separate goroutine, and
+// in order to consistently get all written data the `Finalize` method
+// must be called.
+type printer struct {
+	all  []sdkservices.SessionPrint // do not get prints from here, use Finalize() instead.
+	ch   chan *print
+	done chan struct{}
+}
+
+type print struct {
+	sdkservices.SessionPrint
+
+	// Correlates a print to an activity call.
+	activityCallSeq uint32
+}
+
+// Safe to call event if Finalize has been called.
+func (p *printer) Close() {
+	if p.ch != nil {
+		close(p.ch)
+	}
+}
+
+func (p *printer) Finalize() []sdkservices.SessionPrint {
+	p.Close()
+	<-p.done
+	return p.all
+}
+
+func (p *printer) Print(sp sdkservices.SessionPrint, activityCallSeq uint32, isReplay bool) {
+	p.all = append(p.all, sp)
+
+	if !isReplay {
+		p.ch <- &print{SessionPrint: sp, activityCallSeq: activityCallSeq}
+	}
+}
+
+func (w *sessionWorkflow) newPrinter() *printer {
+	pr := &printer{ch: make(chan *print, 32), done: make(chan struct{})}
+
+	go func() {
+		ctx := context.Background()
+
+		for p := range pr.ch {
+			if err := w.ws.svcs.DB.AddSessionPrint(ctx, w.data.Session.ID(), p.Value, p.activityCallSeq); err != nil {
+				w.l.Error("failed to add session print", zap.Error(err))
+			}
+		}
+
+		close(pr.done)
+		pr.ch = nil
+	}()
+
+	return pr
+}

--- a/internal/backend/sessions/sessionworkflows/workflow.go
+++ b/internal/backend/sessions/sessionworkflows/workflow.go
@@ -415,7 +415,6 @@ func (w *sessionWorkflow) run(wctx workflow.Context, l *zap.Logger) (_ []sdkserv
 	}
 
 	printer := w.newPrinter()
-	defer printer.Close()
 
 	var run sdkservices.Run
 
@@ -512,6 +511,8 @@ func (w *sessionWorkflow) run(wctx workflow.Context, l *zap.Logger) (_ []sdkserv
 
 	ctx := temporalclient.NewWorkflowContextAsGOContext(wctx)
 
+	printer.Start()
+
 	temporalclient.WithoutDeadlockDetection(
 		wctx,
 		func() {
@@ -531,7 +532,7 @@ func (w *sessionWorkflow) run(wctx workflow.Context, l *zap.Logger) (_ []sdkserv
 	)
 
 	if err != nil {
-		return nil, sdktypes.InvalidValue, err
+		return printer.Finalize(), sdktypes.InvalidValue, err
 	}
 
 	kittehs.Must0(w.executors.AddExecutor(fmt.Sprintf("run_%s", run.ID().Value()), run))

--- a/runtimes/pythonrt/Makefile
+++ b/runtimes/pythonrt/Makefile
@@ -30,7 +30,7 @@ run-simple:
 	go run ./testdata/trigger_webhook.go
 
 test-simple: deploy-simple run-simple
-	ak session log --prints-only --no-timestamps
+	ak session prints --no-timestamps
 	sleep 3
 	ak session list -j | jq .state
 

--- a/tests/system/client.go
+++ b/tests/system/client.go
@@ -35,7 +35,7 @@ func waitForSession(akPath, akAddr, step string) (string, error) {
 	waitType := match[2]
 	id := match[3]
 
-	stateRegex := sessionStateAll // wait .. unless .. session, wait for eany session state
+	stateRegex := sessionStateAll // wait .. unless .. session, wait for any session state
 	isSessionExpected := waitType == "for"
 	if isSessionExpected {
 		stateRegex = sessionStateFinal // wait .. for .. session

--- a/tests/system/testdata/deployments/state.txtar
+++ b/tests/system/testdata/deployments/state.txtar
@@ -6,7 +6,7 @@ resp code == 202
 
 wait 5s for session ses_00000000000000000000000007
 
-ak session log my_project --prints-only
+ak session prints my_project
 return code == 0
 output contains 'True'
 
@@ -28,7 +28,7 @@ output contains 'DEPLOYMENT_STATE_DRAINING'
 
 wait 5s for session ses_0000000000000000000000000a
 
-ak session log --prints-only -p my_project
+ak session prints -p my_project
 return code == 0
 output contains 'done'
 

--- a/tests/system/testdata/end2end/builtin_funcs.txtar
+++ b/tests/system/testdata/end2end/builtin_funcs.txtar
@@ -9,7 +9,7 @@ resp code == 202
 wait 5s for session ses_00000000000000000000000007
 
 # Check session's output and final state.
-ak session log --prints-only --page-size 50 -p my_project
+ak session prints -p my_project
 return code == 0
 output contains '1st random int with seed: 5'
 output contains '2nd random int with seed: 2'

--- a/tests/system/testdata/schedule/redefine.txtar
+++ b/tests/system/testdata/schedule/redefine.txtar
@@ -8,7 +8,7 @@ return code == 0
 output equals_json file triggers.json
 
 wait 5s for session ses_00000000000000000000000007
-ak session log ses_00000000000000000000000007 --no-timestamps --prints-only
+ak session prints ses_00000000000000000000000007 --no-timestamps
 return code == 0
 output equals 'cron'
 
@@ -55,3 +55,7 @@ def on_cron_trigger():
   },
   "schedule": "*/1 * * * * * *"
 }
+
+-- test-config.yaml --
+exclusive: true
+

--- a/tests/system/testdata/schedule/schedule_cli.txtar
+++ b/tests/system/testdata/schedule/schedule_cli.txtar
@@ -13,12 +13,12 @@ return code == 0
 output equals 'trigger_id: trg_00000000000000000000000004'
 
 wait 5s for session ses_0000000000000000000000000b
-ak session log ses_0000000000000000000000000b --no-timestamps --prints-only
+ak session prints ses_0000000000000000000000000b --no-timestamps
 return code == 0
 output equals 'cron'
 
 wait 5s for session ses_0000000000000000000000000f
-ak session log ses_0000000000000000000000000f --no-timestamps --prints-only
+ak session prints ses_0000000000000000000000000f --no-timestamps
 return code == 0
 output equals 'cron'
 

--- a/tests/system/testdata/schedule/schedule_manifest.txtar
+++ b/tests/system/testdata/schedule/schedule_manifest.txtar
@@ -7,12 +7,12 @@ return code == 0
 output equals_json file triggers.json
 
 wait 5s for session ses_00000000000000000000000007
-ak session log ses_00000000000000000000000007 --no-timestamps --prints-only
+ak session prints ses_00000000000000000000000007 --no-timestamps
 return code == 0
 output equals 'cron'
 
 wait 5s for session ses_0000000000000000000000000b
-ak session log ses_0000000000000000000000000b --no-timestamps --prints-only
+ak session prints ses_0000000000000000000000000b --no-timestamps
 return code == 0
 output equals 'cron'
 

--- a/tests/system/testdata/sessions/events_python.txtar
+++ b/tests/system/testdata/sessions/events_python.txtar
@@ -28,7 +28,7 @@ resp code == 202
 ak session watch ses_0000000000000000000000000b --end-state COMPLETED
 return code == 0
 
-ak session log --prints-only --no-timestamps -p myproject
+ak session prints --no-timestamps -p myproject
 output equals file prints.txt
 
 

--- a/tests/system/testdata/sessions/events_starlark.txtar
+++ b/tests/system/testdata/sessions/events_starlark.txtar
@@ -28,7 +28,7 @@ resp code == 202
 ak session watch ses_0000000000000000000000000b --end-state COMPLETED
 return code == 0
 
-ak session log --prints-only --no-timestamps -p myproject
+ak session prints --no-timestamps -p myproject
 output equals file prints.txt
 
 

--- a/tests/system/testdata/sessions/start.txtar
+++ b/tests/system/testdata/sessions/start.txtar
@@ -18,7 +18,7 @@ capture_jq sid .session_id
 ak session watch $sid --timeout 5s
 return code == 0
 
-ak session log $sid --no-timestamps --prints-only
+ak session prints $sid --no-timestamps
 return code == 0
 output equals file last.txt
 


### PR DESCRIPTION
asynchronously save prints, don't do it directly in activity or workflow. this speeds up print behaviour significantly.

this also adds a "session prints" command that returns only prints, while removing the ability to do --prints-only on other commands as they no longer return any prints.