### PR TITLE
fix: separate temporal dev server download and start

### DIFF
--- a/cmd/ak/cmd/root.go
+++ b/cmd/ak/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"go.autokitteh.dev/autokitteh/cmd/ak/cmd/runtimes"
 	"go.autokitteh.dev/autokitteh/cmd/ak/cmd/server"
 	"go.autokitteh.dev/autokitteh/cmd/ak/cmd/sessions"
+	"go.autokitteh.dev/autokitteh/cmd/ak/cmd/temporal"
 	"go.autokitteh.dev/autokitteh/cmd/ak/cmd/triggers"
 	"go.autokitteh.dev/autokitteh/cmd/ak/cmd/users"
 	"go.autokitteh.dev/autokitteh/cmd/ak/cmd/vars"
@@ -103,7 +104,6 @@ func init() {
 	RootCmd.AddCommand(versionCmd)
 
 	// Top-level parent commands.
-	mcp.AddSubcommands(RootCmd)
 	auth.AddSubcommands(RootCmd)
 	builds.AddSubcommands(RootCmd)
 	configuration.AddSubcommands(RootCmd)
@@ -113,11 +113,13 @@ func init() {
 	experimental.AddSubcommands(RootCmd)
 	integrations.AddSubcommands(RootCmd)
 	manifest.AddSubcommands(RootCmd)
+	mcp.AddSubcommands(RootCmd)
 	orgs.AddSubcommands(RootCmd)
 	projects.AddSubcommands(RootCmd)
 	runtimes.AddSubcommands(RootCmd)
 	server.AddSubcommands(RootCmd)
 	sessions.AddSubcommands(RootCmd)
+	temporal.AddSubcommands(RootCmd)
 	triggers.AddSubcommands(RootCmd)
 	users.AddSubcommands(RootCmd)
 	vars.AddSubcommands(RootCmd)

--- a/cmd/ak/cmd/temporal/download.go
+++ b/cmd/ak/cmd/temporal/download.go
@@ -1,0 +1,39 @@
+package temporal
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"go.autokitteh.dev/autokitteh/cmd/ak/common"
+	"go.autokitteh.dev/autokitteh/internal/backend/temporaldevsrv"
+	"go.autokitteh.dev/autokitteh/internal/xdg"
+)
+
+var cached temporaldevsrv.CachedDownload
+
+var downloadCmd = common.StandardCommand(&cobra.Command{
+	Use:   `download`,
+	Short: "Download Temporal's dev server",
+	Args:  cobra.NoArgs,
+
+	RunE: func(*cobra.Command, []string) error {
+		l, err := zap.NewDevelopment()
+		if err != nil {
+			return fmt.Errorf("logger: %w", err)
+		}
+
+		path, err := temporaldevsrv.Download(context.Background(), cached, l)
+
+		common.RenderKVIfV("path", path)
+
+		return err
+	},
+})
+
+func init() {
+	downloadCmd.Flags().StringVarP(&cached.Version, "version", "v", "", "desired version of the dev server")
+	downloadCmd.Flags().StringVarP(&cached.DestDir, "dest-dir", "d", xdg.CacheHomeDir(), "destination directory for the dev server")
+}

--- a/cmd/ak/cmd/temporal/temporal.go
+++ b/cmd/ak/cmd/temporal/temporal.go
@@ -1,0 +1,23 @@
+package temporal
+
+import (
+	"github.com/spf13/cobra"
+
+	"go.autokitteh.dev/autokitteh/cmd/ak/common"
+)
+
+var serverCmd = common.StandardCommand(&cobra.Command{
+	Use:   "temporal",
+	Short: "Temporal utilities",
+	Args:  cobra.NoArgs,
+})
+
+// AddSubcommands adds this command, and its own subcommands, to the calling parent.
+func AddSubcommands(parentCmd *cobra.Command) {
+	parentCmd.AddCommand(serverCmd)
+}
+
+func init() {
+	// Subcommands.
+	serverCmd.AddCommand(downloadCmd)
+}

--- a/internal/backend/temporalclient/client.go
+++ b/internal/backend/temporalclient/client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path"
 	"strconv"
 	"time"
 
@@ -18,7 +17,6 @@ import (
 	"go.temporal.io/sdk/contrib/opentelemetry"
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/interceptor"
-	"go.temporal.io/sdk/testsuite"
 	"go.uber.org/zap"
 	zapadapter "logur.dev/adapter/zap"
 	"logur.dev/logur"
@@ -26,7 +24,7 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/backend/fixtures"
 	"go.autokitteh.dev/autokitteh/internal/backend/health/healthreporter"
 	"go.autokitteh.dev/autokitteh/internal/backend/telemetry"
-	"go.autokitteh.dev/autokitteh/internal/xdg"
+	"go.autokitteh.dev/autokitteh/internal/backend/temporaldevsrv"
 )
 
 type (
@@ -45,7 +43,7 @@ type impl struct {
 	client  client.Client
 	l       *zap.Logger
 	cfg     *Config
-	srv     *testsuite.DevServer
+	srv     *temporaldevsrv.DevServer
 	logFile *os.File
 	done    chan struct{}
 	opts    client.Options
@@ -124,65 +122,6 @@ func New(cfg *Config, l *zap.Logger) (Client, error) {
 }
 
 func (c *impl) DataConverter() converter.DataConverter { return c.opts.DataConverter }
-
-func (c *impl) startDevServer(ctx context.Context) error {
-	var err error
-	logPath := path.Join(xdg.DataHomeDir(), "temporal_dev.log")
-	c.logFile, err = os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return fmt.Errorf("open Temporal dev server log file: %w", err)
-	}
-
-	c.cfg.DevServer.ClientOptions = &c.opts
-	c.cfg.DevServer.Stderr = c.logFile
-	c.cfg.DevServer.Stdout = c.logFile
-
-	for i := 0; i < c.cfg.DevServerStartMaxAttempts && c.srv == nil; i++ {
-		l := c.l.With(zap.Int("attempt", i))
-
-		l.Info("starting temporal dev server")
-
-		if i > 0 {
-			select {
-			case <-time.After(c.cfg.DevServerStartRetryInterval):
-				// nop
-			case <-ctx.Done():
-				return fmt.Errorf("context done: %w", ctx.Err())
-			}
-		}
-
-		startCtx := ctx
-
-		if c.cfg.DevServerStartTimeout != 0 {
-			var done func()
-			startCtx, done = context.WithTimeout(ctx, c.cfg.DevServerStartTimeout)
-			defer done()
-		}
-
-		c.srv, err = testsuite.StartDevServer(startCtx, c.cfg.DevServer)
-		if err != nil {
-			l.Error("Failed to starting temporal dev server. Check temporal log for further info.", zap.Error(err), zap.String("log_path", logPath))
-			continue
-		}
-
-		// Give additional time to the server to start up, create namespace, etc.
-		time.Sleep(c.cfg.DevServerStartWaitTime)
-	}
-
-	if err != nil {
-		return fmt.Errorf("start Temporal dev server: %w", err)
-	}
-
-	c.l.Info("started temporal dev server", zap.String("address", c.srv.FrontendHostPort()))
-
-	if c.client != nil {
-		c.client.Close()
-	}
-
-	c.client = c.srv.Client()
-
-	return nil
-}
 
 func (c *impl) TemporalClient() client.Client { return c.client }
 

--- a/internal/backend/temporalclient/client_test.go
+++ b/internal/backend/temporalclient/client_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/client"
-	"go.temporal.io/sdk/testsuite"
 	"go.uber.org/zap/zaptest"
 
+	"go.autokitteh.dev/autokitteh/internal/backend/temporaldevsrv"
 	"go.autokitteh.dev/autokitteh/internal/xdg"
 )
 
@@ -18,7 +18,7 @@ func TestStartDevServer(t *testing.T) {
 
 	c := &impl{
 		cfg: &Config{
-			DevServer:                   testsuite.DevServerOptions{},
+			DevServer:                   temporaldevsrv.DevServerOptions{},
 			DevServerStartMaxAttempts:   3,
 			DevServerStartRetryInterval: time.Second,
 			DevServerStartTimeout:       time.Second * 5,

--- a/internal/backend/temporalclient/config.go
+++ b/internal/backend/temporalclient/config.go
@@ -4,11 +4,11 @@ import (
 	"path/filepath"
 	"time"
 
-	"go.temporal.io/sdk/testsuite"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/configset"
+	"go.autokitteh.dev/autokitteh/internal/backend/temporaldevsrv"
 	"go.autokitteh.dev/autokitteh/internal/xdg"
 )
 
@@ -35,7 +35,7 @@ type Config struct {
 	Namespace             string `koanf:"namespace"`
 
 	// DevServer.ClientOptions is not used.
-	DevServer testsuite.DevServerOptions `koanf:"dev_server"`
+	DevServer temporaldevsrv.DevServerOptions `koanf:"dev_server"`
 
 	// Max number of attempts to start the dev server.
 	DevServerStartMaxAttempts int `koanf:"dev_server_start_max_attempts"`
@@ -76,7 +76,10 @@ var (
 		Dev: &Config{
 			Monitor:               defaultMonitorConfig,
 			StartDevServerIfNotUp: true,
-			DevServer: testsuite.DevServerOptions{
+			DevServer: temporaldevsrv.DevServerOptions{
+				CachedDownload: temporaldevsrv.CachedDownload{
+					DestDir: xdg.CacheHomeDir(),
+				},
 				LogLevel:   zapcore.WarnLevel.String(),
 				EnableUI:   true,
 				DBFilename: filepath.Join(xdg.DataHomeDir(), "temporal_dev.sqlite"),
@@ -90,7 +93,10 @@ var (
 		Test: &Config{
 			Monitor:              defaultMonitorConfig,
 			AlwaysStartDevServer: true,
-			DevServer: testsuite.DevServerOptions{
+			DevServer: temporaldevsrv.DevServerOptions{
+				CachedDownload: temporaldevsrv.CachedDownload{
+					DestDir: xdg.CacheHomeDir(),
+				},
 				LogLevel: zapcore.WarnLevel.String(),
 				EnableUI: true,
 			},

--- a/internal/backend/temporalclient/devsrv.go
+++ b/internal/backend/temporalclient/devsrv.go
@@ -1,0 +1,79 @@
+package temporalclient
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"time"
+
+	"go.uber.org/zap"
+
+	"go.autokitteh.dev/autokitteh/internal/backend/temporaldevsrv"
+	"go.autokitteh.dev/autokitteh/internal/xdg"
+)
+
+func (c *impl) startDevServer(ctx context.Context) error {
+	exePath, err := temporaldevsrv.Download(ctx, c.cfg.DevServer.CachedDownload, c.l)
+	if err != nil {
+		return fmt.Errorf("download temporal dev server: %w", err)
+	}
+
+	logPath := path.Join(xdg.DataHomeDir(), "temporal_dev.log")
+	c.logFile, err = os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open Temporal dev server log file: %w", err)
+	}
+
+	devSrvCfg := c.cfg.DevServer
+	devSrvCfg.ExistingPath = exePath
+	devSrvCfg.ClientOptions = &c.opts
+	devSrvCfg.Stderr = c.logFile
+	devSrvCfg.Stdout = c.logFile
+
+	for i := 0; i < c.cfg.DevServerStartMaxAttempts && c.srv == nil; i++ {
+		l := c.l.With(zap.Int("attempt", i))
+
+		l.Info("starting temporal dev server")
+
+		if i > 0 {
+			select {
+			case <-time.After(c.cfg.DevServerStartRetryInterval):
+				// nop
+			case <-ctx.Done():
+				return fmt.Errorf("context done: %w", ctx.Err())
+			}
+		}
+
+		startCtx := ctx
+
+		if c.cfg.DevServerStartTimeout != 0 {
+			var done func()
+			startCtx, done = context.WithTimeout(ctx, c.cfg.DevServerStartTimeout)
+			defer done()
+		}
+
+		c.srv, err = temporaldevsrv.StartDevServer(startCtx, devSrvCfg)
+		if err != nil {
+			l.Error("Failed to starting temporal dev server. Check temporal log for further info.", zap.Error(err), zap.String("log_path", logPath))
+			continue
+		}
+
+		// Give additional time to the server to start up, create namespace, etc.
+		time.Sleep(c.cfg.DevServerStartWaitTime)
+	}
+
+	if err != nil {
+		return fmt.Errorf("start Temporal dev server: %w", err)
+	}
+
+	c.l.Info("started temporal dev server", zap.String("address", c.srv.FrontendHostPort()))
+
+	if c.client != nil {
+		c.client.Close()
+	}
+
+	c.client = c.srv.Client()
+
+	return nil
+}

--- a/internal/backend/temporalclient/devsrv.go
+++ b/internal/backend/temporalclient/devsrv.go
@@ -46,14 +46,15 @@ func (c *impl) startDevServer(ctx context.Context) error {
 		}
 
 		startCtx := ctx
+		done := func() {}
 
 		if c.cfg.DevServerStartTimeout != 0 {
-			var done func()
 			startCtx, done = context.WithTimeout(ctx, c.cfg.DevServerStartTimeout)
-			defer done()
 		}
 
 		c.srv, err = temporaldevsrv.StartDevServer(startCtx, devSrvCfg)
+		done()
+
 		if err != nil {
 			l.Error("Failed to starting temporal dev server. Check temporal log for further info.", zap.Error(err), zap.String("log_path", logPath))
 			continue

--- a/internal/backend/temporalclient/devsrv.go
+++ b/internal/backend/temporalclient/devsrv.go
@@ -31,7 +31,11 @@ func (c *impl) startDevServer(ctx context.Context) error {
 	devSrvCfg.Stderr = c.logFile
 	devSrvCfg.Stdout = c.logFile
 
-	for i := 0; i < c.cfg.DevServerStartMaxAttempts && c.srv == nil; i++ {
+	for i := range c.cfg.DevServerStartMaxAttempts {
+		if c.srv != nil {
+			break
+		}
+
 		l := c.l.With(zap.Int("attempt", i))
 
 		l.Info("starting temporal dev server")

--- a/internal/backend/temporaldevsrv/devserver.go
+++ b/internal/backend/temporaldevsrv/devserver.go
@@ -1,0 +1,91 @@
+package temporaldevsrv
+
+import (
+	"io"
+	"os/exec"
+
+	"go.temporal.io/sdk/client"
+	"go.uber.org/zap"
+	zapadapter "logur.dev/adapter/zap"
+	"logur.dev/logur"
+)
+
+// Cached download of the dev server.
+type CachedDownload struct {
+	// Which version to download, by default the latest version compatible with the SDK will be downloaded.
+	// Acceptable values are specific release versions (e.g v0.3.0), "default", and "latest".
+	Version string
+	// Destination directory or the user temp directory if unset.
+	DestDir string
+}
+
+// Configuration for the dev server.
+type DevServerOptions struct {
+	// Existing path on the filesystem for the executable.
+	ExistingPath string
+	// Download the executable if not already there.
+	CachedDownload CachedDownload
+	// Client options used to create a client for the dev server.
+	// The provided Namespace or the "default" namespace is automatically registered on startup.
+	// If HostPort is provided, the host and port will be used to bind the server, otherwise the server will bind to
+	// localhost and obtain a free port.
+	ClientOptions *client.Options
+	// SQLite DB filename if persisting or non-persistent if none.
+	DBFilename string
+	// Whether to enable the UI.
+	EnableUI bool
+	// Override UI port if EnableUI is true.
+	// If not provided, a free port will be used.
+	UIPort string
+	// Log format - defaults to "pretty".
+	LogFormat string
+	// Log level - defaults to "warn".
+	LogLevel string
+	// Additional arguments to the dev server.
+	ExtraArgs []string
+	// Where to redirect stdout and stderr, if nil they will be redirected to the current process.
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// Temporal CLI based DevServer
+type DevServer struct {
+	cmd              *exec.Cmd
+	client           client.Client
+	frontendHostPort string
+}
+
+func (opts *DevServerOptions) clientOptionsOrDefault() (out client.Options) {
+	if opts.ClientOptions != nil {
+		// Shallow copy the client options since we intend to overwrite some fields.
+		out = *opts.ClientOptions
+	}
+
+	if out.Logger == nil {
+		out.Logger = logur.LoggerToKV(zapadapter.New(zap.NewNop()))
+	}
+
+	if out.Namespace == "" {
+		out.Namespace = "default"
+	}
+
+	return out
+}
+
+// Stop the running server and wait for shutdown to complete. Error is propagated from server shutdown.
+func (s *DevServer) Stop() error {
+	if err := sendInterrupt(s.cmd.Process); err != nil {
+		return err
+	}
+	return s.cmd.Wait()
+}
+
+// Get a connected client, configured to work with the dev server.
+func (s *DevServer) Client() client.Client {
+	return s.client
+}
+
+// FrontendHostPort returns the host:port for this server.
+func (s *DevServer) FrontendHostPort() string {
+	return s.frontendHostPort
+}

--- a/internal/backend/temporaldevsrv/doc.go
+++ b/internal/backend/temporaldevsrv/doc.go
@@ -1,6 +1,20 @@
-// Adapted from go.temporal.io/sdk@v1.33.0/testsuite.
+// Package temporaldevsrv provides utilities for managing a Temporal development server.
 //
-// Main changes:
-// - Separate download and start. Start requires prior download.
-// - Default dir for download is now xdg.CacheHomeDir().
+// This module is designed to simplify the process of downloading, configuring, starting,
+// and interacting with a Temporal CLI-based development server. It is particularly useful
+// for local development and testing scenarios where a lightweight Temporal server is needed.
+//
+// Key Features:
+//   - Download Management: Handles downloading the Temporal development server binary,
+//     with support for specifying versions and caching the binary in a default directory.
+//   - Server Configuration: Provides options to configure the server, including host/port,
+//     namespace, logging, and UI settings.
+//   - Server Lifecycle: Includes functions to start, stop, and monitor the server's status.
+//   - Integration: Designed to integrate seamlessly with other modules, such as the Temporal
+//     client, to provide a complete development environment.
+//
+// This module is adapted from go.temporal.io/sdk@v1.33.0/testsuite with modifications to
+// separate the download and start processes, and to use xdg.CacheHomeDir() as the default
+// directory for downloads.
+
 package temporaldevsrv

--- a/internal/backend/temporaldevsrv/doc.go
+++ b/internal/backend/temporaldevsrv/doc.go
@@ -1,0 +1,6 @@
+// Adapted from go.temporal.io/sdk@v1.33.0/testsuite.
+//
+// Main changes:
+// - Separate download and start. Start requires prior download.
+// - Default dir for download is now xdg.CacheHomeDir().
+package temporaldevsrv

--- a/internal/backend/temporaldevsrv/download.go
+++ b/internal/backend/temporaldevsrv/download.go
@@ -1,0 +1,202 @@
+package temporaldevsrv
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"go.temporal.io/sdk/temporal"
+	"go.uber.org/zap"
+
+	"go.autokitteh.dev/autokitteh/internal/xdg"
+)
+
+func GetDownloadInfo(ctx context.Context, desired CachedDownload) (exePath string, cached CachedDownload, exists bool) {
+	cached = desired
+
+	if cached.Version == "" {
+		cached.Version = "default"
+	}
+
+	if cached.DestDir == "" {
+		cached.DestDir = xdg.CacheHomeDir()
+	}
+
+	// Build path based on version and check if already present
+	if cached.Version == "default" {
+		exePath = filepath.Join(cached.DestDir, "temporal-cli-go-sdk-"+temporal.SDKVersion)
+	} else {
+		exePath = filepath.Join(cached.DestDir, "temporal-cli-"+cached.Version)
+	}
+
+	if runtime.GOOS == "windows" {
+		exePath += ".exe"
+	}
+
+	_, err := os.Stat(exePath)
+	exists = err == nil
+
+	return
+}
+
+func Download(ctx context.Context, desired CachedDownload, l *zap.Logger) (string, error) {
+	exePath, cached, exists := GetDownloadInfo(ctx, desired)
+
+	l = l.With(
+		zap.String("dest_dir", cached.DestDir),
+		zap.String("version", cached.Version),
+		zap.String("exe_path", exePath),
+	)
+
+	if exists {
+		l.Info("server already downloaded")
+		return exePath, nil
+	}
+
+	client := &http.Client{}
+
+	// Build info URL
+	platform := runtime.GOOS
+	if platform != "windows" && platform != "darwin" && platform != "linux" {
+		return "", fmt.Errorf("unsupported platform %v", platform)
+	}
+	arch := runtime.GOARCH
+	if arch != "amd64" && arch != "arm64" {
+		return "", fmt.Errorf("unsupported architecture %v", arch)
+	}
+	infoURL := fmt.Sprintf("https://temporal.download/cli/%v?platform=%v&arch=%v&sdk-name=sdk-go&sdk-version=%v", url.QueryEscape(cached.Version), platform, arch, temporal.SDKVersion)
+
+	// Get info
+	info := struct {
+		ArchiveURL    string `json:"archiveUrl"`
+		FileToExtract string `json:"fileToExtract"`
+	}{}
+	req, err := http.NewRequestWithContext(ctx, "GET", infoURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed preparing request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed fetching info: %w", err)
+	}
+	b, err := io.ReadAll(resp.Body)
+	if closeErr := resp.Body.Close(); closeErr != nil {
+		l.Warn("Failed to close response body", zap.Error(closeErr))
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed fetching info body: %w", err)
+	} else if resp.StatusCode != 200 {
+		return "", fmt.Errorf("failed fetching info, status: %v, body: %s", resp.Status, b)
+	} else if err = json.Unmarshal(b, &info); err != nil {
+		return "", fmt.Errorf("failed unmarshaling info: %w", err)
+	}
+
+	// Download and extract
+	l.Info("downloading", zap.String("url", info.ArchiveURL))
+
+	req, err = http.NewRequestWithContext(ctx, "GET", info.ArchiveURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed preparing request: %w", err)
+	}
+	resp, err = client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed downloading: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			l.Warn("Failed to close response body", zap.Error(closeErr))
+		}
+	}()
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("failed downloading, status: %v", resp.Status)
+	}
+	// We want to download to a temporary file then rename. A better system-wide
+	// atomic downloader would use a common temp file and check whether it exists
+	// and wait on it, but doing multiple downloads in racy situations is
+	// good/simple enough for now.
+	// Note that we don't use os.TempDir here, instead we use the user provided destination directory which is
+	// guaranteed to make the rename atomic.
+	f, err := os.CreateTemp(cached.DestDir, "temporal-cli-downloading-")
+	if err != nil {
+		return "", fmt.Errorf("failed creating temp file: %w", err)
+	}
+	if strings.HasSuffix(info.ArchiveURL, ".tar.gz") {
+		err = extractTarball(resp.Body, info.FileToExtract, f)
+	} else if strings.HasSuffix(info.ArchiveURL, ".zip") {
+		err = extractZip(resp.Body, info.FileToExtract, f)
+	} else {
+		err = fmt.Errorf("unrecognized file extension on %v", info.ArchiveURL)
+	}
+	closeErr := f.Close()
+	if err != nil {
+		return "", err
+	} else if closeErr != nil {
+		return "", fmt.Errorf("failed to close temp file: %w", closeErr)
+	}
+	// Chmod it if not Windows
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(f.Name(), 0o755); err != nil {
+			return "", fmt.Errorf("failed chmod'ing file: %w", err)
+		}
+	}
+	if err = os.Rename(f.Name(), exePath); err != nil {
+		return "", fmt.Errorf("failed moving file: %w", err)
+	}
+
+	l.Info("downloaded", zap.String("path", exePath))
+
+	return exePath, nil
+}
+
+func extractTarball(r io.Reader, toExtract string, w io.Writer) error {
+	r, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	tarRead := tar.NewReader(r)
+	for {
+		h, err := tarRead.Next()
+		if err != nil {
+			// This can be EOF which means we never found our file
+			return err
+		} else if h.Name == toExtract {
+			_, err = io.Copy(w, tarRead)
+			return err
+		}
+	}
+}
+
+func extractZip(r io.Reader, toExtract string, w io.Writer) error {
+	// Instead of using a third party zip streamer, and since Go stdlib doesn't
+	// support streaming read, we'll just put the entire archive in memory for now
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	zipRead, err := zip.NewReader(bytes.NewReader(b), int64(len(b)))
+	if err != nil {
+		return err
+	}
+	for _, file := range zipRead.File {
+		if file.Name == toExtract {
+			r, err := file.Open()
+			if err != nil {
+				return err
+			}
+			_, err = io.Copy(w, r)
+			return err
+		}
+	}
+	return fmt.Errorf("could not find file in zip archive")
+}

--- a/internal/backend/temporaldevsrv/download.go
+++ b/internal/backend/temporaldevsrv/download.go
@@ -169,7 +169,7 @@ func extractTarball(r io.Reader, toExtract string, w io.Writer) error {
 		h, err := tarRead.Next()
 		if err != nil {
 			// This can be EOF which means we never found our file
-			return err
+			return fmt.Errorf("read %q: %w", toExtract, err)
 		} else if h.Name == toExtract {
 			_, err = io.Copy(w, tarRead)
 			return err

--- a/internal/backend/temporaldevsrv/download.go
+++ b/internal/backend/temporaldevsrv/download.go
@@ -99,7 +99,7 @@ func Download(ctx context.Context, desired CachedDownload, l *zap.Logger) (strin
 	} else if resp.StatusCode != 200 {
 		return "", fmt.Errorf("failed fetching info, status: %v, body: %s", resp.Status, b)
 	} else if err = json.Unmarshal(b, &info); err != nil {
-		return "", fmt.Errorf("failed unmarshaling info: %w", err)
+		return "", fmt.Errorf("failed unmarshalling info: %w", err)
 	}
 
 	// Download and extract

--- a/internal/backend/temporaldevsrv/freeport.go
+++ b/internal/backend/temporaldevsrv/freeport.go
@@ -32,7 +32,7 @@ func getFreePort(host string) (string, int, error) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// On Linux and some BSD variants, ephemeral ports are randomized, and may
-	// consequently repeat within a short time frame after the listenning end
+	// consequently repeat within a short time frame after the listening end
 	// has been closed. To avoid this, we make a connection to the port, then
 	// close that connection from the server's side (this is very important),
 	// which puts the connection in TIME_WAIT state for some time (by default,

--- a/internal/backend/temporaldevsrv/freeport.go
+++ b/internal/backend/temporaldevsrv/freeport.go
@@ -1,0 +1,75 @@
+package temporaldevsrv
+
+import (
+	"fmt"
+	"net"
+	"runtime"
+)
+
+// Copied and adapted from
+// https://github.com/temporalio/cli/blob/350cb2f9dca55e5063b39ffbdaa2739fdeab4399/temporalcli/devserver/freeport.go
+
+// Returns a TCP port that is available to listen on, for the given (local) host.
+//
+// This works by binding a new TCP socket on port 0, which requests the OS to
+// allocate a free port. There is no strict guarantee that the port will remain
+// available after this function returns, but it should be safe to assume that
+// a given port will not be allocated again to any process on this machine
+// within a few seconds.
+//
+// On Unix-based systems, binding to the port returned by this function requires
+// setting the `SO_REUSEADDR` socket option (Go already does that by default,
+// but other languages may not); otherwise, the OS may fail with a message such
+// as "address already in use". Windows default behavior is already appropriate
+// in this regard; on that platform, `SO_REUSEADDR` has a different meaning and
+// should not be set (setting it may have unpredictable consequences).
+func getFreePort(host string) (string, int, error) {
+	l, err := net.Listen("tcp", host+":0")
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to assign a free port: %w", err)
+	}
+	defer func() { _ = l.Close() }()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	// On Linux and some BSD variants, ephemeral ports are randomized, and may
+	// consequently repeat within a short time frame after the listenning end
+	// has been closed. To avoid this, we make a connection to the port, then
+	// close that connection from the server's side (this is very important),
+	// which puts the connection in TIME_WAIT state for some time (by default,
+	// 60s on Linux). While it remains in that state, the OS will not reallocate
+	// that port number for bind(:0) syscalls, yet we are not prevented from
+	// explicitly binding to it (thanks to SO_REUSEADDR).
+	//
+	// On macOS and Windows, the above technique is not necessary, as the OS
+	// allocates ephemeral ports sequentially, meaning a port number will only
+	// be reused after the entire range has been exhausted. Quite the opposite,
+	// given that these OSes use a significantly smaller range for ephemeral
+	// ports, making an extra connection just to reserve a port might actually
+	// be harmful (by hastening ephemeral port exhaustion).
+	if runtime.GOOS != "darwin" && runtime.GOOS != "windows" {
+		r, err := net.DialTCP("tcp", nil, l.Addr().(*net.TCPAddr))
+		if err != nil {
+			return "", 0, fmt.Errorf("failed to assign a free port: %w", err)
+		}
+		c, err := l.Accept()
+		if err != nil {
+			return "", 0, fmt.Errorf("failed to assign a free port: %w", err)
+		}
+		// Closing the socket from the server side
+		_ = c.Close()
+		defer func() { _ = r.Close() }()
+	}
+
+	return host, port, nil
+}
+
+func getFreeHostPort() (string, error) {
+	host, port, err := getFreePort("127.0.0.1")
+	if err != nil {
+		host, port, err = getFreePort("[::1]")
+		if err != nil {
+			return "", err
+		}
+	}
+	return fmt.Sprintf("%v:%v", host, port), nil
+}

--- a/internal/backend/temporaldevsrv/process_nonwindows.go
+++ b/internal/backend/temporaldevsrv/process_nonwindows.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package temporaldevsrv
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// newCmd creates a new command with the given executable path and arguments.
+func newCmd(exePath string, args ...string) *exec.Cmd {
+	cmd := exec.Command(exePath, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd
+}
+
+// sendInterrupt sends an interrupt signal to the given process for graceful shutdown.
+func sendInterrupt(process *os.Process) error {
+	return process.Signal(syscall.SIGINT)
+}

--- a/internal/backend/temporaldevsrv/process_windows.go
+++ b/internal/backend/temporaldevsrv/process_windows.go
@@ -1,0 +1,39 @@
+package temporaldevsrv
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// newCmd creates a new command with the given executable path and arguments.
+func newCmd(exePath string, args ...string) *exec.Cmd {
+	cmd := exec.Command(exePath, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		// isolate the process and signals sent to it from the current console
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd
+}
+
+// sendInterrupt calls the break event on the given process for graceful shutdown.
+func sendInterrupt(process *os.Process) error {
+	dll, err := windows.LoadDLL("kernel32.dll")
+	if err != nil {
+		return err
+	}
+	p, err := dll.FindProc("GenerateConsoleCtrlEvent")
+	if err != nil {
+		return err
+	}
+	r, _, err := p.Call(uintptr(windows.CTRL_BREAK_EVENT), uintptr(process.Pid))
+	if r == 0 {
+		return err
+	}
+	return nil
+}

--- a/internal/backend/temporaldevsrv/start.go
+++ b/internal/backend/temporaldevsrv/start.go
@@ -1,0 +1,136 @@
+package temporaldevsrv
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"go.temporal.io/sdk/client"
+
+	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
+)
+
+// StartDevServer starts a Temporal CLI dev server process. This may download the server if not already downloaded.
+// The server binary must exists either in options.ExistingPath or be downloaded to the path specified in options.CachedDownload.DestDir.
+func StartDevServer(ctx context.Context, options DevServerOptions) (*DevServer, error) {
+	exePath := options.ExistingPath
+	if exePath == "" {
+		var exists bool
+		if exePath, _, exists = GetDownloadInfo(ctx, options.CachedDownload); !exists {
+			return nil, sdkerrors.ErrNotFound
+		}
+	}
+
+	clientOptions := options.clientOptionsOrDefault()
+
+	if clientOptions.HostPort == "" {
+		var err error
+
+		// Make sure this is done after downloading to reduce the chance (however slim) that the free port would be used
+		// up by the time the download completes.
+		clientOptions.HostPort, err = getFreeHostPort()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	host, port, err := net.SplitHostPort(clientOptions.HostPort)
+	if err != nil {
+		return nil, fmt.Errorf("invalid HostPort: %w", err)
+	}
+
+	args := prepareCommand(&options, host, port, clientOptions.Namespace)
+
+	cmd := newCmd(exePath, args...)
+	if options.Stdout != nil {
+		cmd.Stdout = options.Stdout
+	}
+	if options.Stderr != nil {
+		cmd.Stderr = options.Stderr
+	}
+
+	clientOptions.Logger.Info("Starting DevServer", "ExePath", exePath, "Args", args)
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed starting: %w", err)
+	}
+
+	returnedClient, err := waitServerReady(ctx, clientOptions)
+	if err != nil {
+		return nil, err
+	}
+	clientOptions.Logger.Info("DevServer ready")
+	return &DevServer{
+		client:           returnedClient,
+		cmd:              cmd,
+		frontendHostPort: clientOptions.HostPort,
+	}, nil
+}
+
+func prepareCommand(options *DevServerOptions, host, port, namespace string) []string {
+	args := []string{
+		"server",
+		"start-dev",
+		"--ip", host, "--port", port,
+		"--namespace", namespace,
+		"--dynamic-config-value", "frontend.enableServerVersionCheck=false",
+	}
+	if options.LogLevel != "" {
+		args = append(args, "--log-level", options.LogLevel)
+	}
+	if options.LogFormat != "" {
+		args = append(args, "--log-format", options.LogFormat)
+	}
+	if !options.EnableUI {
+		args = append(args, "--headless")
+	}
+	if options.DBFilename != "" {
+		args = append(args, "--db-filename", options.DBFilename)
+	}
+	if options.UIPort != "" {
+		args = append(args, "--ui-port", options.UIPort)
+	}
+	return append(args, options.ExtraArgs...)
+}
+
+// waitServerReady repeatedly attempts to dial the server with given options until it is ready or it is time to give up.
+// Returns a connected client created using the provided options.
+func waitServerReady(ctx context.Context, options client.Options) (client.Client, error) {
+	var returnedClient client.Client
+	lastErr := retryFor(ctx, 600, 100*time.Millisecond, func() error {
+		var err error
+		returnedClient, err = client.DialContext(ctx, options)
+		return err
+	})
+	if lastErr != nil {
+		return nil, fmt.Errorf("failed connecting after timeout, last error: %w", lastErr)
+	}
+	return returnedClient, lastErr
+}
+
+// retryFor retries some function until it returns nil or runs out of attempts. Wait interval between attempts.
+func retryFor(ctx context.Context, maxAttempts int, interval time.Duration, cond func() error) error {
+	if maxAttempts < 1 {
+		// this is used internally, okay to panic
+		panic("maxAttempts should be at least 1")
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	var lastErr error
+	for i := 0; i < maxAttempts; i++ {
+		if curE := cond(); curE == nil {
+			return nil
+		} else {
+			lastErr = curE
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			// Try again after waiting up to interval.
+		}
+	}
+	return lastErr
+}

--- a/internal/backend/temporaldevsrv/start.go
+++ b/internal/backend/temporaldevsrv/start.go
@@ -119,7 +119,7 @@ func retryFor(ctx context.Context, maxAttempts int, interval time.Duration, cond
 	defer ticker.Stop()
 
 	var lastErr error
-	for i := 0; i < maxAttempts; i++ {
+	for range maxAttempts {
 		if curE := cond(); curE == nil {
 			return nil
 		} else {

--- a/internal/xdg/xdg.go
+++ b/internal/xdg/xdg.go
@@ -25,6 +25,7 @@ import (
 const (
 	ConfigEnvVar = "XDG_CONFIG_HOME"
 	DataEnvVar   = "XDG_DATA_HOME"
+	CacheEnvVar  = "XDG_CACHE_HOME"
 
 	appName = "autokitteh"
 	perm    = 0o700 // drxw------
@@ -37,6 +38,8 @@ func ConfigHomeDir() string { return homeDir(xdg.ConfigHome) }
 // DataHomeDir returns the XDG config-home directory for autokitteh,
 // and guarantees that it exists, so callers can use it safely.
 func DataHomeDir() string { return homeDir(xdg.DataHome) }
+
+func CacheHomeDir() string { return homeDir(xdg.CacheHome) }
 
 func homeDir(baseDir string) string {
 	xdg.Reload() // Account for changes in environment variables.

--- a/internal/xdg/xdg.go
+++ b/internal/xdg/xdg.go
@@ -54,6 +54,7 @@ func homeDir(baseDir string) string {
 }
 
 func Reload() {
+	CacheHomeDir()
 	ConfigHomeDir()
 	DataHomeDir()
 }


### PR DESCRIPTION
download now will not count for the start timeout, as well as download to a cache directory and not a temp dir. this will minimize the need to download the server every time and should make it more stable.

also add an "ak temporal download" command to warm up when needed.

this duplicates the temporal code in order to give us more control and tune what it does.
