### PR TITLE
fix(github): negate conditional that results in false negative during GitHub PAT auth

### DIFF
--- a/integrations/github/pat.go
+++ b/integrations/github/pat.go
@@ -19,7 +19,7 @@ func (h handler) handlePAT(w http.ResponseWriter, r *http.Request) {
 	c, l := sdkintegrations.NewConnectionInit(h.logger, w, r, desc)
 
 	// Check the "Content-Type" header.
-	if !common.PostWithoutFormContentType(r) {
+	if common.PostWithoutFormContentType(r) {
 		ct := r.Header.Get(common.HeaderContentType)
 		l.Warn("save connection: unexpected POST content type", zap.String("content_type", ct))
 		c.AbortBadRequest("unexpected content type")


### PR DESCRIPTION
`PostWithoutFormContentType` returns `true` if there is an issue with the form content type, so the error case is when `PostWithoutFormContentType` is `true`

tested: successfully authenticated, sent `curl` requests for both happy and sad path

```
# success
curl -i -X POST https://autokitteh-pasha.ngrok.dev/github/save -H "Content-Type: application/x-www-form-urlencoded" -d '{}'

# failure
curl -i -X POST https://autokitteh-pasha.ngrok.dev/github/save -H "Content-Type: application/json" -d '{}'
```