### PR TITLE
fix: refresh oauth token for custom oauth connnection

### DIFF
--- a/internal/backend/sessions/sessionworkflows/workflow.go
+++ b/internal/backend/sessions/sessionworkflows/workflow.go
@@ -172,6 +172,8 @@ func (w *sessionWorkflow) initEnvModule(cinfos map[string]connInfo) error {
 		maps.Copy(vs, kittehs.TransformMap(cinfos[name].Config, func(k, v string) (string, sdktypes.Value) {
 			return fmt.Sprintf("%s__%s", name, k), sdktypes.NewStringValue(v)
 		}))
+		vs[name+"__connection_id"] = sdktypes.NewStringValue(conn.ID().String())
+
 	}
 
 	mod := sdkexecutor.NewExecutor(

--- a/internal/backend/svc/runtimes.go
+++ b/internal/backend/svc/runtimes.go
@@ -47,8 +47,8 @@ func runtimesFXOption() fx.Option {
 			func(cfg *pythonrt.Config, l *zap.Logger, httpsvc httpsvc.Svc) (*sdkruntimes.Runtime, error) {
 				return pythonrt.New(cfg, l, httpsvc.Addr)
 			},
-			fx.Invoke(func(l *zap.Logger, muxes *muxes.Muxes) {
-				pythonrt.ConfigureWorkerGRPCHandler(l, muxes.NoAuth)
+			fx.Invoke(func(l *zap.Logger, muxes *muxes.Muxes, vars sdkservices.Vars) {
+				pythonrt.ConfigureWorkerGRPCHandler(l, muxes.NoAuth, vars)
 			}),
 		),
 

--- a/internal/backend/svc/runtimes.go
+++ b/internal/backend/svc/runtimes.go
@@ -4,6 +4,7 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 
+	"go.autokitteh.dev/autokitteh/integrations/oauth"
 	"go.autokitteh.dev/autokitteh/internal/backend/configset"
 	"go.autokitteh.dev/autokitteh/internal/backend/httpsvc"
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
@@ -47,8 +48,8 @@ func runtimesFXOption() fx.Option {
 			func(cfg *pythonrt.Config, l *zap.Logger, httpsvc httpsvc.Svc) (*sdkruntimes.Runtime, error) {
 				return pythonrt.New(cfg, l, httpsvc.Addr)
 			},
-			fx.Invoke(func(l *zap.Logger, muxes *muxes.Muxes, vars sdkservices.Vars) {
-				pythonrt.ConfigureWorkerGRPCHandler(l, muxes.NoAuth, vars)
+			fx.Invoke(func(l *zap.Logger, muxes *muxes.Muxes, oauth *oauth.OAuth) {
+				pythonrt.ConfigureWorkerGRPCHandler(l, muxes.NoAuth, oauth)
 			}),
 		),
 

--- a/runtimes/pythonrt/pythonrt_test.go
+++ b/runtimes/pythonrt/pythonrt_test.go
@@ -157,7 +157,7 @@ func newCallbacks(svc *pySvc) *sdkservices.RunCallbacks {
 
 func setupServer(l *zap.Logger) (net.Listener, error) {
 	mux := &http.ServeMux{}
-	ConfigureWorkerGRPCHandler(l, mux)
+	ConfigureWorkerGRPCHandler(l, mux, nil)
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
 		return nil, err

--- a/runtimes/pythonrt/worker_grpc_handler.go
+++ b/runtimes/pythonrt/worker_grpc_handler.go
@@ -433,12 +433,10 @@ func (s *workerGRPCHandler) RefreshOAuthToken(ctx context.Context, req *userCode
 	}
 
 	// Get the integration's OAuth configuration.
-	var cid sdktypes.ConnectionID = sdktypes.InvalidConnectionID
-	cid_str, ok := runner.envVars[req.Connection+"__connection_id"]
-	if ok && cid_str != "" {
+	var cid sdktypes.ConnectionID
+	if cid_str := runner.envVars[req.Connection+"__connection_id"]; cid_str != "" {
 		var err error
-		cid, err = sdktypes.ParseConnectionID(cid_str)
-		if err != nil {
+		if cid, err = sdktypes.ParseConnectionID(cid_str); err != nil {
 			runner.log.Warn("invalid connection ID",
 				zap.String("connection", req.Connection),
 				zap.String("connection_id", cid_str),


### PR DESCRIPTION
Injected the OAuth service and mapped the connection ID to retrieve the corresponding variables.

This PR solves the issue of accessing the client ID and secret for private OAuth connections, which previously wasn't possible because these credentials were not available in environment variables.
Until now, only default OAuth connections worked correctly. With this update, private OAuth connections can also retrieve credentials using the connection variables.

Tested by directly calling the function from Python and debugging the flow — confirmed that the credentials are correctly retrieved for a private OAuth connection.