### PR TITLE
ENG-2143 fix: add missing default org id on first login

### DIFF
--- a/internal/backend/auth/authloginhttpsvc/svc.go
+++ b/internal/backend/auth/authloginhttpsvc/svc.go
@@ -273,7 +273,11 @@ func (a *svc) newSuccessLoginHandler(ctx context.Context, ld *loginData) http.Ha
 			return newErrHandler("internal server error", http.StatusInternalServerError)
 		}
 
-		u = u.WithID(uid)
+		u, err = a.Users.Get(authcontext.SetAuthnSystemUser(ctx), uid, "")
+		if err != nil && !errors.Is(err, sdkerrors.ErrNotFound) {
+			sl.With("err", err).Errorf("failed getting user after create: %v", err)
+			return newErrHandler("internal server error", http.StatusInternalServerError)
+		}
 
 		sl = sl.With("user_id", uid)
 

--- a/internal/backend/auth/authloginhttpsvc/svc.go
+++ b/internal/backend/auth/authloginhttpsvc/svc.go
@@ -274,7 +274,7 @@ func (a *svc) newSuccessLoginHandler(ctx context.Context, ld *loginData) http.Ha
 		}
 
 		u, err = a.Users.Get(authcontext.SetAuthnSystemUser(ctx), uid, "")
-		if err != nil && !errors.Is(err, sdkerrors.ErrNotFound) {
+		if err != nil {
 			sl.With("err", err).Errorf("failed getting user after create: %v", err)
 			return newErrHandler("internal server error", http.StatusInternalServerError)
 		}

--- a/internal/backend/auth/authloginhttpsvc/svc_test.go
+++ b/internal/backend/auth/authloginhttpsvc/svc_test.go
@@ -75,7 +75,7 @@ func TestNewSuccessLoginHandlerImmediate(t *testing.T) {
 			users.Users[testUser.ID()],
 		)
 	}
-	assertCounts(1, 0, 1)
+	assertCounts(1, 0, 2)
 
 	// user already exists and is active.
 	users.Reset(testUser)


### PR DESCRIPTION
when user logs it initially to they system, a default org id is created for it, but we don't return it in create user method so the user object in the session is partial
this change fetches the created user from db after create making sure it has everything.
on subsequent calls the full user object is fetched anyway so the issue doesn't occur again