### PR TITLE
feat(python): Support async handlers

### DIFF
--- a/runtimes/pythonrt/runner/loader.py
+++ b/runtimes/pythonrt/runner/loader.py
@@ -144,7 +144,7 @@ def exports(code_dir, file_name):
 
     tree = ast.parse(code, file_name, "exec")
     for node in tree.body:
-        if not isinstance(node, (ast.FunctionDef, ast.ClassDef)):
+        if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef, ast.ClassDef)):
             continue
 
         args = fn_args(node) if isinstance(node, ast.FunctionDef) else class_args(node)

--- a/runtimes/pythonrt/runner/main.py
+++ b/runtimes/pythonrt/runner/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import builtins
 import inspect
 import json
@@ -441,6 +442,8 @@ class Runner(pb.runner_rpc.RunnerService):
         value = error = tb = None
         try:
             value = fn(*args, **kw)
+            if inspect.iscoroutinefunction(fn):
+                value = asyncio.run(value)
         except BaseException as err:
             log.error("%s raised: %s", func_name, err)
             tb = TracebackException.from_exception(err)

--- a/runtimes/pythonrt/runner/main.py
+++ b/runtimes/pythonrt/runner/main.py
@@ -442,7 +442,7 @@ class Runner(pb.runner_rpc.RunnerService):
         value = error = tb = None
         try:
             value = fn(*args, **kw)
-            if inspect.iscoroutinefunction(fn):
+            if asyncio.iscoroutine(value):
                 value = asyncio.run(value)
         except BaseException as err:
             log.error("%s raised: %s", func_name, err)

--- a/tests/sessions/python/async_handler.txtar
+++ b/tests/sessions/python/async_handler.txtar
@@ -1,0 +1,16 @@
+START
+ACT
+END
+-- main.py:main --
+import autokitteh
+
+
+async def main(event):
+    print('START')
+    await act()
+    print('END')
+
+
+@autokitteh.activity
+async def act():
+    print('ACT')


### PR DESCRIPTION
This simplifies the usage of asyncio code, users can now write:

```python
import autokitteh


async def main(event):
    print('START')
    await act()
    print('END')


@autokitteh.activity
async def act():
    print('ACT')
```

We'll automatically run `main` in asyncio loop.

Ref: ENG-1976