### PR TITLE
fix goreleaser brew part

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,6 +42,8 @@ builds:
 
 brews:
   - name: autokitteh
+    ids:
+      - ak
     description: "Durable workflow automation in just a few lines of code"
     homepage: "https://autokitteh.com/"
     license: "Apache-2.0"


### PR DESCRIPTION
adds ids section to brew in goreleaser so it uses only ak and not ak enterprise build