### PR TITLE
bug(python): Activity marker doesn't work on async

### DIFF
--- a/runtimes/pythonrt/runner/call.py
+++ b/runtimes/pythonrt/runner/call.py
@@ -153,3 +153,9 @@ class AKCall:
             return self.runner.call_in_activity(func, args, kw)
         finally:
             self.in_activity = False
+
+    async def call_async(self, func, *args, **kw):
+        # Support async. Don not change the method name without changing loader.py as
+        # well
+
+        return self(func, *args, **kw)

--- a/runtimes/pythonrt/runner/call.py
+++ b/runtimes/pythonrt/runner/call.py
@@ -154,8 +154,5 @@ class AKCall:
         finally:
             self.in_activity = False
 
-    async def call_async(self, func, *args, **kw):
-        # Support async. Don not change the method name without changing loader.py as
-        # well
-
-        return self(func, *args, **kw)
+    async def async_call(self, func, *args, **kw):
+        return await self(func, *args, **kw)

--- a/runtimes/pythonrt/runner/loader.py
+++ b/runtimes/pythonrt/runner/loader.py
@@ -14,14 +14,17 @@ def name_of(node, code_lines):
 
 
 AK_CALL_NAME = "_ak_call"
+AK_AYNC_CALL_NAME = "_ak_async_call"
 BUILTIN = {v for v in dir(builtins) if callable(getattr(builtins, v))}
 
 _funcs = (ast.AsyncFunctionDef, ast.FunctionDef)
-_callabls = _funcs + (ast.ClassDef,)
+_callables = _funcs + (ast.ClassDef,)
 
 
 class Transformer(ast.NodeTransformer):
     """Replace 'fn(a, b)' with '_ak_call(fn, a, b)'."""
+
+    parent = None
 
     def __init__(self, file_name, src):
         self.file_name = file_name
@@ -30,9 +33,13 @@ class Transformer(ast.NodeTransformer):
         self.patch = False
 
     def visit(self, node):
+        # Track parent to know if call is awaited
+        node.parent = self.parent
+        self.parent = node
+
         # Visit AST nodes. We keep track of functions and indent, in order not to patch
         # module level calls.
-        if isinstance(node, _callabls) and not self.patch:
+        if isinstance(node, _callables) and not self.patch:
             self.patch = True
             self.generic_visit(node)
             self.patch = False
@@ -48,12 +55,16 @@ class Transformer(ast.NodeTransformer):
             self.generic_visit(node)
             return node
 
-        log.info("%s:%d: patching %s with ak_call", self.file_name, node.lineno, name)
         # urlopen("https://autokitteh.h") -> _call(urlopen, "https://autokitteh.com")
-        call_id = AK_CALL_NAME
-        if isinstance(node, ast.AsyncFunctionDef):
-            # This should be in sync with call.py
-            call_id += ".async_call"
+        if isinstance(node.parent, ast.Await):
+            call_id = AK_AYNC_CALL_NAME
+        else:
+            call_id = AK_CALL_NAME
+
+        log.info(
+            "%s:%d: patching %s with %s", self.file_name, node.lineno, name, call_id
+        )
+
         call = ast.Call(
             func=ast.Name(id=call_id, ctx=ast.Load()),
             args=[node.func] + node.args,
@@ -82,6 +93,7 @@ class Loader:
 
         code = compile(patched_tree, module.__file__, "exec")
         setattr(module, AK_CALL_NAME, self.ak_call)
+        setattr(module, AK_AYNC_CALL_NAME, self.ak_call.async_call)
         exec(code, module.__dict__)
 
     def create_module(self, spec):
@@ -151,7 +163,7 @@ def exports(code_dir, file_name):
 
     tree = ast.parse(code, file_name, "exec")
     for node in tree.body:
-        if not isinstance(node, _callabls):
+        if not isinstance(node, _callables):
             continue
 
         args = fn_args(node) if isinstance(node, _funcs) else class_args(node)

--- a/runtimes/pythonrt/runner/main.py
+++ b/runtimes/pythonrt/runner/main.py
@@ -7,6 +7,7 @@ import sys
 from base64 import b64decode
 from collections import namedtuple
 from concurrent.futures import Future, ThreadPoolExecutor
+from functools import update_wrapper
 from io import StringIO
 from multiprocessing import cpu_count
 from pathlib import Path
@@ -233,7 +234,7 @@ class Runner(pb.runner_rpc.RunnerService):
         self.executor = ThreadPoolExecutor()
 
         self.lock = Lock()
-        self.activity_call = None
+        self.activity_call: Call = None
         self._orig_print = print
         self._start_called = False
         self._inactivity_timer = Timer(
@@ -366,12 +367,14 @@ class Runner(pb.runner_rpc.RunnerService):
         # hook = make_audit_hook(ak_call, self.code_dir)
         # sys.addaudithook(hook)
 
+        # Top-level handler marked as activity.
         if activity_marker(fn):
             orig_fn = fn
 
             def handler(event):
                 return ak_call(orig_fn, event)
 
+            update_wrapper(handler, orig_fn)
             fn = handler
 
         self.executor.submit(self.on_event, fn, event)
@@ -458,7 +461,16 @@ class Runner(pb.runner_rpc.RunnerService):
                 error = AutoKittehError(repr(result.error))
             call.fut.set_exception(error)
         else:
-            call.fut.set_result(result.value)
+            if inspect.iscoroutinefunction(call.fn):
+                # Wrap async result from activity so it can be awaited
+                async def future():
+                    return result.value
+
+                value = future()
+            else:
+                value = result.value
+
+            call.fut.set_result(value)
 
         return pb.runner.ActivityReplyResponse()
 

--- a/runtimes/pythonrt/runner/main.py
+++ b/runtimes/pythonrt/runner/main.py
@@ -15,7 +15,6 @@ from time import sleep
 from traceback import TracebackException, format_exception
 
 import autokitteh
-from autokitteh.activities import ACTIVITY_ATTR
 import grpc
 
 # from audit import make_audit_hook  # TODO(ENG-1893): uncomment this.
@@ -511,7 +510,6 @@ class Runner(pb.runner_rpc.RunnerService):
         try:
             value = fn(*args, **kw)
             if asyncio.iscoroutine(value):
-                setattr(value, ACTIVITY_ATTR, getattr(fn, ACTIVITY_ATTR, None))
                 value = asyncio.run(value)
         except BaseException as err:
             log.error("%s raised: %s", func_name, err)

--- a/runtimes/pythonrt/runner/main.py
+++ b/runtimes/pythonrt/runner/main.py
@@ -15,6 +15,7 @@ from time import sleep
 from traceback import TracebackException, format_exception
 
 import autokitteh
+from autokitteh.activities import ACTIVITY_ATTR
 import grpc
 
 # from audit import make_audit_hook  # TODO(ENG-1893): uncomment this.
@@ -510,6 +511,7 @@ class Runner(pb.runner_rpc.RunnerService):
         try:
             value = fn(*args, **kw)
             if asyncio.iscoroutine(value):
+                setattr(value, ACTIVITY_ATTR, getattr(fn, ACTIVITY_ATTR, None))
                 value = asyncio.run(value)
         except BaseException as err:
             log.error("%s raised: %s", func_name, err)

--- a/runtimes/pythonrt/runner/tests/mock_worker.py
+++ b/runtimes/pythonrt/runner/tests/mock_worker.py
@@ -17,11 +17,12 @@ def next_signal_id():
 
 
 class MockWorker(pb.handler_rpc.HandlerService):
-    def __init__(self, runner: pb.runner_rpc.RunnerService):
+    def __init__(self, runner: pb.runner_rpc.RunnerService, verbose=False):
         self.runner = runner
         self.runner.worker = self
         self.event = Event()
         self.calls = Counter()
+        self.verbose = verbose
 
     def start(self, entry_point, data):
         req = pb.runner.StartRequest(
@@ -134,7 +135,8 @@ class MockWorker(pb.handler_rpc.HandlerService):
         self.log("IS_ACTIVE_RUNNER", request)
         return pb.handler.IsActiveRunnerResponse(is_active=True)
 
-    # We can't use 'print' since main replaces it with a call to the worker Print
     def log(self, func, msg):
-        sys.stdout.write(f"<<{func}>> {msg}\n")
+        if self.verbose:
+            # We can't use 'print' since main replaces it with a call to the worker Print
+            sys.stdout.write(f"<<{func}>> {msg}\n")
         self.calls[func] += 1

--- a/runtimes/pythonrt/runner/tests/mock_worker.py
+++ b/runtimes/pythonrt/runner/tests/mock_worker.py
@@ -5,6 +5,7 @@ from itertools import count
 from threading import Event, Thread
 from time import sleep
 from unittest.mock import MagicMock
+from collections import Counter
 
 import pb
 
@@ -15,16 +16,12 @@ def next_signal_id():
     return f"signal-{_next_id()}"
 
 
-# We can't use 'print' since main replaces it with a call to the worker Print
-def log(func, msg):
-    sys.stdout.write(f"<<{func}>> {msg}\n")
-
-
 class MockWorker(pb.handler_rpc.HandlerService):
     def __init__(self, runner: pb.runner_rpc.RunnerService):
         self.runner = runner
         self.runner.worker = self
         self.event = Event()
+        self.calls = Counter()
 
     def start(self, entry_point, data):
         req = pb.runner.StartRequest(
@@ -32,7 +29,7 @@ class MockWorker(pb.handler_rpc.HandlerService):
         )
         ctx = MagicMock()
         resp: pb.runner.StartResponse = self.runner.Start(req, ctx)
-        log("START RESPONSE:", resp)
+        self.log("START RESPONSE:", resp)
         self.event.wait()
 
     def call_execute(self, data):
@@ -41,7 +38,7 @@ class MockWorker(pb.handler_rpc.HandlerService):
         sleep(0.1)
         req = pb.runner.ExecuteRequest(data=data)
         resp: pb.runner.ExecuteResponse = self.runner.Execute(req, ctx)
-        log("EXECUTE RESPONSE:", resp)
+        self.log("EXECUTE RESPONSE:", resp)
 
     def call_activity_reply(self, msg: pb.handler.ExecuteReplyRequest):
         ctx = MagicMock()
@@ -52,10 +49,10 @@ class MockWorker(pb.handler_rpc.HandlerService):
             # TODO: Traceback?
         )
         resp: pb.runner.ActivityReplyResponse = self.runner.ActivityReply(req, ctx)
-        log("ACTIVITY REPLY RESPONSE:", resp)
+        self.log("ACTIVITY REPLY RESPONSE:", resp)
 
     def Activity(self, request: pb.handler.ActivityRequest):
-        log("ACTIVITY", request)
+        self.log("ACTIVITY", request)
         Thread(
             target=self.call_execute,
             args=(request.data,),
@@ -64,7 +61,7 @@ class MockWorker(pb.handler_rpc.HandlerService):
         return pb.handler.ActivityResponse()
 
     def ExecuteReply(self, request: pb.handler.ExecuteReplyRequest):
-        log("EXECUTE", request)
+        self.log("EXECUTE", request)
         Thread(
             target=self.call_activity_reply,
             args=(request,),
@@ -73,47 +70,47 @@ class MockWorker(pb.handler_rpc.HandlerService):
         return pb.handler.ExecuteReplyResponse()
 
     def Done(self, request: pb.handler.DoneRequest):
-        log("DONE", request)
+        self.log("DONE", request)
         self.event.set()
 
     def Log(self, request: pb.handler.LogRequest):
-        log("LOG", request)
+        self.log("LOG", request)
         return pb.handler.LogResponse()
 
     def Print(self, request: pb.handler.PrintRequest):
-        log("PRINT", request.message)
+        self.log("PRINT", request.message)
         return pb.handler.PrintResponse()
 
     def Sleep(self, request: pb.handler.SleepRequest):
-        log("SLEEP", request.duration)
+        self.log("SLEEP", request.duration)
         sleep(request.duration_ms * 1000)
         return pb.handler.SleepResponse()
 
     def Subscribe(self, request: pb.handler.SubscribeRequest):
-        log("SUBSCRIBE", request)
+        self.log("SUBSCRIBE", request)
         return pb.handler.SubscribeResponse(signal_id=next_signal_id())
 
     def NextEvent(self, request: pb.handler.NextEventRequest):
-        log("NEXT_EVENT", request)
+        self.log("NEXT_EVENT", request)
         # TODO: Allow user to set events
         return pb.handler.NextEventResponse(
             event=pb.user_code.Event(data=b"next_event")
         )
 
     def Unsubscribe(self, request: pb.handler.UnsubscribeRequest):
-        log("UNSUBSCRIBE", request)
+        self.log("UNSUBSCRIBE", request)
         return pb.handler.UnsubscribeResponse()
 
     def StartSession(self, request: pb.handler.StartSessionRequest):
-        log("START_SESSION", request)
+        self.log("START_SESSION", request)
         return pb.handler.StartSessionResponse()
 
     def Signal(self, request: pb.handler.SignalRequest):
-        log("SIGNAL", request)
+        self.log("SIGNAL", request)
         return pb.handler.SignalResponse()
 
     def NextSignal(self, request: pb.handler.NextSignalRequest):
-        log("NEXT_SIGNAL", request)
+        self.log("NEXT_SIGNAL", request)
         return pb.handler.NextSignalResponse(
             signal=pb.handler.Signal(
                 name="signal",
@@ -122,17 +119,22 @@ class MockWorker(pb.handler_rpc.HandlerService):
         )
 
     def EncodeJWT(self, request: pb.handler.EncodeJWTRequest):
-        log("ENCODE_JWT", request)
+        self.log("ENCODE_JWT", request)
         return pb.handler.EncodeJWTResponse()
 
     def RefreshOAuthToken(self, request: pb.handler.RefreshRequest):
-        log("REFRESH_OAUTH_TOKEN", request)
+        self.log("REFRESH_OAUTH_TOKEN", request)
         return pb.handler.RefreshResponse(token="token")
 
     def Health(self, request: pb.handler.HandlerHealthRequest):
-        log("HEALTH", request)
+        self.log("HEALTH", request)
         return pb.handler.HandlerHealthResponse()
 
     def IsActivateRunner(self, request: pb.handler.IsActiveRunnerRequest):
-        log("IA_ACTIVE_RUNNER", request)
+        self.log("IS_ACTIVE_RUNNER", request)
         return pb.handler.IsActiveRunnerResponse(is_active=True)
+
+    # We can't use 'print' since main replaces it with a call to the worker Print
+    def log(self, func, msg):
+        sys.stdout.write(f"<<{func}>> {msg}\n")
+        self.calls[func] += 1

--- a/runtimes/pythonrt/runner/tests/workflows/async_activity/program.py
+++ b/runtimes/pythonrt/runner/tests/workflows/async_activity/program.py
@@ -1,0 +1,10 @@
+import autokitteh
+
+
+async def on_event(event):
+    await work()
+
+
+@autokitteh.activity
+async def work():
+    pass

--- a/runtimes/pythonrt/runner/tests/workflows/async_handler/program.py
+++ b/runtimes/pythonrt/runner/tests/workflows/async_handler/program.py
@@ -1,0 +1,6 @@
+import autokitteh
+
+
+@autokitteh.activity
+async def on_event(event):
+    pass

--- a/runtimes/pythonrt/runner/tests/workflows/async_handler/program.py
+++ b/runtimes/pythonrt/runner/tests/workflows/async_handler/program.py
@@ -3,4 +3,17 @@ import autokitteh
 
 @autokitteh.activity
 async def on_event(event):
-    pass
+    print("on_event: start")
+    out = await work()
+    print(f"on_event: end ({out=})")
+
+
+async def work():
+    print("work")
+    return 8
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(on_event(None))

--- a/tests/sessions/python/async_activity.txtar
+++ b/tests/sessions/python/async_activity.txtar
@@ -1,3 +1,7 @@
+on_event: start
+work
+on_event: end (out=8)
+-- main.py:main --
 import autokitteh
 
 
@@ -16,9 +20,3 @@ async def work():
 
 async def value():
     return 8
-
-
-if __name__ == "__main__":
-    import asyncio
-
-    asyncio.run(on_event(None))

--- a/tests/sessions/python/async_activity.txtar
+++ b/tests/sessions/python/async_activity.txtar
@@ -5,7 +5,7 @@ on_event: end (out=8)
 import autokitteh
 
 
-async def on_event(event):
+async def main(event):
     print("on_event: start")
     out = await work()
     print(f"on_event: end ({out=})")

--- a/tests/sessions/python/async_handler.txtar
+++ b/tests/sessions/python/async_handler.txtar
@@ -8,7 +8,8 @@ import autokitteh
 @autokitteh.activity
 async def main(event):
     print("on_event: start")
-    out = await work()
+    w = work()
+    out = await w
     print(f"on_event: end ({out=})")
 
 

--- a/tests/sessions/python/async_handler.txtar
+++ b/tests/sessions/python/async_handler.txtar
@@ -6,7 +6,7 @@ import autokitteh
 
 
 @autokitteh.activity
-async def on_event(event):
+async def main(event):
     print("on_event: start")
     out = await work()
     print(f"on_event: end ({out=})")

--- a/tests/sessions/python/async_handler.txtar
+++ b/tests/sessions/python/async_handler.txtar
@@ -1,16 +1,17 @@
-START
-ACT
-END
+on_event: start
+work
+on_event: end (out=8)
 -- main.py:main --
 import autokitteh
 
 
-async def main(event):
-    print('START')
-    await act()
-    print('END')
-
-
 @autokitteh.activity
-async def act():
-    print('ACT')
+async def on_event(event):
+    print("on_event: start")
+    out = await work()
+    print(f"on_event: end ({out=})")
+
+
+async def work():
+    print("work")
+    return 8


### PR DESCRIPTION
Add support for async.
- In AST, if function is called after an `await` then use `async_call`
- When back from activity, if function is a coroutine function - wrap the return value is a coroutine

Fixes: ENG-2139