### PR TITLE
fix(salesforce): simplify gRPC flow

### DIFF
--- a/integrations/salesforce/grpc.go
+++ b/integrations/salesforce/grpc.go
@@ -5,22 +5,22 @@ import (
 	"crypto/tls"
 
 	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
 	"go.autokitteh.dev/autokitteh/integrations/oauth"
+	"go.autokitteh.dev/autokitteh/internal/backend/auth/authcontext"
+	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
 
 // https://developer.salesforce.com/docs/platform/pub-sub-api/guide/supported-auth.html
 // https://pkg.go.dev/google.golang.org/grpc/credentials#PerRPCCredentials
 type grpcAuth struct {
-	token       *oauth2.Token
-	oauth       *oauth.OAuth
-	logger      *zap.Logger
-	integration sdktypes.Integration
-	vars        sdktypes.Vars
+	logger *zap.Logger
+	vars   sdkservices.Vars
+	oauth  *oauth.OAuth
+	vsid   sdktypes.VarScopeID
 }
 
 // Based on:
@@ -56,16 +56,15 @@ const retryPolicy = `{
 	}]
 }`
 
-func initConn(l *zap.Logger, cfg *oauth2.Config, token *oauth2.Token, instanceURL, orgID string, oauth *oauth.OAuth, integration sdktypes.Integration, vars sdktypes.Vars) (*grpc.ClientConn, error) {
+func (h handler) initConn(l *zap.Logger, cid sdktypes.ConnectionID) (*grpc.ClientConn, error) {
 	conn, err := grpc.NewClient(
 		"api.pubsub.salesforce.com:443",
 		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})),
 		grpc.WithPerRPCCredentials(&grpcAuth{
-			token:       token,
-			oauth:       oauth,
-			logger:      l,
-			integration: integration,
-			vars:        vars,
+			logger: l,
+			vars:   h.vars,
+			oauth:  h.oauth,
+			vsid:   sdktypes.NewVarScopeID(cid),
 		}),
 		grpc.WithDefaultServiceConfig(retryPolicy),
 	)
@@ -78,12 +77,18 @@ func initConn(l *zap.Logger, cfg *oauth2.Config, token *oauth2.Token, instanceUR
 }
 
 func (a *grpcAuth) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
-	a.token = a.oauth.FreshToken(ctx, a.logger, a.integration, a.vars)
+	vs, err := a.vars.Get(authcontext.SetAuthnSystemUser(ctx), a.vsid)
+	if err != nil {
+		a.logger.Error("failed to read connection vars", zap.Error(err))
+		return nil, err
+	}
+
+	t := a.oauth.FreshToken(ctx, a.logger, desc, vs)
 
 	return map[string]string{
-		"accesstoken": a.token.AccessToken,
-		"instanceurl": a.vars.GetValue(instanceURLVar),
-		"tenantid":    a.vars.GetValue(orgIDVar),
+		"accesstoken": t.AccessToken,
+		"instanceurl": vs.GetValue(instanceURLVar),
+		"tenantid":    vs.GetValue(orgIDVar),
 	}, nil
 }
 

--- a/integrations/salesforce/integration.go
+++ b/integrations/salesforce/integration.go
@@ -12,7 +12,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
-	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 	"go.autokitteh.dev/autokitteh/web/static"
 )
 
@@ -62,23 +61,14 @@ func (h handler) reopenExistingPubSubConnections(ctx context.Context) {
 	}
 
 	for _, cid := range cids {
-		vs, err := h.vars.Get(ctx, sdktypes.NewVarScopeID(cid), orgIDVar, instanceURLVar)
-		if err != nil {
-			h.logger.Error("can't restart Salesforce PubSub connection",
-				zap.String("connection_id", cid.String()), zap.Error(err),
-			)
-			continue
-		}
+		l := h.logger.With(zap.String("connection_id", cid.String()))
 
 		cfg, _, err := h.oauth.GetConfig(ctx, desc.UniqueName().String(), cid)
 		if err != nil {
-			h.logger.Error("failed to get Salesforce OAuth config", zap.Error(err))
+			l.Error("failed to get Salesforce OAuth config", zap.Error(err))
 			continue
 		}
 
-		orgID := vs.GetValue(orgIDVar)
-		instanceURL := vs.GetValue(instanceURLVar)
-
-		h.subscribe(cfg.ClientID, orgID, instanceURL, cid)
+		h.subscribe(l, cfg.ClientID, cid)
 	}
 }

--- a/integrations/salesforce/oauth.go
+++ b/integrations/salesforce/oauth.go
@@ -87,7 +87,7 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.subscribe(clientID, orgID, instanceURL, cid)
+	h.subscribe(l, clientID, cid)
 
 	// Redirect the user back to the UI.
 	urlPath, err := c.FinalURL()

--- a/integrations/salesforce/subscription.go
+++ b/integrations/salesforce/subscription.go
@@ -33,10 +33,12 @@ var (
 // https://developer.salesforce.com/docs/platform/pub-sub-api/references/methods/subscribe-rpc.html
 func (h handler) subscribe(l *zap.Logger, clientID string, cid sdktypes.ConnectionID) {
 	mu.Lock()
-	if _, ok := pubSubClients[clientID]; ok {
+	_, ok := pubSubClients[clientID]
+	mu.Unlock()
+
+	if ok {
 		return
 	}
-	mu.Unlock()
 
 	ctx, client := h.initPubSubClient(l, cid, clientID, "")
 	if ctx == nil || client == nil {

--- a/integrations/salesforce/subscription.go
+++ b/integrations/salesforce/subscription.go
@@ -150,12 +150,12 @@ func (h handler) eventLoop(ctx context.Context, l *zap.Logger, clientID string, 
 
 				// Ignore self-triggered events.
 				if s == userID {
-					l.Debug("ignoring Salesforce event", zap.String("commitUser", user))
+					l.Debug("ignoring Salesforce event", zap.String("commitUser", s))
 					continue
 				}
 
 				// Extract changed entity name for the event type.
-				entityName, ok := change["entityName"]
+				entityName, ok := m["entityName"]
 				if !ok {
 					l.Error("entityName is not present in ChangeEventHeader")
 					continue

--- a/integrations/salesforce/subscription.go
+++ b/integrations/salesforce/subscription.go
@@ -131,25 +131,25 @@ func (h handler) eventLoop(ctx context.Context, l *zap.Logger, clientID string, 
 					l.Error("ChangeEventHeader is not present in event data")
 					continue
 				}
-				change, ok := header.(map[string]any)
+				m, ok := header.(map[string]any)
 				if !ok {
 					l.Error("ChangeEventHeader is not a map in event data")
 					continue
 				}
 
-				commitUser, ok := change["commitUser"]
+				commitUser, ok := m["commitUser"]
 				if !ok {
 					l.Error("commitUser is not present in ChangeEventHeader")
 					continue
 				}
-				user, ok := commitUser.(string)
+				s, ok := commitUser.(string)
 				if !ok {
 					l.Error("commitUser is not a string in ChangeEventHeader")
 					continue
 				}
 
 				// Ignore self-triggered events.
-				if user == userID {
+				if s == userID {
 					l.Debug("ignoring Salesforce event", zap.String("commitUser", user))
 					continue
 				}
@@ -160,13 +160,13 @@ func (h handler) eventLoop(ctx context.Context, l *zap.Logger, clientID string, 
 					l.Error("entityName is not present in ChangeEventHeader")
 					continue
 				}
-				entity, ok := entityName.(string)
+				s, ok = entityName.(string)
 				if !ok {
 					l.Error("entityName is not a string in ChangeEventHeader")
 					continue
 				}
 
-				h.dispatchEvent(data, strings.ToLower(entity))
+				h.dispatchEvent(data, strings.ToLower(s))
 			}
 		}
 	}


### PR DESCRIPTION
- Bug fix for gRPC refresh: `grpcAuth` should read vars on its own, and doesn't need a static token and an OAuth config directly
- reuse loggers when possible
- `renewSubscription` was too generic - some details are constants, not parameters
- Fixed `eventLoop` to handle corner cases more robustly