### PR TITLE
fix: Fix build errors when git is not available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 ARCH=$(shell uname -m)
 
 ifeq ($(COMMIT),)
-COMMIT=$(shell git rev-parse HEAD)$(shell git diff --quiet || echo '_dirty')
+COMMIT=$(shell git rev-parse HEAD 2>/dev/null || echo "unknown")$(shell git diff --quiet 2>/dev/null || : && echo '')
 endif
 
 ifeq ($(TIMESTAMP),)


### PR DESCRIPTION
This PR modifies the Makefile to gracefully handle environments where git is not installed. Instead of failing with errors during the build process, we now provide fallback values for version information when git commands cannot be executed.

Refs: INT-325
