### PR TITLE
fix(python): Append site-packages to sys.path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,12 +61,13 @@ RUN adduser \
     appuser
 USER appuser
 
-COPY --chown=appuser:appuser --from=pydeps /usr/local/lib/python3.11/site-packages /usr/lib/python3.11/site-packages
+# Copy packages to user site-packages which is enabled in this image.
+RUN mkdir -p /home/appuser/.local/lib/python3.11/
+COPY --chown=appuser:appuser --from=pydeps /usr/local/lib/python3.11/site-packages /home/appuser/.local/lib/python3.11/site-packages
 
 # Copy the executable from the "build" stage.
 COPY --chown=appuser:appuser --from=build /bin/ak /bin/
 
-ENV PYTHONPATH=/usr/lib/python3.11/site-packages
 ENV AK_WORKER_PYTHON=/usr/local/bin/python
 # Expose the port that the application listens on.
 EXPOSE 9980

--- a/runtimes/pythonrt/dockerfilenodeps
+++ b/runtimes/pythonrt/dockerfilenodeps
@@ -18,4 +18,4 @@ COPY  --from=build /usr/local/lib/python3.11/site-packages /usr/lib/python3.11/s
 COPY  --chown=65532:65532  runner /runner
 COPY  --chown=65532:65532 workflow /workflow
 
-ENV PYTHONPATH=/usr/lib/python3.11/site-packages
+COPY sitecustomize.py /usr/lib/python3.11/sitecustomize.py

--- a/runtimes/pythonrt/dockerfilewithdeps
+++ b/runtimes/pythonrt/dockerfilewithdeps
@@ -22,4 +22,4 @@ COPY  --from=build /usr/local/lib/python3.11/site-packages /usr/lib/python3.11/s
 COPY  --chown=65532:65532  runner /runner
 COPY  --chown=65532:65532 workflow /workflow
 
-ENV PYTHONPATH=/usr/lib/python3.11/site-packages
+COPY sitecustomize.py /usr/lib/python3.11/sitecustomize.py

--- a/runtimes/pythonrt/dockerize_user_code.go
+++ b/runtimes/pythonrt/dockerize_user_code.go
@@ -16,6 +16,9 @@ var dockerfileNoDeps string
 //go:embed dockerfilewithdeps
 var dockerfileWithDeps string
 
+//go:embed sitecustomize.py
+var siteCustomize []byte
+
 func prepareUserCode(code []byte, gzipped bool) (string, error) {
 	tf, err := tar.FromBytes(code, gzipped)
 	if err != nil {
@@ -73,6 +76,10 @@ func prepareUserCode(code []byte, gzipped bool) (string, error) {
 			}
 		}
 
+	}
+
+	if err := os.WriteFile(path.Join(tmpDir, "sitecustomize.py"), siteCustomize, 0o777); err != nil {
+		return "", err
 	}
 
 	dockerfile := []byte(dockerfileNoDeps)

--- a/runtimes/pythonrt/sitecustomize.py
+++ b/runtimes/pythonrt/sitecustomize.py
@@ -1,0 +1,15 @@
+# This is the original sitecustomize.py from distroless + AK additions
+# It is used during docker builds
+import sys
+
+# install the apport exception handler if available
+try:
+    import apport_python_hook
+except ImportError:
+    pass
+else:
+    apport_python_hook.install()
+
+# We don't want to use PYTHONPATH since it sets site-packages before the standard
+# library.
+sys.path.append("/usr/lib/python3.11/site-packages")


### PR DESCRIPTION
Previously we appended site-packages to sys.path and it caused issues with 3rd party packages overriding standard library ones.

Fixes: ENG-2096