### PR TITLE
chore: reduce log spam

### DIFF
--- a/internal/backend/auth/authz/policy.go
+++ b/internal/backend/auth/authz/policy.go
@@ -38,7 +38,6 @@ func NewPolicyCheckFunc(l *zap.Logger, db db.DB, decide policy.DecideFunc) Check
 		}
 
 		l := l.With(zap.Any("input", input), zap.Any("result", result))
-		l.Debug("authz opa decision")
 
 		if !decision {
 			l.WithOptions(zap.AddStacktrace(zap.WarnLevel)).Warn("authz opa decision: denied")

--- a/internal/backend/httpsvc/config.go
+++ b/internal/backend/httpsvc/config.go
@@ -75,6 +75,7 @@ var Configs = configset.Set[Config]{
 				`^/oauth/|/oauth$|/save$`,     // Connection initialization
 			},
 			UnloggedRegexes: []string{
+				`/IsActiveRunner$`,                             // Runner health check
 				`/(healthz|readyz)$`,                           // Kubernetes health checks
 				`\.(css|html|ico|js|png|svg|txt|webmanifest)$`, // Static web content
 			},


### PR DESCRIPTION
Remove unnecessary and very noisy log messages that either don't communicate useful information, or simply denote the passage of time.