### PR TITLE
fix(python): github sdk correct name

### DIFF
--- a/runtimes/pythonrt/py-sdk/autokitteh/github.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/github.py
@@ -68,7 +68,7 @@ class AppAuth(Auth.AppAuth):
 
     def __init__(self, app_id: int, ak_connection_name: str):
         self._app_id = app_id
-        self._private_key = ak_connection_name
+        self._conn_name = ak_connection_name
         self._jwt_expiry = Consts.DEFAULT_JWT_EXPIRY
         self._jwt_issued_at = Consts.DEFAULT_JWT_ISSUED_AT
         self._jwt_algorithm = Consts.DEFAULT_JWT_ALGORITHM
@@ -82,4 +82,4 @@ class AppAuth(Auth.AppAuth):
         }
         # This is the only change from the original code: replace the call to jwt.encode().
         # We don't monkey-patch it because the jwt module is usable outside the GitHub client too.
-        return encode_jwt(payload, self.private_key, self._jwt_algorithm)
+        return encode_jwt(payload, self._conn_name, self._jwt_algorithm)


### PR DESCRIPTION
In the original code, the private key was stored in a field named ` _private_key` but incorrectly accessed as `private_key` when calling encode_jwt. I fixed the reference and also renamed the field to _conn_name to better reflect its actual purpose.