### PR TITLE
fix(jira): remove support for `issue_property_set` and `issue_property_deleted`

### DIFF
--- a/integrations/atlassian/jira/webhooks.go
+++ b/integrations/atlassian/jira/webhooks.go
@@ -169,7 +169,6 @@ func registerWebhook(ctx context.Context, l *zap.Logger, baseURL, token string) 
 				Events: []string{
 					"jira:issue_created", "jira:issue_updated", "jira:issue_deleted",
 					"comment_created", "comment_updated", "comment_deleted",
-					"issue_property_set", "issue_property_deleted",
 				},
 				// "GET .../webhook" doesn't show webhook URLs in the response,
 				// so we use a trick: we specify the AutoKitteh server address in


### PR DESCRIPTION
This PR removes support for `issue_property_set` and `issue_property_delete` events. These events:

- Can only be triggered programmatically via the Jira API (not by user actions in the UI)
- Refer to custom issue properties (not standard fields like assignee), which aren’t visible to end users
- Intentionally omit issue data, making it impossible to map them back to a corresponding issue without additional work

Since these events aren’t relevant to our use cases and add unnecessary complexity, support for them has been removed.