### PR TITLE
feat: convert jwt to rsa and expose jwks endpoint

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -6,6 +6,7 @@ extend-exclude = [
     "runtimes/pythonrt/build_test.go",
     "sdk/sdktypes/integration_id_test.go",
     "go.mod",
+    "internal/backend/auth/authtokens/authjwttokens/jwt_test.go"
 ]
 
 [default.extend-identifiers]

--- a/internal/backend/auth/authloginhttpsvc/svc.go
+++ b/internal/backend/auth/authloginhttpsvc/svc.go
@@ -194,7 +194,10 @@ func (a *svc) registerRoutes(muxes *muxes.Muxes) error {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(jwks)
+		if err := json.NewEncoder(w).Encode(jwks); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	})
 
 	return nil

--- a/internal/backend/auth/authloginhttpsvc/svc.go
+++ b/internal/backend/auth/authloginhttpsvc/svc.go
@@ -17,6 +17,7 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authloginhttpsvc/web"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authsessions"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authtokens"
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authtokens/authjwttokens"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authusers"
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
 	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
@@ -178,6 +179,22 @@ func (a *svc) registerRoutes(muxes *muxes.Muxes) error {
 		if err := json.NewEncoder(w).Encode(u); err != nil {
 			a.L.Error("failed writing response", zap.Error(err))
 		}
+	})
+
+	muxes.NoAuth.HandleFunc("/.well-known/jwks.json", func(w http.ResponseWriter, r *http.Request) {
+		rsaTokens, ok := a.Deps.Tokens.(authjwttokens.RSATokens)
+		if !ok {
+			http.Error(w, "RSA tokens not configured", http.StatusBadRequest)
+			return
+		}
+		jwks, err := rsaTokens.GetJWKS()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(jwks)
 	})
 
 	return nil

--- a/internal/backend/auth/authtokens/authjwttokens/jwks.go
+++ b/internal/backend/auth/authtokens/authjwttokens/jwks.go
@@ -1,0 +1,45 @@
+package authjwttokens
+
+import (
+	"encoding/base64"
+	"math/big"
+)
+
+// JWKS represents a JSON Web Key Set as defined in RFC 7517
+type JWKS struct {
+	Keys []JWK `json:"keys"`
+}
+
+// JWK represents a JSON Web Key as defined in RFC 7517
+type JWK struct {
+	Kid string `json:"kid"`
+	Kty string `json:"kty"`
+	Alg string `json:"alg"`
+	Use string `json:"use"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+// GetJWKS returns the JWKS containing the public key information
+func (rs *rsaTokens) GetJWKS() (*JWKS, error) {
+	if rs.publicKey == nil {
+		return nil, ErrNoPublicKey
+	}
+
+	// Convert public key components to base64url encoding
+	nBytes := rs.publicKey.N.Bytes()
+	eBytes := big.NewInt(int64(rs.publicKey.E)).Bytes()
+
+	jwk := JWK{
+		Kid: "1", // You might want to make this configurable or derive it from the key
+		Kty: "RSA",
+		Alg: "RS256",
+		Use: "sig",
+		N:   base64.RawURLEncoding.EncodeToString(nBytes),
+		E:   base64.RawURLEncoding.EncodeToString(eBytes),
+	}
+
+	return &JWKS{
+		Keys: []JWK{jwk},
+	}, nil
+}

--- a/internal/backend/auth/authtokens/authjwttokens/jwks_test.go
+++ b/internal/backend/auth/authtokens/authjwttokens/jwks_test.go
@@ -1,0 +1,36 @@
+package authjwttokens
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJWKS(t *testing.T) {
+	cfg := &Config{
+		Algorithm: AlgorithmRSA,
+		RSA: RSAConfig{
+			PrivateKey: testRSAPrivateKey,
+			PublicKey:  testRSAPublicKey,
+		},
+	}
+
+	tokens, err := New(cfg)
+	require.NoError(t, err)
+
+	rsaTokens, ok := tokens.(RSATokens)
+	require.True(t, ok, "tokens should implement RSATokens interface")
+
+	jwks, err := rsaTokens.GetJWKS()
+	require.NoError(t, err)
+	require.NotNil(t, jwks)
+	require.Len(t, jwks.Keys, 1)
+
+	key := jwks.Keys[0]
+	assert.Equal(t, "RSA", key.Kty)
+	assert.Equal(t, "RS256", key.Alg)
+	assert.Equal(t, "sig", key.Use)
+	assert.NotEmpty(t, key.N)
+	assert.NotEmpty(t, key.E)
+}

--- a/internal/backend/auth/authtokens/authjwttokens/jwt.go
+++ b/internal/backend/auth/authtokens/authjwttokens/jwt.go
@@ -9,8 +9,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-const issuer = "ak"
-
 type Algorithm string
 
 const (

--- a/internal/backend/auth/authtokens/authjwttokens/jwt.go
+++ b/internal/backend/auth/authtokens/authjwttokens/jwt.go
@@ -1,38 +1,31 @@
 package authjwttokens
 
 import (
-	"encoding/hex"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
-	"time"
-
-	j "github.com/golang-jwt/jwt/v5"
-	"github.com/google/uuid"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authtokens"
-	"go.autokitteh.dev/autokitteh/internal/backend/auth/authusers"
 	"go.autokitteh.dev/autokitteh/internal/backend/configset"
-	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 const issuer = "ak"
 
-var (
-	method   = j.SigningMethodHS256
-	hashSize = method.Hash.Size()
+type Algorithm string
+
+const (
+	AlgorithmHMAC Algorithm = "hmac"
+	AlgorithmRSA  Algorithm = "rsa"
 )
 
+// Config represents the top-level JWT configuration
 type Config struct {
-	SignKey string `koanf:"sign_key"`
+	Algorithm Algorithm  `koanf:"algorithm"`
+	HMAC      HMACConfig `koanf:"hmac"`
+	RSA       RSAConfig  `koanf:"rsa"`
 }
 
-type tokens struct {
-	signKey []byte
-}
-
+// token is shared between HMAC and RSA implementations
 type token struct {
 	User sdktypes.User
 }
@@ -40,68 +33,27 @@ type token struct {
 var Configs = configset.Set[Config]{
 	Default: &Config{},
 	Dev: &Config{
-		SignKey: strings.Repeat("00", hashSize),
+		Algorithm: AlgorithmHMAC,
+		HMAC: HMACConfig{
+			SignKey: strings.Repeat("00", hashSize),
+		},
 	},
 	Test: &Config{
-		SignKey: strings.Repeat("00", hashSize),
+		Algorithm: AlgorithmHMAC,
+		HMAC: HMACConfig{
+			SignKey: strings.Repeat("00", hashSize),
+		},
 	},
 }
 
+// New creates a new JWT token provider based on the configuration
 func New(cfg *Config) (authtokens.Tokens, error) {
-	key, err := hex.DecodeString(cfg.SignKey)
-	if err != nil {
-		return nil, fmt.Errorf("invalid signing key: %w", err)
+	switch cfg.Algorithm {
+	case AlgorithmHMAC:
+		return newHMAC(&cfg.HMAC)
+	case AlgorithmRSA:
+		return newRSA(&cfg.RSA)
+	default:
+		return nil, errors.New("unsupported JWT algorithm")
 	}
-
-	if len(key) != hashSize {
-		return nil, fmt.Errorf("invalid key len: %d != desired %d", len(key), hashSize)
-	}
-
-	return &tokens{signKey: key}, nil
-}
-
-func (js *tokens) Create(u sdktypes.User) (string, error) {
-	if authusers.IsSystemUserID(u.ID()) {
-		return "", sdkerrors.NewInvalidArgumentError("system user")
-	}
-
-	uuid, err := uuid.NewV7()
-	if err != nil {
-		return "", fmt.Errorf("generate UUID: %w", err)
-	}
-
-	tok := token{User: u}
-	bs, err := json.Marshal(tok)
-	if err != nil {
-		return "", fmt.Errorf("marshal token: %w", err)
-	}
-
-	claim := j.RegisteredClaims{
-		IssuedAt: j.NewNumericDate(time.Now()),
-		Issuer:   issuer,
-		Subject:  string(bs),
-		ID:       uuid.String(),
-	}
-
-	return j.NewWithClaims(method, claim).SignedString(js.signKey)
-}
-
-func (js *tokens) Parse(raw string) (sdktypes.User, error) {
-	var claims j.RegisteredClaims
-
-	t, err := j.ParseWithClaims(raw, &claims, func(t *j.Token) (interface{}, error) { return js.signKey, nil })
-	if err != nil {
-		return sdktypes.InvalidUser, err // TODO: better error handling
-	}
-
-	if !t.Valid {
-		return sdktypes.InvalidUser, errors.New("invalid token")
-	}
-
-	var tok token
-	if err := json.Unmarshal([]byte(claims.Subject), &tok); err != nil {
-		return sdktypes.InvalidUser, fmt.Errorf("unmarshal token: %w", err)
-	}
-
-	return tok.User, nil
 }

--- a/internal/backend/auth/authtokens/authjwttokens/jwt_test.go
+++ b/internal/backend/auth/authtokens/authjwttokens/jwt_test.go
@@ -1,0 +1,321 @@
+package authjwttokens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authtokens"
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authusers"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+const (
+	testRSAPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIJKAIBAAKCAgEApH5oa4ZuyMKGHLYUeEs0gAoE+85yOCgP/R1Ma19hB5wd5nrl
+Gya3O45g/3gjhQZMjrJpClOW9hrP5UxFrxQ5izIqV7/kLr3tCFN+7sNA98BRGKN5
+KXTVMB8T4YumSRGlUoT3lxXiDfIP49GoLhFB9NUenuc7/oTxivRUswhJNv6K7Xp3
+THh7rCH35miKmLRdyaIUTqh1u96JycW2EHLjGQBwd5BdLRx2AeOEx5V6fXUOUgmP
+safI/E8x5BQNvJpvOI9T6/YvuZoG/1BAxB78kGEJ/vqQeknAnI0IdFza/MVBnTkY
+0AyKXXSuEQxm83zWnZMK7kact3/ffgO2Ov1fQ90fxyki4RIN0omZDwSdUYHiJ1+4
+hbGnFShSNuPZ3jwi5coUZ9//KS3FPm6sP14cMoNqVph3jY//0eqAze0zqPUCKqHt
+7taTl+jhMYE1spMQjbtUuTo14OgRRvwF3b6lmekTFfAgfApT1rBBZCeycY76EtrB
+kq+8h0c9iuZyYYp1Bd8omCAng2PquWVNIDngCcfzd1nsVsjaL+wcnIHs7qo8XrB5
+Cuy2hvUv7XeJ3YrOsTPDkSkvABQ3MQx80Zx7y5UeUiwgw1s7ajxc3KXF9yVsesDi
+O7v+6GHIlM1Go0INHwzUwuL3PxNy1i7cU8pf5K5Wi7S9b7azLG/f6lGgo5UCAwEA
+AQKCAgALo3oF6ZwbDlBo5aUrIb8UNCFII8JHIOaItTL8AeKepDglX5qoQiQCzb8l
+ND3nIpv2GL9/4Iw0247MHYpsqdSseZ8vWD9v4zZLOYUopZ4KKYxTXvWqrj6LSheh
+BL1+PAZjgU73XLAC5pajOulYYRY2mYGyIpBHIObqOwFnLXXoszfnN5wLSBcQBdNB
+dTIhPdnI83PWYOr7oPJE2X1ZSpew5CwQ+aDuGS5sUcnKSVRCXi7mNRD6s/FvkLbp
++VVDe/XUnaeFcYTM8A4AsI/0kHC0UnlfliD01hUPvpbTjOJdsiNDWY/c4JZFqITM
+ZgE+xx10RrwmQc7C2QRaKS8Sm2zLBmYSPqHxFCK+0yJzgKOXTBDO+LZLoRTaTHGf
+zvYqYeO8G+Vv2CfCSJ55WYK1wpod1IiZbwMTepwRwRhslSyGdxlV83kvDW9e4aOI
+pVDNDwkkwIr3t2IYYk1nvToZcj1rK2NvYx173mkl64I4sBoTE5+pJzfmA40ycFJ0
+a1/GvXSNg6R8/aEBkGuO/3Nj4pZIlFTbkgkcRTIplR7D9myzepODOZ2lNc728EHk
+0tmFtx9dD8JyttYALtCrtKAm7kI7+Bko9iuOtcKyJ71iVyOxmHla7RKs2l2Qbt5Y
+1BCLWSR5ZGipjrY/ELMjYxn2x/YecduCAM+PJaLbHuRK+kdeIQKCAQEA0O2AH65h
+Krt4gB0ffhVKoPOvtu7kc46v0OUUa+HRC/E9k8WTkqeRHpn1Lij/i0dxZIQrC92l
+7g76PtEO+ov/ubOLjiwIW+UWu2Ii5ZwhzNSjLB9ZUaC6RmCMjAzolxykF7BgDjeF
+mnkauHEGlaAPPuTfGL5pHraTFFnBDY3cNVuipfYBgjqe5QxVsKUYv9N4/+W/ZyPX
+/sZ09I9S6ihsFVnYmMgpbahS+WsaxZg5a/3GhUbvf/JojFif84FOlb05tIZ7g3QF
++F9DrFVDGvRZiglVIDtL2auVNwBrwrO/THhlHBtuybujuvv7/C6nhzqaszkZboTz
+MAvXgROeudHWGQKCAQEAyY4NlOaFMwWPNYZj2BGNxWB4WSmsUY6hcl9Dc2NbakQ1
+A2A780Ox4DNLBP68Io7yjSBAN/BjiXQNUubqo8GvGr7NL72QptMlM1NRCA8jXGOR
+QAAVol5Jcir07E9gWY+eKHh5kJh4WPEviZxZPxttpat9sC1iPYl1zHwREzygbUOf
+nD2mdIT68RZnEqeDh9eAWcdjioM/VpzvSec3h3/yavt9JEkZZaZtAE4fAcF36xTs
+Rpy8iCCn08nj5LVPxUIsYu6tdJW5gQlQxdPrqbvEkxvZ6eFLzaeVZJjO+WIsk0Pf
+RHi8pF48DzEepI2on2dn5680F6Yv8QoczNJ8XYtQ3QKCAQB74HYZUsGWHrXh8GKd
+1W38ZMCIzLhzs+SXDVzAYpIabJ1AIuPPDr/CzzJKflCWenPHT35eeLtLnWHPIRGq
+iJvFtalHUOBb7EdAL33Vem+oDWP6Y1QITC5mUBTFbVnzTy4URaWOiGkVID0xowJu
+cQrZFccZ2rxlU4d9h4Ip0TUCBiU4FdbrKmrQEDI2nI1CH9cck1KbiuskyvLJlrlo
+0TLUrgL5A6VcuXMJI/IpuopBd6TfnSGgUVCf9mRQcxjvO9UdLqfJV1+61nE/mwZA
+0yTL7aCljcL5evzsMbmzJfSFGNWKhtF3l2QLGCFecyMt0RessGxd1UKD+GF8zO9N
+6hbxAoIBAQChNIW2Xz2P1lV5SPiYe0m54PPA1KznOj30nS70njYiY1VHUvQAGFev
+azcIUrmkplJm/7F9TD5AVNrHQLvQp/vmV08DbQnB9ETfrTa1TG5K2bP1zVuAVwtF
+TghA7Sex2kV0Nw970AcJlDYiSTO0Xrqu899+Rn45m7TlDSIXEbl6SsjhDQoSTb3r
+j7B24hY4UutsYyZBRcImAzT8Fft626HHYUfw+qpee+LYiKMSI2xHUJ+9xmSgOAYj
+RWmJpl6b9dZMdnuzMIGDLDE3WM03H2AVDQSYpEKdxPie0f1Qxu3CB1oOiMbQbDJ7
+MB1DHa4NeIZJbv8qHxhfIGhyhbNEmkXdAoIBAFH34QyM8QNe3tdntfqpq3pVUcyO
+7yJV04et5+o4ewqdDgssb8YEqRVrN20gBPIrYPGhtjTvpbLTA4hXdzO+uIFSlk29
+sos29sbgtmNLEfx2BmCQfsx7mwMW5AuPknfR+0L8NXrSKz3Zl2IAAfzfqM5USeyi
+8SZmf38sbg279RtYZv0FcXdt7+tYAFMa1IEfqjW9lclJmviFocF1emE7Y4f+y9sz
+WsRQTSSD2ECPf8dtSe2sYJ6mhWqdtro89h/s/P0uJ7Ew95RweB7g/nEBPd2l9VdS
+zyko3qtyo9j1Gj/C4QAbglr2ex20+SMscCUepBIV2tsDMCyaCwv7dG7CJ6E=
+-----END RSA PRIVATE KEY-----
+`
+
+	testRSAPublicKey = `-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEApH5oa4ZuyMKGHLYUeEs0
+gAoE+85yOCgP/R1Ma19hB5wd5nrlGya3O45g/3gjhQZMjrJpClOW9hrP5UxFrxQ5
+izIqV7/kLr3tCFN+7sNA98BRGKN5KXTVMB8T4YumSRGlUoT3lxXiDfIP49GoLhFB
+9NUenuc7/oTxivRUswhJNv6K7Xp3THh7rCH35miKmLRdyaIUTqh1u96JycW2EHLj
+GQBwd5BdLRx2AeOEx5V6fXUOUgmPsafI/E8x5BQNvJpvOI9T6/YvuZoG/1BAxB78
+kGEJ/vqQeknAnI0IdFza/MVBnTkY0AyKXXSuEQxm83zWnZMK7kact3/ffgO2Ov1f
+Q90fxyki4RIN0omZDwSdUYHiJ1+4hbGnFShSNuPZ3jwi5coUZ9//KS3FPm6sP14c
+MoNqVph3jY//0eqAze0zqPUCKqHt7taTl+jhMYE1spMQjbtUuTo14OgRRvwF3b6l
+mekTFfAgfApT1rBBZCeycY76EtrBkq+8h0c9iuZyYYp1Bd8omCAng2PquWVNIDng
+Ccfzd1nsVsjaL+wcnIHs7qo8XrB5Cuy2hvUv7XeJ3YrOsTPDkSkvABQ3MQx80Zx7
+y5UeUiwgw1s7ajxc3KXF9yVsesDiO7v+6GHIlM1Go0INHwzUwuL3PxNy1i7cU8pf
+5K5Wi7S9b7azLG/f6lGgo5UCAwEAAQ==
+-----END PUBLIC KEY-----
+`
+)
+
+func TestHMACTokens(t *testing.T) {
+	cfg := &Config{
+		Algorithm: AlgorithmHMAC,
+		HMAC: HMACConfig{
+			SignKey: strings.Repeat("00", hashSize),
+		},
+	}
+
+	tokens, err := New(cfg)
+	require.NoError(t, err)
+
+	testTokens(t, tokens)
+}
+
+func TestRSATokens(t *testing.T) {
+	cfg := &Config{
+		Algorithm: AlgorithmRSA,
+		RSA: RSAConfig{
+			PrivateKey: testRSAPrivateKey,
+			PublicKey:  testRSAPublicKey,
+		},
+	}
+
+	tokens, err := New(cfg)
+	require.NoError(t, err)
+
+	testTokens(t, tokens)
+}
+
+func testTokens(t *testing.T, tokens authtokens.Tokens) {
+	t.Helper()
+
+	tests := []struct {
+		name    string
+		user    sdktypes.User
+		wantErr bool
+	}{
+		{
+			name:    "valid user",
+			user:    sdktypes.NewUser().WithID(sdktypes.NewUserID()),
+			wantErr: false,
+		},
+		{
+			name:    "system user",
+			user:    authusers.SystemUser,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token, err := tokens.Create(tt.user)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.NotEmpty(t, token)
+
+			// Test parsing
+			parsedUser, err := tokens.Parse(token)
+			require.NoError(t, err)
+			assert.Equal(t, tt.user.ID(), parsedUser.ID())
+		})
+	}
+}
+
+func TestInvalidTokens(t *testing.T) {
+	hmacCfg := &Config{
+		Algorithm: AlgorithmHMAC,
+		HMAC: HMACConfig{
+			SignKey: strings.Repeat("00", hashSize),
+		},
+	}
+
+	rsaCfg := &Config{
+		Algorithm: AlgorithmRSA,
+		RSA: RSAConfig{
+			PrivateKey: testRSAPrivateKey,
+			PublicKey:  testRSAPublicKey,
+		},
+	}
+
+	tests := []struct {
+		name      string
+		cfg       *Config
+		tokenFunc func(tokens authtokens.Tokens) string
+	}{
+		{
+			name: "invalid hmac token",
+			cfg:  hmacCfg,
+			tokenFunc: func(tokens authtokens.Tokens) string {
+				return "invalid.token.format"
+			},
+		},
+		{
+			name: "invalid rsa token",
+			cfg:  rsaCfg,
+			tokenFunc: func(tokens authtokens.Tokens) string {
+				return "invalid.token.format"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokens, err := New(tt.cfg)
+			require.NoError(t, err)
+
+			invalidToken := tt.tokenFunc(tokens)
+			_, err = tokens.Parse(invalidToken)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *Config
+		wantErr bool
+	}{
+		{
+			name: "valid hmac config",
+			cfg: &Config{
+				Algorithm: AlgorithmHMAC,
+				HMAC: HMACConfig{
+					SignKey: strings.Repeat("00", hashSize),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid hmac key length",
+			cfg: &Config{
+				Algorithm: AlgorithmHMAC,
+				HMAC: HMACConfig{
+					SignKey: "tooshort",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid rsa config",
+			cfg: &Config{
+				Algorithm: AlgorithmRSA,
+				RSA: RSAConfig{
+					PrivateKey: testRSAPrivateKey,
+					PublicKey:  testRSAPublicKey,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing rsa private key",
+			cfg: &Config{
+				Algorithm: AlgorithmRSA,
+				RSA: RSAConfig{
+					PublicKey: testRSAPublicKey,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing rsa public key",
+			cfg: &Config{
+				Algorithm: AlgorithmRSA,
+				RSA: RSAConfig{
+					PrivateKey: testRSAPrivateKey,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid algorithm",
+			cfg: &Config{
+				Algorithm: "invalid",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New(tt.cfg)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCrossAlgorithmTokens(t *testing.T) {
+	hmacCfg := &Config{
+		Algorithm: AlgorithmHMAC,
+		HMAC: HMACConfig{
+			SignKey: strings.Repeat("00", hashSize),
+		},
+	}
+
+	rsaCfg := &Config{
+		Algorithm: AlgorithmRSA,
+		RSA: RSAConfig{
+			PrivateKey: testRSAPrivateKey,
+			PublicKey:  testRSAPublicKey,
+		},
+	}
+
+	hmacTokens, err := New(hmacCfg)
+	require.NoError(t, err)
+
+	rsaTokens, err := New(rsaCfg)
+	require.NoError(t, err)
+
+	user := sdktypes.NewUser().WithID(sdktypes.NewUserID())
+
+	// Create HMAC token
+	hmacToken, err := hmacTokens.Create(user)
+	require.NoError(t, err)
+
+	// Create RSA token
+	rsaToken, err := rsaTokens.Create(user)
+	require.NoError(t, err)
+
+	// Try to parse HMAC token with RSA parser
+	_, err = rsaTokens.Parse(hmacToken)
+	assert.Error(t, err)
+
+	// Try to parse RSA token with HMAC parser
+	_, err = hmacTokens.Parse(rsaToken)
+	assert.Error(t, err)
+}

--- a/internal/backend/auth/authtokens/authjwttokens/jwthmac.go
+++ b/internal/backend/auth/authtokens/authjwttokens/jwthmac.go
@@ -1,0 +1,93 @@
+package authjwttokens
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	j "github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authtokens"
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authusers"
+	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+const hmacIssuer = "ak-hmac"
+
+var (
+	hmacMethod = j.SigningMethodHS256
+	hashSize   = hmacMethod.Hash.Size()
+)
+
+type HMACConfig struct {
+	SignKey string `koanf:"sign_key"`
+}
+
+type hmacTokens struct {
+	signKey []byte
+}
+
+func newHMAC(cfg *HMACConfig) (authtokens.Tokens, error) {
+	key, err := hex.DecodeString(cfg.SignKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid signing key: %w", err)
+	}
+
+	if len(key) != hashSize {
+		return nil, fmt.Errorf("invalid key len: %d != desired %d", len(key), hashSize)
+	}
+
+	return &hmacTokens{signKey: key}, nil
+}
+
+func (js *hmacTokens) Create(u sdktypes.User) (string, error) {
+	if authusers.IsSystemUserID(u.ID()) {
+		return "", sdkerrors.NewInvalidArgumentError("system user")
+	}
+
+	uuid, err := uuid.NewV7()
+	if err != nil {
+		return "", fmt.Errorf("generate UUID: %w", err)
+	}
+
+	tok := token{User: u}
+	bs, err := json.Marshal(tok)
+	if err != nil {
+		return "", fmt.Errorf("marshal token: %w", err)
+	}
+
+	claim := j.RegisteredClaims{
+		IssuedAt: j.NewNumericDate(time.Now()),
+		Issuer:   hmacIssuer,
+		Subject:  string(bs),
+		ID:       uuid.String(),
+	}
+
+	return j.NewWithClaims(hmacMethod, claim).SignedString(js.signKey)
+}
+
+func (js *hmacTokens) Parse(raw string) (sdktypes.User, error) {
+	var claims j.RegisteredClaims
+
+	t, err := j.ParseWithClaims(raw, &claims, func(t *j.Token) (interface{}, error) {
+		return js.signKey, nil
+	})
+	if err != nil {
+		return sdktypes.InvalidUser, err
+	}
+
+	if !t.Valid {
+		return sdktypes.InvalidUser, errors.New("invalid token")
+	}
+
+	var tok token
+	if err := json.Unmarshal([]byte(claims.Subject), &tok); err != nil {
+		return sdktypes.InvalidUser, fmt.Errorf("unmarshal token: %w", err)
+	}
+
+	return tok.User, nil
+}

--- a/internal/backend/auth/authtokens/authjwttokens/jwtrsa.go
+++ b/internal/backend/auth/authtokens/authjwttokens/jwtrsa.go
@@ -14,7 +14,6 @@ import (
 
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authtokens"
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authusers"
-	"go.autokitteh.dev/autokitteh/internal/backend/configset"
 	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
@@ -31,15 +30,6 @@ type RSAConfig struct {
 type rsaTokens struct {
 	privateKey *rsa.PrivateKey
 	publicKey  *rsa.PublicKey
-}
-
-// Using same token structure as HMAC version
-
-var RSAConfigs = configset.Set[RSAConfig]{
-	Default: &RSAConfig{},
-	// For dev/test, you'll need to generate and provide RSA key pairs
-	Dev:  &RSAConfig{},
-	Test: &RSAConfig{},
 }
 
 var (

--- a/internal/backend/auth/authtokens/authjwttokens/jwtrsa.go
+++ b/internal/backend/auth/authtokens/authjwttokens/jwtrsa.go
@@ -42,6 +42,16 @@ var RSAConfigs = configset.Set[RSAConfig]{
 	Test: &RSAConfig{},
 }
 
+var (
+	ErrNoPublicKey    = errors.New("no public key available")
+	ErrInvalidKeyType = errors.New("invalid key type")
+)
+
+type RSATokens interface {
+	authtokens.Tokens
+	GetJWKS() (*JWKS, error)
+}
+
 func parsePrivateKey(pemStr string) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode([]byte(pemStr))
 	if block == nil {
@@ -98,7 +108,7 @@ func parsePublicKey(pemStr string) (*rsa.PublicKey, error) {
 	return rsaPub, nil
 }
 
-func newRSA(cfg *RSAConfig) (authtokens.Tokens, error) {
+func newRSA(cfg *RSAConfig) (RSATokens, error) {
 	if cfg.PrivateKey == "" || cfg.PublicKey == "" {
 		return nil, errors.New("both private and public keys must be provided")
 	}

--- a/internal/backend/auth/authtokens/authjwttokens/jwtrsa.go
+++ b/internal/backend/auth/authtokens/authjwttokens/jwtrsa.go
@@ -19,7 +19,7 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
-const rsaIssuer = "ak-rsa"
+const issuer = "autokitteh.cloud"
 
 var rsaMethod = j.SigningMethodRS256
 
@@ -147,7 +147,7 @@ func (rs *rsaTokens) Create(u sdktypes.User) (string, error) {
 
 	claim := j.RegisteredClaims{
 		IssuedAt: j.NewNumericDate(time.Now()),
-		Issuer:   rsaIssuer,
+		Issuer:   issuer,
 		Subject:  string(bs),
 		ID:       uuid.String(),
 	}

--- a/internal/backend/auth/authtokens/authjwttokens/jwtrsa.go
+++ b/internal/backend/auth/authtokens/authjwttokens/jwtrsa.go
@@ -1,0 +1,168 @@
+package authjwttokens
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"time"
+
+	j "github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authtokens"
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authusers"
+	"go.autokitteh.dev/autokitteh/internal/backend/configset"
+	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+const rsaIssuer = "ak-rsa"
+
+var rsaMethod = j.SigningMethodRS256
+
+type RSAConfig struct {
+	PrivateKey string `koanf:"private_key"` // PEM encoded RSA private key
+	PublicKey  string `koanf:"public_key"`  // PEM encoded RSA public key
+}
+
+type rsaTokens struct {
+	privateKey *rsa.PrivateKey
+	publicKey  *rsa.PublicKey
+}
+
+// Using same token structure as HMAC version
+
+var RSAConfigs = configset.Set[RSAConfig]{
+	Default: &RSAConfig{},
+	// For dev/test, you'll need to generate and provide RSA key pairs
+	Dev:  &RSAConfig{},
+	Test: &RSAConfig{},
+}
+
+func parsePrivateKey(pemStr string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, errors.New("failed to parse PEM block containing private key")
+	}
+
+	// Try PKCS1 first
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err == nil {
+		return key, nil
+	}
+
+	// If PKCS1 fails, try PKCS8
+	pkcs8Key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
+	}
+
+	rsaKey, ok := pkcs8Key.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("key is not an RSA private key")
+	}
+
+	return rsaKey, nil
+}
+
+func parsePublicKey(pemStr string) (*rsa.PublicKey, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, errors.New("failed to parse PEM block containing public key")
+	}
+
+	// Try PKIX first
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err == nil {
+		rsaPub, ok := pub.(*rsa.PublicKey)
+		if !ok {
+			return nil, errors.New("key is not an RSA public key")
+		}
+		return rsaPub, nil
+	}
+
+	// If PKIX fails, try x509 certificate
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse public key: %w", err)
+	}
+
+	rsaPub, ok := cert.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		return nil, errors.New("key is not an RSA public key")
+	}
+
+	return rsaPub, nil
+}
+
+func newRSA(cfg *RSAConfig) (authtokens.Tokens, error) {
+	if cfg.PrivateKey == "" || cfg.PublicKey == "" {
+		return nil, errors.New("both private and public keys must be provided")
+	}
+
+	privateKey, err := parsePrivateKey(cfg.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid private key: %w", err)
+	}
+
+	publicKey, err := parsePublicKey(cfg.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid public key: %w", err)
+	}
+
+	return &rsaTokens{
+		privateKey: privateKey,
+		publicKey:  publicKey,
+	}, nil
+}
+
+func (rs *rsaTokens) Create(u sdktypes.User) (string, error) {
+	if authusers.IsSystemUserID(u.ID()) {
+		return "", sdkerrors.NewInvalidArgumentError("system user")
+	}
+
+	uuid, err := uuid.NewV7()
+	if err != nil {
+		return "", fmt.Errorf("generate UUID: %w", err)
+	}
+
+	tok := token{User: u}
+	bs, err := json.Marshal(tok)
+	if err != nil {
+		return "", fmt.Errorf("marshal token: %w", err)
+	}
+
+	claim := j.RegisteredClaims{
+		IssuedAt: j.NewNumericDate(time.Now()),
+		Issuer:   rsaIssuer,
+		Subject:  string(bs),
+		ID:       uuid.String(),
+	}
+
+	return j.NewWithClaims(rsaMethod, claim).SignedString(rs.privateKey)
+}
+
+func (rs *rsaTokens) Parse(raw string) (sdktypes.User, error) {
+	var claims j.RegisteredClaims
+
+	t, err := j.ParseWithClaims(raw, &claims, func(t *j.Token) (interface{}, error) {
+		return rs.publicKey, nil
+	})
+	if err != nil {
+		return sdktypes.InvalidUser, err
+	}
+
+	if !t.Valid {
+		return sdktypes.InvalidUser, errors.New("invalid token")
+	}
+
+	var tok token
+	if err := json.Unmarshal([]byte(claims.Subject), &tok); err != nil {
+		return sdktypes.InvalidUser, fmt.Errorf("unmarshal token: %w", err)
+	}
+
+	return tok.User, nil
+}


### PR DESCRIPTION
solves [ENG-2065] and [ENG-2066]

Merging this requires a change to the infrastructure code as well
[https://github.com/autokitteh/infrastructure/pull/12]


The change has no affect to dev/test mode

In standard mode, need to select the jwt signing algorithm
```bash
 # Can be rsa or hmac
AK_AUTHJWTTOKENS__ALGORITHM = rsa 

# If hmac is selected, a sign key needs to be provided
AK_AUTHJWTTOKENS__HMAC__SIGN_KEY = ""

# If rsa is selected, a private and public keys are required
AK_AUTHJWTTOKENS__RSA__PRIVATE_KEY = ""
AK_AUTHJWTTOKENS__RSA__PUBLIC_KEY = ""
```


This change also exposes a jwks endpoint over ```http://<api_domain>/.well-known/jwks.json```
The endpoint returns standard jwks if algorithm is rsa, otherwise it returns an error

