### PR TITLE
fix(pythonrt): reduce prints drain time to 10ms

### DIFF
--- a/runtimes/pythonrt/pythonrt.go
+++ b/runtimes/pythonrt/pythonrt.go
@@ -447,7 +447,7 @@ func (py *pySvc) eventData(kwargs map[string]sdktypes.Value) ([]byte, error) {
 
 // drainPrints drains the print channel at the end of a run.
 func (py *pySvc) drainPrints(ctx context.Context) {
-	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
 	defer cancel()
 	// flush the rest of the prints and logs.
 	for {


### PR DESCRIPTION
Per analysis from https://github.com/autokitteh/autokitteh/pull/1244, we got the `drainPrints` function hanging for a full second after each activity. There is no need to wait this long, if at all. Reduce grace time for print to 10ms, which will greatly speed up scripts run time.