### PR TITLE
fix: unwrap dicts with struct keys

### DIFF
--- a/sdk/sdktypes/value.go
+++ b/sdk/sdktypes/value.go
@@ -195,6 +195,15 @@ var valueStringUnwrapper = ValueWrapper{
 			return NewStringValuef("|function: %v|", v.GetFunction().Name()), nil
 		}
 
+		if v.IsStruct() {
+			ctor := v.GetStruct().Ctor()
+			str, err := ctor.ToString()
+			if err != nil {
+				str = ctor.String()
+			}
+			return NewStringValuef("|struct: %v|", str), nil
+		}
+
 		return v, nil
 	},
 }


### PR DESCRIPTION
LangGraph appears to returns dictionaries with class keys, this will prevent it from failing to render on the UI.

See also ENG-2095.