### PR TITLE
BUG: when activity returns a value that causes pickle to throw AttributeError, python hangs

### DIFF
--- a/tests/sessions/python/unpickle_error.txtar
+++ b/tests/sessions/python/unpickle_error.txtar
@@ -6,16 +6,21 @@ for more details.
 -- main.py main --
 import autokitteh
 
+# Will cause recursion error when unpickled
+class Infi:
+    def __init__(self):
+        self._lookup = {}
 
-class Unpickleable:
-    def __reduce__(self):
-        raise AttributeError("This class cannot be pickled")
+    def __getattr__(self, attr):
+        if attr in self._lookup:
+            return self._lookup[attr]
+        raise AttributeError(attr)
 
 
 def main(event):
-	boom()
+	get_infi()
 
 
 @autokitteh.activity
-def boom():
-	return Unpickleable()
+def get_infi():
+	return Infi()


### PR DESCRIPTION
```
import autokitteh


class Unpickleable:
    def __reduce__(self):
        raise AttributeError("This class cannot be pickled")


def main(event):
	boom()


@autokitteh.activity
def boom():
	return Unpickleable()
```

we get this when trying to pickle LangGraph `builder.compile` result which throws for some reason:
```
AttributeError: Can't get local object 'CompiledStateGraph.attach_node.<locals>._get_updates'
```