### PR TITLE
fix: add thread_ts from app_mention event in slack

### DIFF
--- a/integrations/slack/events/app.go
+++ b/integrations/slack/events/app.go
@@ -17,8 +17,9 @@ type AppMentionEvent struct {
 	TS      string `json:"ts,omitempty"`
 	EventTS string `json:"event_ts,omitempty"`
 
-	Text   string           `json:"text,omitempty"`
-	Blocks []map[string]any `json:"blocks,omitempty"`
+	ThreadTS string           `json:"thread_ts,omitempty"`
+	Text     string           `json:"text,omitempty"`
+	Blocks   []map[string]any `json:"blocks,omitempty"`
 
 	ClientMsgID string `json:"client_msg_id,omitempty"`
 }

--- a/integrations/slack/events/app.go
+++ b/integrations/slack/events/app.go
@@ -11,15 +11,15 @@ import (
 type AppMentionEvent struct {
 	Type string `json:"type,omitempty"`
 
-	User    string `json:"user,omitempty"`
-	Team    string `json:"team,omitempty"`
-	Channel string `json:"channel,omitempty"`
-	TS      string `json:"ts,omitempty"`
-	EventTS string `json:"event_ts,omitempty"`
+	User     string `json:"user,omitempty"`
+	Team     string `json:"team,omitempty"`
+	Channel  string `json:"channel,omitempty"`
+	TS       string `json:"ts,omitempty"`
+	EventTS  string `json:"event_ts,omitempty"`
+	ThreadTS string `json:"thread_ts,omitempty"`
 
-	ThreadTS string           `json:"thread_ts,omitempty"`
-	Text     string           `json:"text,omitempty"`
-	Blocks   []map[string]any `json:"blocks,omitempty"`
+	Text   string           `json:"text,omitempty"`
+	Blocks []map[string]any `json:"blocks,omitempty"`
 
 	ClientMsgID string `json:"client_msg_id,omitempty"`
 }


### PR DESCRIPTION
As part of a client project, the requirement is to send all messages from a Slack thread to an AWS knowledge base whenever their app is mentioned within that thread.

To do this, we need the thread_ts to fetch the full thread. I noticed it wasn't included in the event payload, so I added it to ensure we can retrieve all messages correctly.
