### PR TITLE
fix(slack): don't panic if interactive event doesn't contain enterprise ID

### DIFF
--- a/integrations/slack/webhooks/webhook.go
+++ b/integrations/slack/webhooks/webhook.go
@@ -232,8 +232,16 @@ func (h handler) extractIDs(l *zap.Logger, body []byte, wantContentType string) 
 		)
 		return "", "", "", err
 	}
+	eID := ""
+	if p.Enterprise != nil {
+		eID = p.Enterprise.ID
+	}
 
-	return p.APIAppID, p.Enterprise.ID, p.Team.ID, nil
+	tID := ""
+	if p.Team != nil {
+		tID = p.Team.ID
+	}
+	return p.APIAppID, eID, tID, nil
 }
 
 // signingSecret reads the signing secret from the private connection's

--- a/integrations/slack/webhooks/webhook.go
+++ b/integrations/slack/webhooks/webhook.go
@@ -233,16 +233,12 @@ func (h handler) extractIDs(l *zap.Logger, body []byte, wantContentType string) 
 		return "", "", "", err
 	}
 
-	eID := ""
+	enterpriseID := ""
 	if p.Enterprise != nil {
-		eID = p.Enterprise.ID
+		enterpriseID = p.Enterprise.ID
 	}
 
-	tID := ""
-	if p.Team != nil {
-		tID = p.Team.ID
-	}
-	return p.APIAppID, eID, tID, nil
+	return p.APIAppID, enterpriseID, p.Team.ID, nil
 }
 
 // signingSecret reads the signing secret from the private connection's

--- a/integrations/slack/webhooks/webhook.go
+++ b/integrations/slack/webhooks/webhook.go
@@ -232,6 +232,7 @@ func (h handler) extractIDs(l *zap.Logger, body []byte, wantContentType string) 
 		)
 		return "", "", "", err
 	}
+
 	eID := ""
 	if p.Enterprise != nil {
 		eID = p.Enterprise.ID


### PR DESCRIPTION
unmarshalling payload has *Enterprise and *Team which can be nil
trying to reach Enterprise.ID or Team.ID throws a panic

I"m not sure this is the correct solution - @pashafateev  / @daabr. Feel free to discard the change.

**This does happen in production** 

```go
// Interaction payloads.
	var p BlockActionsPayload
	if err := json.Unmarshal([]byte(payload), &p); err != nil {
		l.Warn("failed to parse interaction payload for app/team IDs",
			zap.String("payload", payload),
			zap.Error(err),
		)
		return "", "", "", err
	}

	eID := ""
	if p.Enterprise != nil {
		eID = p.Enterprise.ID
	}

	tID := ""
	if p.Team != nil {
		tID = p.Team.ID
	}
	return p.APIAppID, eID, tID, nil
```