### PR TITLE
fix(jira): ignore irrelevant events + cosmetic tweaks

### DIFF
--- a/integrations/atlassian/jira/event.go
+++ b/integrations/atlassian/jira/event.go
@@ -78,7 +78,7 @@ func (h handler) handleEvent(w http.ResponseWriter, r *http.Request) {
 	// issue_property_set and issue_property_deleted events aren’t supported or relevant to AutoKitteh.
 	// They occur when custom fields are programmatically changed on an issue.
 	// We ignore them because our webhook only extends expiration and doesn't update subscriptions.
-	if jiraEvent["webhookEvent"] == "issue_property_set" || jiraEvent["webhookEvent"] == "issue_property_deleted" {
+	if strings.HasPrefix(jiraEvent["webhookEvent"], "issue_property") {
 		l.Debug("Jira issue property set/deleted event", zap.Any("event", jiraEvent))
 		return
 	}

--- a/integrations/atlassian/jira/event.go
+++ b/integrations/atlassian/jira/event.go
@@ -78,7 +78,7 @@ func (h handler) handleEvent(w http.ResponseWriter, r *http.Request) {
 	// issue_property_set and issue_property_deleted events aren’t supported or relevant to AutoKitteh.
 	// They occur when custom fields are programmatically changed on an issue.
 	// We ignore them because our webhook only extends expiration and doesn't update subscriptions.
-	if strings.HasPrefix(jiraEvent["webhookEvent"], "issue_property") {
+	if jiraEvent["webhookEvent"] == "issue_property_set" || jiraEvent["webhookEvent"] == "issue_property_deleted" {
 		l.Debug("Jira issue property set/deleted event", zap.Any("event", jiraEvent))
 		return
 	}

--- a/integrations/atlassian/jira/event.go
+++ b/integrations/atlassian/jira/event.go
@@ -75,6 +75,14 @@ func (h handler) handleEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// issue_property_set and issue_property_deleted events aren’t supported or relevant to AutoKitteh.
+	// They occur when custom fields are programmatically changed on an issue.
+	// We ignore them because our webhook only extends expiration and can’t update subscriptions.
+	if jiraEvent["webhookEvent"] == "issue_property_set" || jiraEvent["webhookEvent"] == "issue_property_deleted" {
+		l.Debug("Jira issue property set/deleted event", zap.Any("event", jiraEvent))
+		return
+	}
+
 	// Construct an AutoKitteh event from the Jira event.
 	akEvent, err := constructEvent(l, jiraEvent)
 	if err != nil {
@@ -103,11 +111,8 @@ func (h handler) handleEvent(w http.ResponseWriter, r *http.Request) {
 	for _, id := range ids {
 		u, err := transformIssueURL(jiraEvent, l)
 		if err != nil {
-			l.Error("Failed to transform Jira URL",
-				zap.Error(err),
-				zap.Any("jiraEvent", jiraEvent),
-			)
-			http.Error(w, "Bad Request", http.StatusBadRequest)
+			l.Error("Failed to transform Jira URL", zap.Error(err))
+			common.HTTPError(w, http.StatusBadRequest)
 			return
 		}
 		wk := webhookKey(u, strconv.Itoa(id))

--- a/integrations/atlassian/jira/event.go
+++ b/integrations/atlassian/jira/event.go
@@ -77,7 +77,7 @@ func (h handler) handleEvent(w http.ResponseWriter, r *http.Request) {
 
 	// issue_property_set and issue_property_deleted events aren’t supported or relevant to AutoKitteh.
 	// They occur when custom fields are programmatically changed on an issue.
-	// We ignore them because our webhook only extends expiration and can’t update subscriptions.
+	// We ignore them because our webhook only extends expiration and doesn't update subscriptions.
 	if jiraEvent["webhookEvent"] == "issue_property_set" || jiraEvent["webhookEvent"] == "issue_property_deleted" {
 		l.Debug("Jira issue property set/deleted event", zap.Any("event", jiraEvent))
 		return


### PR DESCRIPTION
This is a rollback of #1208 
Because our current implementation does not support updating webhooks, we decided to ignore `issue_property_set` and `issue_property_delete` events instead.

Here is what the log would print:
```
2025-03-26 17:20:24 WARN jira/event.go:82 Jira issue property set/deleted event {"integration": "jira", "url_path": "/jira/webhook", "event": {"matchedWebhookIds":[39],"property":{"key":"custom_property","value":{"status":"processing"}},"timestamp":1743034824099,"webhookEvent":"issue_property_set"}}
```

I don't think it exposes any sensitive data, but I'm also not sure it's necessary?

Testing: successfully received event

Refs: INT-361