### PR TITLE
feat: add exponential backoff to `Subscribe` method in Salesforce gRPC

### DIFF
--- a/integrations/salesforce/grpc.go
+++ b/integrations/salesforce/grpc.go
@@ -26,11 +26,28 @@ const retryPolicy = `{
 	"methodConfig": [{
 		"name": [{"service": "eventbus.v1.PubSub", "method": "Subscribe"}],
 		"retryPolicy": {
-			"MaxAttempts": 4,
-			"InitialBackoff": "1s",
-			"MaxBackoff": "10s",
-			"BackoffMultiplier": 2.0,
-			"RetryableStatusCodes": [ ]
+			"maxAttempts": 4,
+			"initialBackoff": "1s",
+			"maxBackoff": "10s",
+			"backoffMultiplier": 2.0,
+			"retryableStatusCodes": [
+				"CANCELLED", 
+				"UNKNOWN", 
+				"INVALID_ARGUMENT",
+				"DEADLINE_EXCEEDED",
+				"NOT_FOUND",
+				"ALREADY_EXISTS",
+				"PERMISSION_DENIED",
+				"RESOURCE_EXHAUSTED",
+				"FAILED_PRECONDITION",
+				"ABORTED",
+				"OUT_OF_RANGE",
+				"UNIMPLEMENTED",
+				"INTERNAL",
+				"UNAVAILABLE",
+				"DATA_LOSS",
+				"UNAUTHENTICATED"
+			]
 		}
 	}]
 }`

--- a/integrations/salesforce/grpc.go
+++ b/integrations/salesforce/grpc.go
@@ -28,9 +28,9 @@ const retryPolicy = `{
 		"retryPolicy": {
 			"MaxAttempts": 4,
 			"InitialBackoff": "1s",
-			"MaxBackoff": "128s",
+			"MaxBackoff": "10s",
 			"BackoffMultiplier": 2.0,
-			"RetryableStatusCodes": [ "UNAVAILABLE" ]
+			"RetryableStatusCodes": [ ]
 		}
 	}]
 }`

--- a/integrations/salesforce/grpc.go
+++ b/integrations/salesforce/grpc.go
@@ -19,6 +19,9 @@ type grpcAuth struct {
 	tenantID    string
 }
 
+// Based on:
+// - https://grpc.io/docs/guides/retry/
+// - https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto
 const retryPolicy = `{
 	"methodConfig": [{
 		"name": [{"service": "eventbus.v1.PubSub", "method": "Subscribe"}],

--- a/integrations/salesforce/subscription.go
+++ b/integrations/salesforce/subscription.go
@@ -80,7 +80,6 @@ func (h handler) eventLoop(ctx context.Context, clientID string, subscribeTopic 
 			n, err := renewSubscription(l, stream, defaultBatchSize, subscribeTopic)
 			if err != nil {
 				l.Error("failed to renew Salesforce events subscription", zap.Error(err))
-				// TODO(INT-333): Add exponential backoff.
 				continue
 			}
 			numLeftToReceive = n
@@ -153,7 +152,6 @@ func initStream(ctx context.Context, l *zap.Logger, client pb.PubSubClient) pb.P
 		stream, err := client.Subscribe(ctx)
 		if err != nil {
 			l.Error("failed to create gRPC stream for Salesforce events", zap.Error(err))
-			// TODO(INT-333): Add exponential backoff.
 			continue
 		}
 


### PR DESCRIPTION
Testing: verified that events work as expected. Tested exponential backoff by attempting to init a grpc connection with an expired token. Observed expected behavior.

Refs: INT-333