### PR TITLE
feat: switch to store jwt in cookie

### DIFF
--- a/internal/backend/auth/authhttpmiddleware/authmiddleware.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware.go
@@ -67,10 +67,10 @@ func newTokensMiddleware(tokens authtokens.Tokens) middlewareFn {
 
 func newSessionsMiddleware(sessions authsessions.Store) middlewareFn {
 	return func(r *http.Request) (sdktypes.UserID, *middlewareError) {
-		session, err := sessions.Get(r)
+		user, err := sessions.Get(r)
 		// Do not fail on error - graceful degradation in case of session structure changes.
-		if err == nil && session != nil {
-			return session.UserID, nil
+		if err == nil && user.IsValid() {
+			return user.ID(), nil
 		}
 
 		return sdktypes.InvalidUserID, nil

--- a/internal/backend/auth/authhttpmiddleware/authmiddleware_test.go
+++ b/internal/backend/auth/authhttpmiddleware/authmiddleware_test.go
@@ -101,7 +101,8 @@ func TestTokensMiddleware(t *testing.T) {
 }
 
 func TestSessionsMiddleware(t *testing.T) {
-	sessions := kittehs.Must1(authsessions.New(authsessions.Configs.Dev))
+	tokens, _ := authjwttokens.New(authjwttokens.Configs.Dev)
+	sessions := kittehs.Must1(authsessions.New(authsessions.Configs.Dev, tokens))
 
 	mw := newSessionsMiddleware(sessions)
 
@@ -112,7 +113,7 @@ func TestSessionsMiddleware(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	kittehs.Must0(sessions.Set(w, authsessions.NewSessionData(testUser1.ID())))
+	kittehs.Must0(sessions.Set(w, testUser1))
 	cookies := w.Result().Cookies()
 
 	// legit cookies.
@@ -153,9 +154,8 @@ func (u testUsers) Setup(context.Context) error { return nil }
 
 func newTestHarness(t *testing.T, useDefaultUser bool) *harness {
 	h, check := newTestHandler(t, authcontext.GetAuthnUserID)
-
-	sessions := kittehs.Must1(authsessions.New(authsessions.Configs.Dev))
-	tokens := kittehs.Must1(authjwttokens.New(authjwttokens.Configs.Dev))
+	tokens, _ := authjwttokens.New(authjwttokens.Configs.Dev)
+	sessions := kittehs.Must1(authsessions.New(authsessions.Configs.Dev, tokens))
 	users := &sdktest.TestUsers{}
 
 	if useDefaultUser {
@@ -209,7 +209,7 @@ func TestNewWithoutDefaultUser(t *testing.T) {
 
 	// correct token, but no such user.
 	w = httptest.NewRecorder()
-	kittehs.Must0(h.sessions.Set(w, authsessions.NewSessionData(testUser1.ID())))
+	kittehs.Must0(h.sessions.Set(w, testUser1))
 	cookies := w.Result().Cookies()
 
 	w = httptest.NewRecorder()
@@ -310,7 +310,7 @@ func TestNewWithDefaultUser(t *testing.T) {
 
 	// correct session, but no such user.
 	w = httptest.NewRecorder()
-	kittehs.Must0(h.sessions.Set(w, authsessions.NewSessionData(testUser1.ID())))
+	kittehs.Must0(h.sessions.Set(w, testUser1))
 	cookies := w.Result().Cookies()
 
 	w = httptest.NewRecorder()

--- a/internal/backend/auth/authloginhttpsvc/svc.go
+++ b/internal/backend/auth/authloginhttpsvc/svc.go
@@ -169,7 +169,7 @@ func (a *svc) registerRoutes(muxes *muxes.Muxes) error {
 
 		// renew cookie expiration time
 		if err := a.Deps.Sessions.Set(w, u); err != nil {
-			a.L.Warn("failed renewing session for user: "+string(u.ID().UUIDValue().String()), zap.Error(err))
+			a.L.Warn("failed renewing session for user: "+u.ID().UUIDValue().String(), zap.Error(err), zap.String("user_id", u.ID().String()))
 		}
 
 		w.Header().Add("Content-Type", "application/json")

--- a/internal/backend/auth/authloginhttpsvc/svc.go
+++ b/internal/backend/auth/authloginhttpsvc/svc.go
@@ -168,7 +168,9 @@ func (a *svc) registerRoutes(muxes *muxes.Muxes) error {
 		}
 
 		// renew cookie expiration time
-		a.Deps.Sessions.Set(w, u)
+		if err := a.Deps.Sessions.Set(w, u); err != nil {
+			a.L.Warn("failed renewing session for user: "+string(u.ID().UUIDValue().String()), zap.Error(err))
+		}
 
 		w.Header().Add("Content-Type", "application/json")
 

--- a/internal/backend/auth/authloginhttpsvc/svc.go
+++ b/internal/backend/auth/authloginhttpsvc/svc.go
@@ -250,7 +250,7 @@ func (a *svc) newSuccessLoginHandler(ctx context.Context, ld *loginData) http.Ha
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := a.Deps.Sessions.Set(w, authsessions.NewSessionData(uid)); err != nil {
+		if err := a.Deps.Sessions.Set(w, u); err != nil {
 			sl.With("err", err).Errorf("failed storing session: %v", err)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return

--- a/internal/backend/auth/authloginhttpsvc/svc_test.go
+++ b/internal/backend/auth/authloginhttpsvc/svc_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authsessions"
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authtokens/authjwttokens"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdktest"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
@@ -132,7 +133,8 @@ func TestNewSuccessLoginHandlerSessions(t *testing.T) {
 		},
 	}
 
-	sessions := kittehs.Must1(authsessions.New(authsessions.Configs.Dev))
+	tokens, _ := authjwttokens.New(authjwttokens.Configs.Dev)
+	sessions := kittehs.Must1(authsessions.New(authsessions.Configs.Dev, tokens))
 
 	s := &svc{
 		Deps: Deps{
@@ -162,7 +164,7 @@ func TestNewSuccessLoginHandlerSessions(t *testing.T) {
 
 			sd, err := sessions.Get(r)
 			if assert.NoError(t, err) {
-				assert.Equal(t, testUser.ID(), sd.UserID)
+				assert.Equal(t, testUser.ID(), sd.ID())
 			}
 		}
 	}

--- a/internal/backend/auth/authsessions/config.go
+++ b/internal/backend/auth/authsessions/config.go
@@ -7,20 +7,23 @@ import (
 )
 
 type Config struct {
-	SameSite   http.SameSite
-	CookieKeys string `koanf:"cookie_keys"` // pairs of hash and block keys.
-	Domain     string `koanf:"ui_domain"`
-	Secure     bool
+	SameSite          http.SameSite
+	CookieKeys        string `koanf:"cookie_keys"` // pairs of hash and block keys.
+	Domain            string `koanf:"ui_domain"`
+	Secure            bool
+	ExpirationMinutes int `koanf:"expiration_minutes"`
 }
 
 var Configs = configset.Set[Config]{
 	Default: &Config{
-		SameSite: http.SameSiteNoneMode,
-		Secure:   true,
+		SameSite:          http.SameSiteNoneMode,
+		Secure:            true,
+		ExpirationMinutes: 60 * 24 * 14, // 14 days
 	},
 	Dev: &Config{
-		Secure:     false,
-		SameSite:   http.SameSiteLaxMode,
-		CookieKeys: "0000000000000000000000000000000000000000000000000000000000000000,0000000000000000000000000000000000000000000000000000000000000000",
+		Secure:            false,
+		SameSite:          http.SameSiteLaxMode,
+		CookieKeys:        "0000000000000000000000000000000000000000000000000000000000000000,0000000000000000000000000000000000000000000000000000000000000000",
+		ExpirationMinutes: 60 * 24 * 14, // 14 days
 	},
 }

--- a/internal/backend/auth/authsessions/store.go
+++ b/internal/backend/auth/authsessions/store.go
@@ -1,158 +1,115 @@
 package authsessions
 
 import (
-	"encoding/hex"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
-	"github.com/dghubble/sessions"
-	"github.com/google/uuid"
-
-	"go.autokitteh.dev/autokitteh/internal/kittehs"
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authtokens"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 const (
-	sessionName        = "ak_user_session"
-	sessionDataKeyName = "ak_data"
-	loggedInCookie     = "ak_logged_in"
+	sessionName    = "ak_user_session"
+	loggedInCookie = "ak_logged_in"
 )
 
-type sessionData struct {
-	UserID    sdktypes.UserID
-	Validator string
-	CreatedAt time.Time
-}
-
-func NewSessionData(uid sdktypes.UserID) *sessionData {
-	return &sessionData{
-		UserID:    uid,
-		Validator: uuid.NewString(),
-		CreatedAt: time.Now(),
-	}
-}
-
 type store struct {
-	store    sessions.Store[[]byte]
-	domain   string
-	secure   bool
-	sameSite http.SameSite
+	// store    sessions.Store[[]byte]
+	domain     string
+	secure     bool
+	sameSite   http.SameSite
+	tokens     authtokens.Tokens
+	expiration time.Duration
 }
 
 type Store interface {
-	Set(http.ResponseWriter, *sessionData) error
-	Get(*http.Request) (*sessionData, error)
+	Set(http.ResponseWriter, sdktypes.User) error
+	Get(*http.Request) (sdktypes.User, error)
 	Delete(http.ResponseWriter)
 }
 
-func New(cfg *Config) (Store, error) {
-	rawKeyPairs := kittehs.Transform(strings.Split(cfg.CookieKeys, ","), strings.TrimSpace)
-	if len(rawKeyPairs)&1 != 0 {
-		return nil, errors.New("key pairs must be an even length list of hex encoded keys")
-	}
-
-	keyPairs, err := kittehs.TransformError(rawKeyPairs, hex.DecodeString)
-	if err != nil {
-		return nil, fmt.Errorf("invalid key pairs: %w", err)
-	}
-
+func New(cfg *Config, tokens authtokens.Tokens) (Store, error) {
 	domain := cfg.Domain
 	if len(domain) > 0 && !strings.HasPrefix(domain, ".") {
 		domain = "." + cfg.Domain
 	}
 
-	cookieConfig := sessions.CookieConfig{
-		Domain:   cfg.Domain,
-		Path:     "/",
-		Secure:   cfg.Secure,
-		HTTPOnly: true,
-		SameSite: cfg.SameSite,
-	}
-
 	return &store{
-		store:    sessions.NewCookieStore[[]byte](&cookieConfig, keyPairs...),
-		domain:   domain,
-		secure:   cfg.Secure,
-		sameSite: cfg.SameSite,
+		domain:     domain,
+		secure:     cfg.Secure,
+		sameSite:   cfg.SameSite,
+		tokens:     tokens,
+		expiration: time.Duration(cfg.ExpirationMinutes) * time.Minute,
 	}, nil
 }
 
-func (s store) newSessionWithData(data *sessionData) (*sessions.Session[[]byte], error) {
-	session := s.store.New(sessionName)
-
-	bs, err := json.Marshal(data)
+func (s store) Set(w http.ResponseWriter, user sdktypes.User) error {
+	jwt, err := s.tokens.Create(user)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal user data: %w", err)
-	}
-
-	session.Set(sessionDataKeyName, bs)
-	return session, nil
-}
-
-func (s store) Set(w http.ResponseWriter, data *sessionData) error {
-	session, err := s.newSessionWithData(data)
-	if err != nil {
-		return err
-	}
-
-	if err := session.Save(w); err != nil {
 		return err
 	}
 
 	http.SetCookie(w, &http.Cookie{
-		Name:     loggedInCookie,
-		Value:    data.Validator,
+		Name:     sessionName,
+		Value:    jwt,
 		Path:     "/",
 		Domain:   s.domain,
 		SameSite: s.sameSite,
 		Secure:   s.secure,
+		Expires:  time.Now().Add(s.expiration),
+	})
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     loggedInCookie,
+		Value:    "true",
+		Path:     "/",
+		Domain:   s.domain,
+		SameSite: s.sameSite,
+		Secure:   s.secure,
+		Expires:  time.Now().Add(s.expiration),
 	})
 
 	return nil
 }
 
-func (s store) Get(req *http.Request) (*sessionData, error) {
+func (s store) Get(req *http.Request) (sdktypes.User, error) {
 	cookie, err := req.Cookie(loggedInCookie)
 	if err != nil {
 		if errors.Is(err, http.ErrNoCookie) {
-			return nil, nil
+			return sdktypes.InvalidUser, nil
 		}
-		return nil, err
+		return sdktypes.InvalidUser, err
 	}
 
-	// make sure the cookie value is a UUID.
-	if _, err := uuid.Parse(cookie.Value); err != nil {
-		return nil, errors.New("invalid logged in cookie")
+	if cookie.Value != "true" {
+		return sdktypes.InvalidUser, errors.New("invalid logged in cookie")
 	}
 
-	session, err := s.store.Get(req, sessionName)
+	sessionCookie, err := req.Cookie(sessionName)
 	if err != nil {
 		if errors.Is(err, http.ErrNoCookie) {
-			return nil, nil
+			return sdktypes.InvalidUser, nil
 		}
-		return nil, err
+		return sdktypes.InvalidUser, err
 	}
 
-	bs := session.Get(sessionDataKeyName)
-
-	var sd sessionData
-	if err := json.Unmarshal(bs, &sd); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal user data: %w", err)
+	user, err := s.tokens.Parse(sessionCookie.Value)
+	if err != nil {
+		return sdktypes.InvalidUser, err
 	}
 
-	if cookie.Value != sd.Validator {
-		return nil, errors.New("invalid logged in cookie")
-	}
-
-	return &sd, nil
+	return user, nil
 }
 
 func (s *store) Delete(w http.ResponseWriter) {
-	s.store.Destroy(w, sessionName)
+	http.SetCookie(w, &http.Cookie{
+		Name:    sessionName,
+		Value:   "",
+		Path:    "/",
+		Expires: time.Unix(0, 0),
+	})
 	http.SetCookie(w, &http.Cookie{
 		Name:    loggedInCookie,
 		Value:   "",

--- a/internal/backend/auth/authsessions/store_test.go
+++ b/internal/backend/auth/authsessions/store_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authtokens/authjwttokens"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
@@ -16,7 +17,9 @@ var testUID = sdktypes.NewUserID()
 
 func newStore(t *testing.T) Store {
 	cfg := Configs.Dev
-	s, err := New(cfg)
+	tokens, _ := authjwttokens.New(authjwttokens.Configs.Dev)
+
+	s, err := New(cfg, tokens)
 	require.NoError(t, err)
 	return s
 }
@@ -33,7 +36,7 @@ func TestStoreGetNoLoggedinCookie(t *testing.T) {
 	s := newStore(t)
 	r := http.Request{}
 	sd, err := s.Get(&r)
-	assert.Nil(t, sd)
+	assert.Equal(t, sd, sdktypes.InvalidUser)
 	assert.Nil(t, err)
 }
 
@@ -45,15 +48,15 @@ func TestStoreGetInvalidLoggedInCookie(t *testing.T) {
 		},
 	}
 	sd, err := s.Get(&r)
-	assert.Nil(t, sd)
+	assert.Equal(t, sd, sdktypes.InvalidUser)
 	assert.Error(t, err, "invalid logged in cookie")
 }
 
 func TestStoreGetNoSessionCookie(t *testing.T) {
 	s := newStore(t)
-	r := newRequestWithLoggedInCookie(uuid.NewString())
+	r := newRequestWithLoggedInCookie("true")
 	sd, err := s.Get(&r)
-	assert.Nil(t, sd)
+	assert.Equal(t, sd, sdktypes.InvalidUser)
 	assert.Nil(t, err)
 }
 
@@ -67,18 +70,15 @@ func TestStoreGetInvalidSessionCookie(t *testing.T) {
 	})
 
 	sd, err := s.Get(&r)
-	assert.Nil(t, sd)
+	assert.Equal(t, sd, sdktypes.InvalidUser)
 	assert.Error(t, err)
 }
 
 func TestStoreGetValidatorMismatch(t *testing.T) {
 	s := newStore(t)
 	w := httptest.NewRecorder()
-	validator := uuid.NewString()
-	err := s.Set(w, &sessionData{
-		UserID:    testUID,
-		Validator: validator,
-	})
+	u := sdktypes.NewUser().WithID(testUID)
+	err := s.Set(w, u)
 	assert.Nil(t, err)
 
 	otherValidator := uuid.NewString()
@@ -86,18 +86,16 @@ func TestStoreGetValidatorMismatch(t *testing.T) {
 	r.AddCookie(w.Result().Cookies()[0])
 
 	sd, err := s.Get(&r)
-	assert.Nil(t, sd)
+	assert.Equal(t, sd, sdktypes.InvalidUser)
 	assert.Error(t, err)
 }
 
 func TestStoreSetGetSuccess(t *testing.T) {
 	s := newStore(t)
 	w := httptest.NewRecorder()
-	validator := uuid.NewString()
-	expectedSessionData := &sessionData{
-		UserID:    testUID,
-		Validator: validator,
-	}
+	validator := "true"
+	u := sdktypes.NewUser().WithID(testUID)
+	expectedSessionData := u
 	err := s.Set(w, expectedSessionData)
 	assert.Nil(t, err)
 
@@ -108,6 +106,5 @@ func TestStoreSetGetSuccess(t *testing.T) {
 
 	sd, err := s.Get(&r)
 	assert.Nil(t, err)
-	assert.Equal(t, sd.Validator, expectedSessionData.Validator)
-	assert.Equal(t, sd.UserID, expectedSessionData.UserID)
+	assert.Equal(t, sd.ID(), expectedSessionData.ID())
 }


### PR DESCRIPTION
- This change makes the UI cookie store a standard jwt, unifying the "experience" of jwt and cookie

- it will also allow us simpler / easier usage in the gateway before the server

- it introduce an expiration time to the cookie so users are logged out automatically if it is not renewed (default for 14 days)

- auto renew cookies whenever the UI calls who-am-i endpoint, in case it will call it once a day, it will work fine without any probelms

