### PR TITLE
fix(sessions): parent close policy to abandon

### DIFF
--- a/internal/backend/sessions/sessionworkflows/workflows.go
+++ b/internal/backend/sessions/sessionworkflows/workflows.go
@@ -8,6 +8,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
@@ -140,6 +141,7 @@ func (ws *workflows) StartChildWorkflow(wctx workflow.Context, childSession sdkt
 				taskQueueName,
 				workflowID(childSessionID),
 				fmt.Sprintf("session %v", childSessionID),
+				enums.PARENT_CLOSE_POLICY_ABANDON,
 				memo,
 			),
 		),

--- a/internal/backend/temporalclient/workflow.go
+++ b/internal/backend/temporalclient/workflow.go
@@ -38,7 +38,7 @@ func (wc WorkflowConfig) ToStartWorkflowOptions(qname, id, sum string, memo map[
 	}
 }
 
-func (wc WorkflowConfig) ToChildWorkflowOptions(qname, id, sum string, parentClosePolicy enumspb.ParentClosePolicy, memo map[string]string) workflow.ChildWorkflowOptions {
+func (wc WorkflowConfig) ToChildWorkflowOptions(qname, id, sum string, pcp enumspb.ParentClosePolicy, memo map[string]string) workflow.ChildWorkflowOptions {
 	wc = wc.With(defaultWorkflowConfig)
 	return workflow.ChildWorkflowOptions{
 		WorkflowID:          id,

--- a/internal/backend/temporalclient/workflow.go
+++ b/internal/backend/temporalclient/workflow.go
@@ -3,6 +3,7 @@ package temporalclient
 import (
 	"time"
 
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/workflow"
 
@@ -37,12 +38,13 @@ func (wc WorkflowConfig) ToStartWorkflowOptions(qname, id, sum string, memo map[
 	}
 }
 
-func (wc WorkflowConfig) ToChildWorkflowOptions(qname, id, sum string, memo map[string]string) workflow.ChildWorkflowOptions {
+func (wc WorkflowConfig) ToChildWorkflowOptions(qname, id, sum string, parentClosePolicy enumspb.ParentClosePolicy, memo map[string]string) workflow.ChildWorkflowOptions {
 	wc = wc.With(defaultWorkflowConfig)
 	return workflow.ChildWorkflowOptions{
 		WorkflowID:          id,
 		TaskQueue:           qname,
 		StaticSummary:       sum,
+		ParentClosePolicy:   parentClosePolicy,
 		Memo:                kittehs.TransformMapValues(memo, func(v string) any { return v }),
 		WorkflowTaskTimeout: wc.WorkflowTaskTimeout,
 	}

--- a/internal/backend/temporalclient/workflow.go
+++ b/internal/backend/temporalclient/workflow.go
@@ -44,7 +44,7 @@ func (wc WorkflowConfig) ToChildWorkflowOptions(qname, id, sum string, pcp enums
 		WorkflowID:          id,
 		TaskQueue:           qname,
 		StaticSummary:       sum,
-		ParentClosePolicy:   parentClosePolicy,
+		ParentClosePolicy:   pcp,
 		Memo:                kittehs.TransformMapValues(memo, func(v string) any { return v }),
 		WorkflowTaskTimeout: wc.WorkflowTaskTimeout,
 	}


### PR DESCRIPTION
this will prevent child workflows from being terminated when the parent is terminated. in the future, we might consider configuring this.