### PR TITLE
feat(ENG-2158): add metrics to workflow executor

### DIFF
--- a/internal/backend/db/dbgorm/workflow_execution_request_enterprise.go
+++ b/internal/backend/db/dbgorm/workflow_execution_request_enterprise.go
@@ -62,6 +62,7 @@ func (gdb *gormdb) GetWorkflowExecutionRequests(ctx context.Context, workerID st
 			SessionID:  sdktypes.NewIDFromUUID[sdktypes.SessionID](request.SessionID),
 			Args:       args,
 			Memo:       memo,
+			Status:     request.Status,
 		}
 	}
 

--- a/internal/backend/db/dbinterface_enterprise.go
+++ b/internal/backend/db/dbinterface_enterprise.go
@@ -14,6 +14,7 @@ type WorkflowExecutionRequest struct {
 	WorkflowID string
 	Args       any
 	Memo       map[string]string
+	Status     string
 }
 
 type DB interface {

--- a/internal/backend/telemetry/helpers.go
+++ b/internal/backend/telemetry/helpers.go
@@ -13,3 +13,7 @@ func NewCounter(name string, description string) (metric.Int64Counter, error) {
 func NewHistogram(name string, description string) (metric.Int64Histogram, error) {
 	return M().Int64Histogram(name, metric.WithDescription(description))
 }
+
+func NewGauge(name, description string) (metric.Float64Gauge, error) {
+	return M().Float64Gauge(name, metric.WithDescription(description))
+}

--- a/internal/backend/workflowexecutor/enterprise_executor.go
+++ b/internal/backend/workflowexecutor/enterprise_executor.go
@@ -155,7 +155,7 @@ func (e *executor) startPoller(ctx context.Context) {
 func (e *executor) NotifyDone(ctx context.Context, id string) error {
 	e.inProgressWorkflowsCount.Add(-1)
 
-	e.metrics.DecrementActivedWorkflows(ctx)
+	e.metrics.DecrementActiveWorkflows(ctx)
 
 	if err := e.svcs.DB.UpdateRequestStatus(ctx, id, "done"); err != nil {
 		e.l.Error("Failed to update workflow execution request status", zap.Error(err), zap.String("workflow_id", id))

--- a/internal/backend/workflowexecutor/enterprise_executor.go
+++ b/internal/backend/workflowexecutor/enterprise_executor.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/configset"
@@ -54,10 +55,11 @@ type executor struct {
 
 	stopChannel chan struct{}
 
-	inProgressWorkflowsCount int64
+	inProgressWorkflowsCount atomic.Int64
 	cfg                      *Config
 
 	executeLock sync.Mutex
+	metrics     *metrics
 }
 
 func (e *executor) WorkflowQueue() string {
@@ -79,8 +81,8 @@ func (e *executor) Start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	e.inProgressWorkflowsCount = inProgress
-	e.l.Info("Starting workflow executor", zap.Int64("in_progress_workflows", e.inProgressWorkflowsCount))
+	e.inProgressWorkflowsCount.Store(inProgress)
+	e.l.Info(fmt.Sprintf("Starting workflow executor. in_progress_workflows: %d", inProgress))
 	e.startPoller(ctx)
 	return nil
 }
@@ -91,7 +93,6 @@ func (e *executor) Stop(ctx context.Context) error {
 }
 
 func New(svcs Svcs, l *zap.Logger, cfg *Config) (*executor, error) {
-
 	sampledLogger := l.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 		return zapcore.NewSamplerWithOptions(core, time.Second, 1, 0)
 	}))
@@ -103,22 +104,31 @@ func New(svcs Svcs, l *zap.Logger, cfg *Config) (*executor, error) {
 		stopChannel:   make(chan struct{}, 1),
 		cfg:           cfg,
 		executeLock:   sync.Mutex{},
+		metrics:       newMetrics(cfg.WorkerID),
 	}
 
 	return e, nil
 }
 
-func (e *executor) availableSlots() int {
-	return e.maxConcurrent - int(e.inProgressWorkflowsCount)
+func (e *executor) availableSlots(ctx context.Context) int {
+	active := int(e.inProgressWorkflowsCount.Load())
+	max := e.maxConcurrent
+	load := (float64(active) * 100.0) / float64(max)
+	e.metrics.SetWorkerLoad(ctx, load)
+	return max - active
 }
 
 func (e *executor) Execute(ctx context.Context, sessionID sdktypes.SessionID, args any, memo map[string]string) error {
-	return e.svcs.DB.CreateWorkflowExecutionRequest(ctx, db.WorkflowExecutionRequest{
+	if err := e.svcs.DB.CreateWorkflowExecutionRequest(ctx, db.WorkflowExecutionRequest{
 		SessionID:  sessionID,
 		WorkflowID: workflowID(sessionID),
 		Args:       args,
 		Memo:       memo,
-	})
+	}); err != nil {
+		return err
+	}
+	e.metrics.IncrementQueuedWorkflows(ctx)
+	return nil
 }
 
 func (e *executor) startPoller(ctx context.Context) {
@@ -143,11 +153,15 @@ func (e *executor) startPoller(ctx context.Context) {
 }
 
 func (e *executor) NotifyDone(ctx context.Context, id string) error {
-	e.inProgressWorkflowsCount--
+	e.inProgressWorkflowsCount.Add(-1)
+
+	e.metrics.DecrementActivedWorkflows(ctx)
+
 	if err := e.svcs.DB.UpdateRequestStatus(ctx, id, "done"); err != nil {
 		e.l.Error("Failed to update workflow execution request status", zap.Error(err), zap.String("workflow_id", id))
 	}
-	e.l.Info(fmt.Sprintf("Active workflows: %d out of %d", e.inProgressWorkflowsCount, e.maxConcurrent))
+
+	e.l.Info(fmt.Sprintf("Workflow Done. Active workflows: %d out of %d", e.inProgressWorkflowsCount.Load(), e.maxConcurrent))
 	return nil
 }
 
@@ -155,7 +169,7 @@ func (e *executor) runOnce(ctx context.Context) {
 	e.executeLock.Lock()
 	defer e.executeLock.Unlock()
 
-	availableSlots := e.availableSlots()
+	availableSlots := e.availableSlots(ctx)
 	if availableSlots <= 0 {
 		e.sampledLogger.Info("Max concurrent workflows reached, waiting for free slots", zap.Int("MaxConcurrent", e.maxConcurrent))
 		return
@@ -174,11 +188,20 @@ func (e *executor) runOnce(ctx context.Context) {
 			continue
 		}
 
+		if job.Status == "pending" {
+			// only decrement the queued workflows gauge if the job was pending before
+			// if it was already in progress, a worker was stuck and we retry it
+			e.metrics.DecrementQueuedWorkflows(ctx)
+		} else {
+			// if status wasn't pending before, it means we are retrying a workflow
+			e.metrics.IncrementRetriedWorkflowsCounter(ctx)
+		}
+
 		if err := e.svcs.DB.UpdateRequestStatus(ctx, job.WorkflowID, "in_progress"); err != nil {
 			e.l.Error("Failed to delete workflow execution request", zap.Error(err), zap.String("session_id", job.SessionID.String()))
 		}
 
-		e.sampledLogger.Info(fmt.Sprintf("Active workflows: %d out of %d", e.inProgressWorkflowsCount, e.maxConcurrent))
+		e.sampledLogger.Info(fmt.Sprintf("Workflow Started. Active workflows: %d out of %d", e.inProgressWorkflowsCount.Load(), e.maxConcurrent))
 	}
 }
 
@@ -187,7 +210,9 @@ func (e *executor) executeAndIncrement(ctx context.Context, sessionID sdktypes.S
 	if err != nil {
 		return err
 	}
-	e.inProgressWorkflowsCount++
+	e.inProgressWorkflowsCount.Add(1)
+
+	e.metrics.IncrementActiveWorkflows(ctx)
 
 	return nil
 }

--- a/internal/backend/workflowexecutor/enterprise_executor.go
+++ b/internal/backend/workflowexecutor/enterprise_executor.go
@@ -161,7 +161,7 @@ func (e *executor) NotifyDone(ctx context.Context, id string) error {
 		e.l.Error("Failed to update workflow execution request status", zap.Error(err), zap.String("workflow_id", id))
 	}
 
-	e.l.Info(fmt.Sprintf("Workflow Done. Active workflows: %d out of %d", e.inProgressWorkflowsCount.Load(), e.maxConcurrent))
+	e.l.Info(fmt.Sprintf("Workflow Done %s. Active workflows: %d out of %d", id, e.inProgressWorkflowsCount.Load(), e.maxConcurrent), zap.String("session_id", id))
 	return nil
 }
 

--- a/internal/backend/workflowexecutor/enterprise_executor_test.go
+++ b/internal/backend/workflowexecutor/enterprise_executor_test.go
@@ -84,7 +84,7 @@ func TestRunOnceOneJob(t *testing.T) {
 	assert.Equal(t, mockTemporal.executeWorkflowName, e.WorkflowSessionName(), "Expected workflow name to match")
 
 	// Verify executor
-	assert.Equal(t, e.inProgressWorkflowsCount, int64(1), "Expected in-progress workflows count to be incremented")
+	assert.Equal(t, e.inProgressWorkflowsCount.Load(), int64(1), "Expected in-progress workflows count to be incremented")
 
 	// Test we don't take more jobs if we have no slots available
 	e.runOnce(t.Context())
@@ -95,11 +95,11 @@ func TestRunOnceOneJob(t *testing.T) {
 	e.runOnce(t.Context())
 	assert.Equal(t, mdb.getRequestCount, 2, "Expected one request to be made")
 
-	assert.Equal(t, e.inProgressWorkflowsCount, int64(2), "Expected in-progress workflows count to be incremented")
+	assert.Equal(t, e.inProgressWorkflowsCount.Load(), int64(2), "Expected in-progress workflows count to be incremented")
 
 	err := e.NotifyDone(t.Context(), "test-workflow")
 	assert.NilError(t, err, "Expected NotifyDone to succeed")
-	assert.Equal(t, e.inProgressWorkflowsCount, int64(1), "Expected in-progress workflows count to be decremented")
+	assert.Equal(t, e.inProgressWorkflowsCount.Load(), int64(1), "Expected in-progress workflows count to be decremented")
 }
 
 // Utilities and mocks for testing

--- a/internal/backend/workflowexecutor/metrics.go
+++ b/internal/backend/workflowexecutor/metrics.go
@@ -42,7 +42,7 @@ func (m *metrics) DecrementQueuedWorkflows(ctx context.Context) {
 func (m *metrics) IncrementActiveWorkflows(ctx context.Context) {
 	m.activeWorkflowsGauge.Add(ctx, 1, metric.WithAttributes(attribute.String("worker_id", m.workerID)))
 }
-func (m *metrics) DecrementActivedWorkflows(ctx context.Context) {
+func (m *metrics) DecrementActiveWorkflows(ctx context.Context) {
 	m.activeWorkflowsGauge.Add(ctx, -1, metric.WithAttributes(attribute.String("worker_id", m.workerID)))
 }
 

--- a/internal/backend/workflowexecutor/metrics.go
+++ b/internal/backend/workflowexecutor/metrics.go
@@ -1,0 +1,55 @@
+//go:build enterprise
+// +build enterprise
+
+package workflowexecutor
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"go.autokitteh.dev/autokitteh/internal/backend/telemetry"
+	"go.autokitteh.dev/autokitteh/internal/kittehs"
+)
+
+type metrics struct {
+	workerID                      string
+	queuedWorkflowsGauge          metric.Int64UpDownCounter
+	activeWorkflowsGauge          metric.Int64UpDownCounter
+	retriedWorkflowRequestCounter metric.Int64Counter
+	workerLoadGauge               metric.Float64Gauge
+}
+
+func newMetrics(workerID string) *metrics {
+
+	return &metrics{
+		workerID:                      workerID,
+		queuedWorkflowsGauge:          kittehs.Must1(telemetry.NewUpDownCounter("workflow_executor.queued", "Queued workflows gauge")),
+		activeWorkflowsGauge:          kittehs.Must1(telemetry.NewUpDownCounter("workflow_executor.active_workflows", "Active workflows gauge")),
+		retriedWorkflowRequestCounter: kittehs.Must1(telemetry.NewCounter("workflow_executor.retried", "Retried workflows counter")),
+		workerLoadGauge:               kittehs.Must1(telemetry.NewGauge("workflow_executor.load", "Worker load gauge")),
+	}
+}
+
+func (m *metrics) IncrementQueuedWorkflows(ctx context.Context) {
+	m.queuedWorkflowsGauge.Add(ctx, 1, metric.WithAttributes(attribute.String("worker_id", m.workerID)))
+}
+func (m *metrics) DecrementQueuedWorkflows(ctx context.Context) {
+	m.queuedWorkflowsGauge.Add(ctx, -1, metric.WithAttributes(attribute.String("worker_id", m.workerID)))
+}
+
+func (m *metrics) IncrementActiveWorkflows(ctx context.Context) {
+	m.activeWorkflowsGauge.Add(ctx, 1, metric.WithAttributes(attribute.String("worker_id", m.workerID)))
+}
+func (m *metrics) DecrementActivedWorkflows(ctx context.Context) {
+	m.activeWorkflowsGauge.Add(ctx, -1, metric.WithAttributes(attribute.String("worker_id", m.workerID)))
+}
+
+func (m *metrics) IncrementRetriedWorkflowsCounter(ctx context.Context) {
+	m.retriedWorkflowRequestCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("worker_id", m.workerID)))
+}
+
+func (m *metrics) SetWorkerLoad(ctx context.Context, load float64) {
+	m.workerLoadGauge.Record(ctx, load, metric.WithAttributes(attribute.String("worker_id", m.workerID)))
+}

--- a/internal/backend/workflowexecutor/shared.go
+++ b/internal/backend/workflowexecutor/shared.go
@@ -26,7 +26,7 @@ func (e *executor) execute(ctx context.Context, sessionID sdktypes.SessionID, wo
 	if err != nil {
 		return err
 	}
-	e.l.Info("Started workflow", zap.String("workflow_id", r.GetID()), zap.String("workflow_name", e.WorkflowSessionName()))
+	e.l.Info("Started workflow", zap.String("workflow_id", r.GetID()), zap.String("workflow_name", e.WorkflowSessionName()), zap.String("session_id", sessionID.String()))
 
 	return nil
 }


### PR DESCRIPTION
Add the following metrics 

```golang
queuedWorkflowsGauge:          kittehs.Must1(telemetry.NewUpDownCounter("workflow_executor.queued", "Queued workflows gauge")),
activeWorkflowsGauge:          kittehs.Must1(telemetry.NewUpDownCounter("workflow_executor.active_workflows", "Active workflows gauge")),
retriedWorkflowRequestCounter: kittehs.Must1(telemetry.NewCounter("workflow_executor.retried", "Retried workflows counter")),
workerLoadGauge:               kittehs.Must1(telemetry.NewGauge("workflow_executor.load", "Worker load gauge")),
```


fix: added atomic counter instead of counter for active workflows instead of using a lock around inc/dec