### PR TITLE
fix(ENG-2161): executor race condition fix

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/alecthomas/chroma/v2 v2.16.0 h1:QC5ZMizk67+HzxFDjQ4ASjni5kWBTGiigRG1u
 github.com/alecthomas/chroma/v2 v2.16.0/go.mod h1:RVX6AvYm4VfYe/zsk7mjHueLDZor3aWCNE14TFlepBk=
 github.com/alecthomas/go-check-sumtype v0.3.1 h1:u9aUvbGINJxLVXiFvHUlPEaD7VDULsrxJb4Aq31NLkU=
 github.com/alecthomas/go-check-sumtype v0.3.1/go.mod h1:A8TSiN3UPRw3laIgWEUOHHLPa6/r9MtoigdlP5h3K/E=
+github.com/alecthomas/kong v1.9.0 h1:Wgg0ll5Ys7xDnpgYBuBn/wPeLGAuK0NvYmEcisJgrIs=
+github.com/alecthomas/kong v1.9.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/alexkohler/nakedret/v2 v2.0.6 h1:ME3Qef1/KIKr3kWX3nti3hhgNxw6aqN5pZmQiFSsuzQ=

--- a/internal/backend/db/dbgorm/scheme/enterprise_records.go
+++ b/internal/backend/db/dbgorm/scheme/enterprise_records.go
@@ -17,6 +17,7 @@ type WorkflowExecutionRequest struct {
 	AcquiredAt *time.Time
 	AcquiredBy *string `gorm:"index:idx_acquired_by_status"` // worker ID that acquired the request
 
-	Status    string    `gorm:"default:'pending';index:idx_acquired_by_status,where:status='in_progress'"`
-	CreatedAt time.Time `gorm:"default:NOW()"`
+	Status     string    `gorm:"default:'pending';index:idx_acquired_by_status,where:status='in_progress'"`
+	CreatedAt  time.Time `gorm:"default:NOW()"`
+	RetryCount int       `gorm:"default:0"` // Number of times this request has been retried
 }

--- a/internal/backend/db/dbgorm/workflow_execution_request_enterprise.go
+++ b/internal/backend/db/dbgorm/workflow_execution_request_enterprise.go
@@ -40,8 +40,8 @@ func (gdb *gormdb) GetWorkflowExecutionRequests(ctx context.Context, workerID st
 	var requests []scheme.WorkflowExecutionRequest
 	if err := gdb.writer.WithContext(ctx).Model(&scheme.WorkflowExecutionRequest{}).Raw(`
 	UPDATE workflow_execution_requests
-	SET acquired_at = NOW(), acquired_by = $1
-	WHERE session_id IN (SELECT session_id FROM workflow_execution_requests WHERE status = 'pending' OR acquired_at < NOW() - INTERVAL '1 day' LIMIT $2 FOR UPDATE SKIP LOCKED)
+	SET acquired_at = NOW(), acquired_by = $1, status = 'in_progress', retry_count = retry_count + 1
+	WHERE session_id IN (SELECT session_id FROM workflow_execution_requests WHERE status = 'pending' OR (status = 'in_progress' AND acquired_at < NOW() - INTERVAL '1 day') ORDER BY created_at LIMIT $2 FOR UPDATE SKIP LOCKED)
 	RETURNING *;
 	`, workerID, maxRequests).Scan(&requests).Error; err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func (gdb *gormdb) GetWorkflowExecutionRequests(ctx context.Context, workerID st
 			SessionID:  sdktypes.NewIDFromUUID[sdktypes.SessionID](request.SessionID),
 			Args:       args,
 			Memo:       memo,
-			Status:     request.Status,
+			RetryCount: request.RetryCount,
 		}
 	}
 

--- a/internal/backend/db/dbinterface_enterprise.go
+++ b/internal/backend/db/dbinterface_enterprise.go
@@ -14,7 +14,7 @@ type WorkflowExecutionRequest struct {
 	WorkflowID string
 	Args       any
 	Memo       map[string]string
-	Status     string
+	RetryCount int
 }
 
 type DB interface {

--- a/internal/backend/workflowexecutor/enterprise_executor_test.go
+++ b/internal/backend/workflowexecutor/enterprise_executor_test.go
@@ -77,7 +77,6 @@ func TestRunOnceOneJob(t *testing.T) {
 
 	// Verify DB
 	assert.Equal(t, mdb.getRequestCount, 1, "Expected one request to be made")
-	assert.Equal(t, mdb.updateRequestStatusCallCount, 1, "Expected request status to be updated once")
 
 	// Verify Temporal
 	assert.Equal(t, mockTemporal.executeWorkflowCallCount, 1, "Expected workflow to be executed once")
@@ -142,8 +141,6 @@ type mockDB struct {
 		slots    int
 	}
 
-	updateRequestStatusCallCount int
-
 	dbResult func() ([]db.WorkflowExecutionRequest, error)
 }
 
@@ -155,7 +152,6 @@ func (m *mockDB) GetWorkflowExecutionRequests(ctx context.Context, workerID stri
 	return m.dbResult()
 }
 func (m *mockDB) UpdateRequestStatus(ctx context.Context, workflowID string, status string) error {
-	m.updateRequestStatusCallCount++
 	// Mock implementation, just return nil to simulate success
 	return nil
 }

--- a/internal/backend/workflowexecutor/metrics.go
+++ b/internal/backend/workflowexecutor/metrics.go
@@ -33,10 +33,10 @@ func newMetrics(workerID string) *metrics {
 }
 
 func (m *metrics) IncrementQueuedWorkflows(ctx context.Context) {
-	m.queuedWorkflowsGauge.Add(ctx, 1, metric.WithAttributes(attribute.String("worker_id", m.workerID)))
+	m.queuedWorkflowsGauge.Add(ctx, 1)
 }
 func (m *metrics) DecrementQueuedWorkflows(ctx context.Context) {
-	m.queuedWorkflowsGauge.Add(ctx, -1, metric.WithAttributes(attribute.String("worker_id", m.workerID)))
+	m.queuedWorkflowsGauge.Add(ctx, -1)
 }
 
 func (m *metrics) IncrementActiveWorkflows(ctx context.Context) {

--- a/migrations/postgres/enterprise/20250630145151_add-retry-count.sql
+++ b/migrations/postgres/enterprise/20250630145151_add-retry-count.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+-- modify "workflow_execution_requests" table
+ALTER TABLE "workflow_execution_requests" ADD COLUMN "retry_count" bigint NULL DEFAULT 0;
+
+-- +goose Down
+-- reverse: modify "workflow_execution_requests" table
+ALTER TABLE "workflow_execution_requests" DROP COLUMN "retry_count";

--- a/migrations/postgres/enterprise/atlas.sum
+++ b/migrations/postgres/enterprise/atlas.sum
@@ -1,4 +1,4 @@
-h1:jrZFh0ErUeI7R3Ouy5w7V5ZctqeFX/h5C50SkUWZ+So=
+h1:CpDteUU3PiAZ4ZUdS2+YtpvT8FGcUpNAy8Xo0XPkMlc=
 20240704121932_baseline.sql h1:1JS9FYe08Ef0wTpJIeeL4wIqHc8E/RXhuqmTI/FwkzY=
 20240714051207_no-db-user.sql h1:tx0AwepNeeL/XWD74sLRGwisrkNs4lyH/H4BG/663FQ=
 20240727114921_project-not-nil-name.sql h1:ZG3tDLzQSxd81S4BDe/IOMktltkurwyuFwu5gkqQvrA=
@@ -31,3 +31,4 @@ h1:jrZFh0ErUeI7R3Ouy5w7V5ZctqeFX/h5C50SkUWZ+So=
 20250612074534_drop_index_current_state_type.sql h1:qhq0uqipQ1oXTYc9Luz/19rxjS4kvJqMbaEPUet1mDw=
 20250616125426_values.sql h1:r+baS++AzS8rBj9lh5NHR9nUdVJmiQ0B65S0FWAOVf0=
 20250624052617_workflow-throtelling.sql h1:nmqIHXI66X6Ia08uTgZ5ZBz4wi4H0Hi5L78/pw3jUDs=
+20250630145151_add-retry-count.sql h1:YFExaaKwdgR7Sa12OCfrbuSlouU1BbKQQ6CeDFSNLAA=


### PR DESCRIPTION
incorrect skip locked usage, 

rows in status pending were acquired twice in multi instance environments, because they were fetched but kept in status pending until they were executed by the runner

this change set the status to in_progress atomically when querying instead of later on in code
assuring same row won't be fetched twice if it pending