### PR TITLE
fix(devserver): increase start timeout, verify namespace

### DIFF
--- a/internal/backend/temporalclient/config.go
+++ b/internal/backend/temporalclient/config.go
@@ -35,10 +35,19 @@ type Config struct {
 	Namespace             string `koanf:"namespace"`
 
 	// DevServer.ClientOptions is not used.
-	DevServer                   testsuite.DevServerOptions `koanf:"dev_server"`
-	DevServerStartMaxAttempts   int                        `koanf:"dev_server_start_max_attempts"`
-	DevServerStartRetryInterval time.Duration              `koanf:"dev_server_start_retry_interval"`
-	DevServerStartTimeout       time.Duration              `koanf:"dev_server_start_timeout"`
+	DevServer testsuite.DevServerOptions `koanf:"dev_server"`
+
+	// Max number of attempts to start the dev server.
+	DevServerStartMaxAttempts int `koanf:"dev_server_start_max_attempts"`
+
+	// Time to wait between dev server start attempts.
+	DevServerStartRetryInterval time.Duration `koanf:"dev_server_start_retry_interval"`
+
+	// Time to wait for dev server to start.
+	DevServerStartTimeout time.Duration `koanf:"dev_server_start_timeout"`
+
+	// Time to wait from dev server start until its namespace is up.
+	DevServerStartWaitTime time.Duration `koanf:"dev_server_start_wait_time"`
 
 	TLS tlsConfig `koanf:"tls"`
 
@@ -73,8 +82,10 @@ var (
 				DBFilename: filepath.Join(xdg.DataHomeDir(), "temporal_dev.sqlite"),
 			},
 			DevServerStartMaxAttempts: 1,
-			DevServerStartTimeout:     time.Second * 4,
+			DevServerStartTimeout:     time.Second * 10,
+			DevServerStartWaitTime:    time.Second,
 			EnableHelperRedirect:      true,
+			Namespace:                 "default",
 		},
 		Test: &Config{
 			Monitor:              defaultMonitorConfig,
@@ -85,7 +96,9 @@ var (
 			},
 			DevServerStartMaxAttempts:   3,
 			DevServerStartRetryInterval: time.Second,
-			DevServerStartTimeout:       time.Second * 4,
+			DevServerStartTimeout:       time.Second * 10,
+			DevServerStartWaitTime:      time.Second,
+			Namespace:                   "default",
 		},
 	}
 )


### PR DESCRIPTION
- increase start timeout to accomodate long download time
- sleep for a bit after dev start to allow the server time to create the namespace
- verify that the namespace is there on start
- instruct the user to look at temporal's logs on failed start