### PR TITLE
feat: add k8s integration

### DIFF
--- a/integrations/kubernetes/client.go
+++ b/integrations/kubernetes/client.go
@@ -1,0 +1,44 @@
+package kubernetes
+
+import (
+	"context"
+
+	"go.autokitteh.dev/autokitteh/integrations/common"
+	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
+	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
+	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+var (
+	desc          = common.Descriptor("kubernetes", "Kubernetes", "/static/images/k8s.svg")
+	configFileVar = sdktypes.NewSymbol("configFile")
+	authTypeVar   = sdktypes.NewSymbol("authType")
+)
+
+type integration struct{ vars sdkservices.Vars }
+
+func New(vars sdkservices.Vars) sdkservices.Integration {
+	i := &integration{vars: vars}
+	return sdkintegrations.NewIntegration(
+		desc,
+		sdkmodule.New(),
+		connStatus(i),
+		connTest(i),
+		sdkintegrations.WithConnectionConfigFromVars(vars),
+	)
+}
+
+// TODO: Implement the connection status functions for Kubernetes integration.
+func connStatus(_ *integration) sdkintegrations.OptFn {
+	return sdkintegrations.WithConnectionStatus(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
+		return sdktypes.NewStatus(sdktypes.StatusCodeWarning, "Init required"), nil
+	})
+}
+
+// TODO: Implement the connection test function for Kubernetes integration.
+func connTest(_ *integration) sdkintegrations.OptFn {
+	return sdkintegrations.WithConnectionTest(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
+		return sdktypes.NewStatus(sdktypes.StatusCodeUnspecified, "Not implemented"), nil
+	})
+}

--- a/integrations/kubernetes/client.go
+++ b/integrations/kubernetes/client.go
@@ -3,19 +3,20 @@ package kubernetes
 import (
 	"context"
 
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/integrations"
 	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.uber.org/zap"
 )
 
 var (
 	desc          = common.Descriptor("kubernetes", "Kubernetes", "/static/images/k8s.svg")
-	configFileVar = sdktypes.NewSymbol("configFile")
-	authTypeVar   = sdktypes.NewSymbol("authType")
+	configFileVar = sdktypes.NewSymbol("config_file")
+	authTypeVar   = sdktypes.NewSymbol("auth_type")
 )
 
 type integration struct{ vars sdkservices.Vars }

--- a/integrations/kubernetes/client.go
+++ b/integrations/kubernetes/client.go
@@ -56,7 +56,7 @@ func connStatus(i *integration) sdkintegrations.OptFn {
 	})
 }
 
-// TODO: Implement the connection test function for Kubernetes integration.
+// TODO: INT-431 Implement the connection test function for k8s integration.
 func connTest(_ *integration) sdkintegrations.OptFn {
 	return sdkintegrations.WithConnectionTest(func(ctx context.Context, cid sdktypes.ConnectionID) (sdktypes.Status, error) {
 		return sdktypes.NewStatus(sdktypes.StatusCodeUnspecified, "Not implemented"), nil

--- a/integrations/kubernetes/save.go
+++ b/integrations/kubernetes/save.go
@@ -1,0 +1,48 @@
+package kubernetes
+
+import (
+	"net/http"
+
+	"go.uber.org/zap"
+
+	"go.autokitteh.dev/autokitteh/integrations"
+	"go.autokitteh.dev/autokitteh/integrations/common"
+	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
+	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
+)
+
+// handler is an autokitteh webhook which implements [http.Handler]
+// to save data from web form submissions as connections.
+type handler struct {
+	logger *zap.Logger
+}
+
+func NewHTTPHandler(l *zap.Logger) http.Handler {
+	return handler{logger: l}
+}
+
+// ServeHTTP saves a new autokitteh connection with user-submitted data.
+func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	c, l := sdkintegrations.NewConnectionInit(h.logger, w, r, desc)
+
+	// Check the "Content-Type" header.
+	if common.PostWithoutFormContentType(r) {
+		ct := r.Header.Get(common.HeaderContentType)
+		l.Warn("save connection: unexpected POST content type", zap.String("content_type", ct))
+		c.AbortBadRequest("unexpected content type")
+		return
+	}
+
+	// Read and parse POST request body.
+	if err := r.ParseForm(); err != nil {
+		l.Warn("Failed to parse incoming HTTP request", zap.Error(err))
+		c.AbortBadRequest("form parsing error")
+		return
+	}
+
+	configFile := r.Form.Get("configFile")
+
+	c.Finalize(sdktypes.NewVars().
+		Set(configFileVar, configFile, true).
+		Set(authTypeVar, integrations.Init, false))
+}

--- a/integrations/kubernetes/save.go
+++ b/integrations/kubernetes/save.go
@@ -40,7 +40,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	configFile := r.Form.Get("configFile")
+	configFile := r.Form.Get("config_file")
 
 	c.Finalize(sdktypes.NewVars().
 		Set(configFileVar, configFile, true).

--- a/integrations/kubernetes/server.go
+++ b/integrations/kubernetes/server.go
@@ -1,0 +1,21 @@
+package kubernetes
+
+import (
+	"go.uber.org/zap"
+
+	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
+)
+
+const (
+	// savePath is the URL path for our handler to save new
+	// connections, after users submit them via a web form.
+	savePath = "/kubernetes/save"
+)
+
+func Start(l *zap.Logger, m *muxes.Muxes) {
+	// Init webhooks save connection vars (via "c.Finalize" calls), so they need
+	// to have an authenticated user context, so the DB layer won't reject them.
+	// For this purpose, init webhooks are managed by the "auth" mux, which passes
+	// through AutoKitteh's auth middleware to extract the user ID from a cookie.
+	m.Auth.Handle("POST "+savePath, NewHTTPHandler(l))
+}

--- a/internal/backend/svc/integrations.go
+++ b/internal/backend/svc/integrations.go
@@ -24,6 +24,7 @@ import (
 	"go.autokitteh.dev/autokitteh/integrations/google/sheets"
 	"go.autokitteh.dev/autokitteh/integrations/height"
 	"go.autokitteh.dev/autokitteh/integrations/hubspot"
+	"go.autokitteh.dev/autokitteh/integrations/kubernetes"
 	"go.autokitteh.dev/autokitteh/integrations/linear"
 	"go.autokitteh.dev/autokitteh/integrations/microsoft"
 	"go.autokitteh.dev/autokitteh/integrations/microsoft/teams"
@@ -105,6 +106,7 @@ func integrationsFXOption() fx.Option {
 		integration("height", configset.Empty, height.New),
 		integration("hubspot", configset.Empty, hubspot.New),
 		integration("jira", configset.Empty, jira.New),
+		integration("kubernetes", configset.Empty, kubernetes.New),
 		integration("linear", configset.Empty, linear.New),
 		integration("microsoft", configset.Empty, microsoft.New),
 		integration("microsoft_teams", configset.Empty, teams.New),
@@ -127,6 +129,7 @@ func integrationsFXOption() fx.Option {
 				height.Start(l, muxes, vars, oauth, dispatch)
 				hubspot.Start(l, muxes, oauth)
 				jira.Start(l, muxes, vars, oauth, dispatch)
+				kubernetes.Start(l, muxes)
 				linear.Start(l, muxes, vars, oauth, dispatch)
 				microsoft.Start(l, muxes, vars, oauth, dispatch)
 				salesforce.Start(l, muxes, vars, oauth, dispatch)

--- a/runtimes/pythonrt/py-sdk/autokitteh/kubernetes.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/kubernetes.py
@@ -18,7 +18,8 @@ def kubernetes_client(connection: str) -> ModuleType:
 
     Raises:
         ValueError: AutoKitteh connection name is invalid.
-        ConnectionInitError: AutoKitteh connection was not initialized yet.
+        ConnectionInitError: If the connection config is missing or invalid,
+            or if an unexpected error occurs during client initialization.
 
     """
     check_connection_name(connection)
@@ -34,8 +35,11 @@ def kubernetes_client(connection: str) -> ModuleType:
             temp_path = temp_file.name
 
         config.load_kube_config(config_file=temp_path)
+    except config.ConfigException as e:
+        raise ConnectionInitError(connection) from e
     except Exception as e:
         raise ConnectionInitError(connection) from e
+
     finally:
         os.unlink(temp_path)
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/kubernetes.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/kubernetes.py
@@ -1,13 +1,13 @@
-import json
 import os
 import tempfile
+from types import ModuleType
 
 from kubernetes import client, config
 from .connections import check_connection_name
 from .errors import ConnectionInitError
 
 
-def kubernetes_client(connection: str):  # TODO: add type hints
+def kubernetes_client(connection: str) -> ModuleType:
     """Initialize a Kubernetes client, based on an AutoKitteh connection.
 
     Args:
@@ -28,14 +28,13 @@ def kubernetes_client(connection: str):  # TODO: add type hints
     if not config_file:
         raise ConnectionInitError(connection)
 
-    parsed = json.loads(config_file)
-    with tempfile.NamedTemporaryFile(delete=False, mode="w") as temp_file:
-        json.dump(parsed, temp_file, indent=2)
-        temp_path = temp_file.name
-
     try:
+        with tempfile.NamedTemporaryFile(delete=False, mode="w") as temp_file:
+            temp_file.write(config_file)
+            temp_path = temp_file.name
+
         config.load_kube_config(config_file=temp_path)
-    except config.ConfigException as e:
+    except Exception as e:
         raise ConnectionInitError(connection) from e
     finally:
         os.unlink(temp_path)

--- a/runtimes/pythonrt/py-sdk/autokitteh/kubernetes.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/kubernetes.py
@@ -1,0 +1,43 @@
+import json
+import os
+import tempfile
+
+from kubernetes import client, config
+from .connections import check_connection_name
+from .errors import ConnectionInitError
+
+
+def kubernetes_client(connection: str):  # TODO: add type hints
+    """Initialize a Kubernetes client, based on an AutoKitteh connection.
+
+    Args:
+        connection: AutoKitteh connection name.
+
+    Returns:
+        Kubernetes API client.
+
+    Raises:
+        ValueError: AutoKitteh connection name is invalid.
+        ConnectionInitError: AutoKitteh connection was not initialized yet.
+
+    """
+    check_connection_name(connection)
+
+    config_file = os.getenv(connection + "__configFile")
+
+    if not config_file:
+        raise ConnectionInitError(connection)
+
+    parsed = json.loads(config_file)
+    with tempfile.NamedTemporaryFile(delete=False, mode="w") as temp_file:
+        json.dump(parsed, temp_file, indent=2)
+        temp_path = temp_file.name
+
+    try:
+        config.load_kube_config(config_file=temp_path)
+    except config.ConfigException as e:
+        raise ConnectionInitError(connection) from e
+    finally:
+        os.unlink(temp_path)
+
+    return client

--- a/runtimes/pythonrt/py-sdk/docs/requirements.txt
+++ b/runtimes/pythonrt/py-sdk/docs/requirements.txt
@@ -12,6 +12,7 @@ google-auth-httplib2 ~= 0.2
 google-auth-oauthlib ~= 1.2
 google-generativeai ~= 0.8
 hubspot-api-client ~= 11.1
+kubernetes ~= 31.0
 msgraph-sdk ~= 1.18
 openai ~= 1.57
 PyGithub ~= 2.6

--- a/runtimes/pythonrt/py-sdk/pyproject.toml
+++ b/runtimes/pythonrt/py-sdk/pyproject.toml
@@ -26,6 +26,7 @@ all = [
 	"google-auth-oauthlib ~= 1.2",
 	"google-generativeai ~= 0.8",
 	"hubspot-api-client ~= 11.1",
+	"kubernetes ~= 31.0",
 	"msgraph-sdk ~= 1.18",
 	"openai ~= 1.57",
 	"PyGithub ~= 2.6",


### PR DESCRIPTION
Add the Kubernetes integration

-  client and server
-  saves the JSON config file used to initialize the Kubernetes connection
- py-sdk: used Kubernetes library and added it to `requirements.txt` and return the standard k8s client
