### PR TITLE
fix(python): deal with unpicklable exceptions correctly when not caught

### DIFF
--- a/runtimes/pythonrt/runner/main.py
+++ b/runtimes/pythonrt/runner/main.py
@@ -457,7 +457,7 @@ class Runner(pb.runner_rpc.RunnerService):
 
         try:
             if result.error:
-                req.error = self.result_error(result.error)
+                req.error = self.result_error(restore_error(result.error))
                 tb = pb_traceback(result.traceback)
                 req.traceback.extend(tb)
             else:

--- a/tests/sessions/python/caught_unpicklable_exception.txtar
+++ b/tests/sessions/python/caught_unpicklable_exception.txtar
@@ -1,0 +1,24 @@
+exception
+done
+
+-- main.py main --
+from autokitteh import activity
+import openai
+import httpx
+
+
+@activity
+def callstuff():
+    resp = httpx.Response(425)
+    resp.request = httpx.Request("GET", "https://example.com")
+
+    # This exception can be pickled, but not unpickled.
+    raise openai.RateLimitError("message", response=resp, body=None)
+
+
+def main(_):
+    try:
+        callstuff()
+    except openai.RateLimitError as e:
+        print("exception")
+    print("done")

--- a/tests/sessions/python/uncaught_unpicklable_exception.txtar
+++ b/tests/sessions/python/uncaught_unpicklable_exception.txtar
@@ -1,0 +1,22 @@
+-- main.py main --
+from autokitteh import activity
+import openai
+import httpx
+
+
+@activity
+def callstuff():
+    resp = httpx.Response(425)
+    resp.request = httpx.Request("GET", "https://example.com")
+
+    # This exception can be pickled, but not unpickled.
+    raise openai.RateLimitError("message", response=resp, body=None)
+
+
+def main(_):
+    callstuff()
+
+-- error.txt --
+error: RateLimitError()
+
+openai.RateLimitError


### PR DESCRIPTION
actual fix in runtimes/pythonrt/runner/main.py.

there are some issues still I think - I have a suspicion that this doesn't work well with classes that inherit other classes, so the `__str__` doesn't work well. but this is better than nothing. need to investigate further.

also, added ability to compare session errors to tests.