### PR TITLE
fix: allow disable workflow executor poller

### DIFF
--- a/internal/backend/workflowexecutor/enterprise_executor.go
+++ b/internal/backend/workflowexecutor/enterprise_executor.go
@@ -28,6 +28,7 @@ var (
 	Configs = configset.Set[Config]{
 		Default: &Config{
 			MaxConcurrentWorkflows: 1,
+			WorkerID:               "default-worker",
 		},
 		Test: &Config{
 			WorkerID: "test-worker",

--- a/internal/backend/workflowexecutor/enterprise_executor.go
+++ b/internal/backend/workflowexecutor/enterprise_executor.go
@@ -22,16 +22,22 @@ type Config struct {
 	MaxConcurrentWorkflows int                           `koanf:"max_concurrent_workflows"`
 	WorkerID               string                        `koanf:"worker_id"`
 	SessionWorkflow        temporalclient.WorkflowConfig `koanf:"session_workflow"`
+	EnablePoller           bool                          `koanf:"enable_poller"`
 }
 
 var (
 	Configs = configset.Set[Config]{
 		Default: &Config{
 			MaxConcurrentWorkflows: 1,
-			WorkerID:               "default-worker",
+			EnablePoller:           false,
 		},
 		Test: &Config{
-			WorkerID: "test-worker",
+			WorkerID:     "test-worker",
+			EnablePoller: true,
+		},
+		Dev: &Config{
+			MaxConcurrentWorkflows: 10,
+			EnablePoller:           true,
 		},
 	}
 )
@@ -59,6 +65,14 @@ func (e *executor) WorkflowQueue() string {
 
 // Start implements WorkflowResourcesManager.
 func (e *executor) Start(ctx context.Context) error {
+	if !e.cfg.EnablePoller {
+		e.l.Info("Workflow executor polling is disabled, skipping start")
+		return nil
+	}
+
+	if e.cfg.WorkerID == "" {
+		return errors.New("worker_id is required")
+	}
 	inProgress, err := e.svcs.DB.CountInProgressWorkflowExecutionRequests(ctx, e.cfg.WorkerID)
 	if err != nil {
 		return err
@@ -75,9 +89,6 @@ func (e *executor) Stop(ctx context.Context) error {
 }
 
 func New(svcs Svcs, l *zap.Logger, cfg *Config) (*executor, error) {
-	if cfg.WorkerID == "" {
-		return nil, errors.New("worker_id is required")
-	}
 
 	sampledLogger := l.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 		return zapcore.NewSamplerWithOptions(core, time.Second, 1, 0)

--- a/internal/backend/workflowexecutor/enterprise_executor.go
+++ b/internal/backend/workflowexecutor/enterprise_executor.go
@@ -38,6 +38,7 @@ var (
 		Dev: &Config{
 			MaxConcurrentWorkflows: 10,
 			EnablePoller:           true,
+			WorkerID:               "dev-worker",
 		},
 	}
 )

--- a/internal/backend/workflowexecutor/enterprise_executor.go
+++ b/internal/backend/workflowexecutor/enterprise_executor.go
@@ -73,6 +73,7 @@ func (e *executor) Start(ctx context.Context) error {
 	if e.cfg.WorkerID == "" {
 		return errors.New("worker_id is required")
 	}
+
 	inProgress, err := e.svcs.DB.CountInProgressWorkflowExecutionRequests(ctx, e.cfg.WorkerID)
 	if err != nil {
 		return err


### PR DESCRIPTION
Allow disabling poller so we can have servers that only push requests and others that consume the requests