### PR TITLE
fix(salesforce): robust gRPC retries

### DIFF
--- a/integrations/linear/events.go
+++ b/integrations/linear/events.go
@@ -133,7 +133,7 @@ func (h handler) checkRequest(w http.ResponseWriter, r *http.Request) map[string
 	return payload
 }
 
-// TODO(INT-284): Support all AutoKitteh connection auth types.
+// TODO(INT-332): Support all AutoKitteh connection auth types.
 func (h handler) signingSecret() (string, error) {
 	secret := os.Getenv("LINEAR_WEBHOOK_SECRET")
 	if secret == "" {

--- a/integrations/salesforce/subscription.go
+++ b/integrations/salesforce/subscription.go
@@ -47,7 +47,7 @@ func (h handler) subscribe(clientID, orgID string, cid sdktypes.ConnectionID) {
 	}
 
 	t := common.FreshOAuthToken(ctx, l, h.oauth, h.vars, desc, vs)
-	cfg, _, err := h.oauth.Get(ctx, desc.ID().String())
+	cfg, _, err := h.oauth.Get(ctx, desc.UniqueName().String())
 	if err != nil {
 		l.Error("failed to get Salesforce OAuth config", zap.Error(err))
 		return


### PR DESCRIPTION
Allow the gRPC client to handle OAuth refreshes automatically, so a long-running gRPC client won't lose its authentication after a day.

Add error retries for several gRPC error conditions, and TODOs for exponential backoffs in a couple of them.

Refs: INT-319, INT-333