### PR TITLE
fix: call cleanup once pythonrt is done

### DIFF
--- a/runtimes/pythonrt/pythonrt.go
+++ b/runtimes/pythonrt/pythonrt.go
@@ -86,9 +86,17 @@ type pySvc struct {
 	firstCall bool // first call is the trigger, other calls are activities
 
 	channels comChannels
+
+	didCleanup bool
 }
 
 func (py *pySvc) cleanup(ctx context.Context) {
+	if py.didCleanup {
+		return
+	}
+
+	py.didCleanup = true
+
 	if err := runnerManager.Stop(ctx, py.runnerID); err != nil {
 		py.log.Warn("stop manager", zap.Error(err))
 	}

--- a/runtimes/pythonrt/pythonrt.go
+++ b/runtimes/pythonrt/pythonrt.go
@@ -519,7 +519,7 @@ func (py *pySvc) Call(ctx context.Context, v sdktypes.Value, args []sdktypes.Val
 			return sdktypes.InvalidValue, fmt.Errorf("start request: %w", err)
 		}
 		defer func() {
-			py.cleanup(ctx)
+			py.cleanup(context.Background())
 		}()
 	} else {
 		// If we're here, it's an activity call

--- a/runtimes/pythonrt/pythonrt.go
+++ b/runtimes/pythonrt/pythonrt.go
@@ -510,6 +510,9 @@ func (py *pySvc) Call(ctx context.Context, v sdktypes.Value, args []sdktypes.Val
 			}
 			return sdktypes.InvalidValue, fmt.Errorf("start request: %w", err)
 		}
+		defer func() {
+			py.cleanup(ctx)
+		}()
 	} else {
 		// If we're here, it's an activity call
 		req := pbUserCode.ExecuteRequest{Data: fn.Data()}

--- a/runtimes/pythonrt/pythonrt_test.go
+++ b/runtimes/pythonrt/pythonrt_test.go
@@ -238,6 +238,8 @@ func Test_pySvc_Run(t *testing.T) {
 	}
 	_, err = run.Call(ctx, fn, nil, kwargs)
 	require.NoError(t, err, "call")
+
+	require.True(t, svc.didCleanup, "cleanup wasn't called")
 }
 
 var isGoodVersionCasess = []struct {


### PR DESCRIPTION
This fixes a critical issue where runners are never stopped 
fixed [ENG-2062]