### PR TITLE
fix(ENG-2176): cancelled workflows did not notify on end

### DIFF
--- a/internal/backend/db/dbgorm/workflow_execution_request_enterprise.go
+++ b/internal/backend/db/dbgorm/workflow_execution_request_enterprise.go
@@ -78,6 +78,17 @@ func (gdb *gormdb) CountInProgressWorkflowExecutionRequests(ctx context.Context,
 	}
 	return count, nil
 }
+func (gdb *gormdb) GetInProgressWorkflowIds(ctx context.Context, workerID string) ([]string, error) {
+	var workflowIds []string
+	if err := gdb.writer.WithContext(ctx).Model(&scheme.WorkflowExecutionRequest{}).
+		Where("acquired_by = ? AND status = 'in_progress'", workerID).
+		Select("workflow_id").
+		Find(&workflowIds).
+		Error; err != nil {
+		return nil, err
+	}
+	return workflowIds, nil
+}
 
 func (gdb *gormdb) UpdateRequestStatus(ctx context.Context, workflowID string, status string) (bool, error) {
 	result := gdb.writer.WithContext(ctx).Model(&scheme.WorkflowExecutionRequest{}).

--- a/internal/backend/db/dbgorm/workflow_execution_request_enterprise.go
+++ b/internal/backend/db/dbgorm/workflow_execution_request_enterprise.go
@@ -90,7 +90,7 @@ func (gdb *gormdb) GetInProgressWorkflowIds(ctx context.Context, workerID string
 	return workflowIds, nil
 }
 
-func (gdb *gormdb) UpdateRequestStatus(ctx context.Context, workflowID string, status string) (bool, error) {
+func (gdb *gormdb) UpdateWorkflowExecutionRequestStatus(ctx context.Context, workflowID string, status string) (bool, error) {
 	result := gdb.writer.WithContext(ctx).Model(&scheme.WorkflowExecutionRequest{}).
 		Where("workflow_id = ?", workflowID).
 		Where("status != ?", status).

--- a/internal/backend/db/dbgorm/workflow_execution_request_enterprise.go
+++ b/internal/backend/db/dbgorm/workflow_execution_request_enterprise.go
@@ -78,16 +78,16 @@ func (gdb *gormdb) CountInProgressWorkflowExecutionRequests(ctx context.Context,
 	}
 	return count, nil
 }
-func (gdb *gormdb) GetInProgressWorkflowIds(ctx context.Context, workerID string) ([]string, error) {
-	var workflowIds []string
+func (gdb *gormdb) GetInProgressWorkflowIDs(ctx context.Context, workerID string) ([]string, error) {
+	var workflowIDs []string
 	if err := gdb.writer.WithContext(ctx).Model(&scheme.WorkflowExecutionRequest{}).
 		Where("acquired_by = ? AND status = 'in_progress'", workerID).
 		Select("workflow_id").
-		Find(&workflowIds).
+		Find(&workflowIDs).
 		Error; err != nil {
 		return nil, err
 	}
-	return workflowIds, nil
+	return workflowIDs, nil
 }
 
 func (gdb *gormdb) UpdateWorkflowExecutionRequestStatus(ctx context.Context, workflowID string, status string) (bool, error) {

--- a/internal/backend/db/dbgorm/workflow_execution_request_enterprise.go
+++ b/internal/backend/db/dbgorm/workflow_execution_request_enterprise.go
@@ -79,8 +79,15 @@ func (gdb *gormdb) CountInProgressWorkflowExecutionRequests(ctx context.Context,
 	return count, nil
 }
 
-func (gdb *gormdb) UpdateRequestStatus(ctx context.Context, workflowID string, status string) error {
-	return gdb.writer.WithContext(ctx).Model(&scheme.WorkflowExecutionRequest{}).
+func (gdb *gormdb) UpdateRequestStatus(ctx context.Context, workflowID string, status string) (bool, error) {
+	result := gdb.writer.WithContext(ctx).Model(&scheme.WorkflowExecutionRequest{}).
 		Where("workflow_id = ?", workflowID).
-		Update("status", status).Error
+		Where("status != ?", status).
+		Update("status", status)
+
+	if result.Error != nil {
+		return false, result.Error
+	}
+
+	return result.RowsAffected > 0, nil
 }

--- a/internal/backend/db/dbinterface_enterprise.go
+++ b/internal/backend/db/dbinterface_enterprise.go
@@ -23,7 +23,7 @@ type DB interface {
 	// WorkflowExecutionRequest
 	CreateWorkflowExecutionRequest(ctx context.Context, request WorkflowExecutionRequest) error
 	GetWorkflowExecutionRequests(ctx context.Context, workerID string, maxRequests int) ([]WorkflowExecutionRequest, error)
-	UpdateRequestStatus(ctx context.Context, workflowID string, status string) (bool, error)
+	UpdateWorkflowExecutionRequestStatus(ctx context.Context, workflowID string, status string) (bool, error)
 	CountInProgressWorkflowExecutionRequests(ctx context.Context, workerID string) (int64, error)
 	GetInProgressWorkflowIds(ctx context.Context, workerID string) ([]string, error)
 }

--- a/internal/backend/db/dbinterface_enterprise.go
+++ b/internal/backend/db/dbinterface_enterprise.go
@@ -23,6 +23,6 @@ type DB interface {
 	// WorkflowExecutionRequest
 	CreateWorkflowExecutionRequest(ctx context.Context, request WorkflowExecutionRequest) error
 	GetWorkflowExecutionRequests(ctx context.Context, workerID string, maxRequests int) ([]WorkflowExecutionRequest, error)
-	UpdateRequestStatus(ctx context.Context, workflowID string, status string) error
+	UpdateRequestStatus(ctx context.Context, workflowID string, status string) (bool, error)
 	CountInProgressWorkflowExecutionRequests(ctx context.Context, workerID string) (int64, error)
 }

--- a/internal/backend/db/dbinterface_enterprise.go
+++ b/internal/backend/db/dbinterface_enterprise.go
@@ -25,5 +25,5 @@ type DB interface {
 	GetWorkflowExecutionRequests(ctx context.Context, workerID string, maxRequests int) ([]WorkflowExecutionRequest, error)
 	UpdateWorkflowExecutionRequestStatus(ctx context.Context, workflowID string, status string) (bool, error)
 	CountInProgressWorkflowExecutionRequests(ctx context.Context, workerID string) (int64, error)
-	GetInProgressWorkflowIds(ctx context.Context, workerID string) ([]string, error)
+	GetInProgressWorkflowIDs(ctx context.Context, workerID string) ([]string, error)
 }

--- a/internal/backend/db/dbinterface_enterprise.go
+++ b/internal/backend/db/dbinterface_enterprise.go
@@ -25,4 +25,5 @@ type DB interface {
 	GetWorkflowExecutionRequests(ctx context.Context, workerID string, maxRequests int) ([]WorkflowExecutionRequest, error)
 	UpdateRequestStatus(ctx context.Context, workflowID string, status string) (bool, error)
 	CountInProgressWorkflowExecutionRequests(ctx context.Context, workerID string) (int64, error)
+	GetInProgressWorkflowIds(ctx context.Context, workerID string) ([]string, error)
 }

--- a/internal/backend/sessions/sessionworkflows/activities.go
+++ b/internal/backend/sessions/sessionworkflows/activities.go
@@ -40,7 +40,7 @@ const (
 func (ws *workflows) registerActivities() {
 	// Utils Worker activities
 
-	// We need to registrer the terminate workflow activity on the utils worker,
+	// We need to register the terminate workflow activity on the utils worker,
 	// since it is used to terminate workflows and should not be registered on the sessions worker.
 	ws.utilsWorker.RegisterActivityWithOptions(
 		ws.updateSessionStateActivity,

--- a/internal/backend/sessions/sessionworkflows/workflows.go
+++ b/internal/backend/sessions/sessionworkflows/workflows.go
@@ -28,6 +28,7 @@ import (
 const (
 	terminateSessionWorkflowName        = "terminate_session"
 	delayedTerminateSessionWorkflowName = "delayed_terminate_session"
+	utilsWorkerQueue                    = "utils"
 )
 
 type StartWorkflowOptions struct{}
@@ -46,12 +47,13 @@ type sessionWorkflowParams struct {
 }
 
 type workflows struct {
-	l        *zap.Logger
-	cfg      Config
-	worker   worker.Worker
-	svcs     *sessionsvcs.Svcs
-	sessions sdkservices.Sessions
-	calls    sessioncalls.Calls
+	l              *zap.Logger
+	cfg            Config
+	sessionsWorker worker.Worker
+	utilsWorker    worker.Worker
+	svcs           *sessionsvcs.Svcs
+	sessions       sdkservices.Sessions
+	calls          sessioncalls.Calls
 }
 
 func workflowID(sessionID sdktypes.SessionID) string { return sessionID.String() }
@@ -68,30 +70,35 @@ func New(
 }
 
 func (ws *workflows) StartWorkers(ctx context.Context) error {
-	ws.worker = temporalclient.NewWorker(ws.l.Named("sessionworkflowsworker"), ws.svcs.Temporal.TemporalClient(), ws.svcs.WorkflowExecutor.WorkflowQueue(), ws.cfg.Worker)
-	if ws.worker == nil {
+	ws.sessionsWorker = temporalclient.NewWorker(ws.l.Named("sessionworkflowsworker"), ws.svcs.Temporal.TemporalClient(), ws.svcs.WorkflowExecutor.WorkflowQueue(), ws.cfg.Worker)
+	if ws.sessionsWorker == nil {
 		return nil
 	}
 
-	ws.worker.RegisterWorkflowWithOptions(
+	ws.sessionsWorker.RegisterWorkflowWithOptions(
 		ws.sessionWorkflow,
 		workflow.RegisterOptions{Name: ws.svcs.WorkflowExecutor.WorkflowSessionName()},
 	)
 
+	ws.utilsWorker = temporalclient.NewWorker(ws.l.Named("utilsworker"), ws.svcs.Temporal.TemporalClient(), utilsWorkerQueue, ws.cfg.Worker)
+
 	// Legacy termination workflow, using explicit parameters instead of a struct.
-	ws.worker.RegisterWorkflowWithOptions(
+	ws.utilsWorker.RegisterWorkflowWithOptions(
 		ws.legacyTerminateSessionWorkflow,
 		workflow.RegisterOptions{Name: terminateSessionWorkflowName},
 	)
 
-	ws.worker.RegisterWorkflowWithOptions(
+	ws.utilsWorker.RegisterWorkflowWithOptions(
 		ws.terminateSessionWorkflow,
 		workflow.RegisterOptions{Name: delayedTerminateSessionWorkflowName},
 	)
 
 	ws.registerActivities()
 
-	return ws.worker.Start()
+	if err := ws.sessionsWorker.Start(); err != nil {
+		return err
+	}
+	return ws.utilsWorker.Start()
 }
 
 func memo(session sdktypes.Session, oid sdktypes.OrgID) map[string]string {
@@ -191,6 +198,26 @@ func (ws *workflows) sessionWorkflow(wctx workflow.Context, params sessionWorkfl
 		zap.String("parent_session_id", parentSessionID.String()),
 	)
 
+	didNotifyDone := false
+
+	defer func() {
+		if errors.Is(wctx.Err(), workflow.ErrCanceled) {
+			if didNotifyDone {
+				return
+			}
+
+			didNotifyDone = true
+
+			l.Info("session workflow canceled, notifying workflow ended", zap.String("session_id", sid.String()))
+			dwctx, done := workflow.NewDisconnectedContext(wctx)
+			defer done()
+			err := workflow.ExecuteActivity(dwctx, notifyWorkflowEndedActivity, session.ID()).Get(dwctx, nil)
+			if err != nil {
+				l.Info("notify workflow ended activity failed", zap.Error(err))
+			}
+		}
+	}()
+
 	eventTime := struct {
 		createdAt time.Time
 		valid     bool
@@ -247,8 +274,6 @@ func (ws *workflows) sessionWorkflow(wctx workflow.Context, params sessionWorkfl
 	// from this point on we should not be doing anything really that should be cancelled.
 	// the original wctx might have been cancelled, so we work with a disconnected context
 	// to avoid any belated non-timely cancellations.
-	dwctx, done := workflow.NewDisconnectedContext(wctx)
-	defer done()
 
 	sessionDurationHistogram.Record(metricsCtx, duration.Milliseconds(),
 		metric.WithAttributes(attribute.Bool("replay", isReplaying), attribute.Bool("success", err == nil)))
@@ -265,6 +290,9 @@ func (ws *workflows) sessionWorkflow(wctx workflow.Context, params sessionWorkfl
 	}
 
 	workflowErr := err
+
+	dwctx, done := workflow.NewDisconnectedContext(wctx)
+	defer done()
 
 	if err != nil {
 		l := l.With(zap.Error(err))
@@ -321,9 +349,12 @@ func (ws *workflows) sessionWorkflow(wctx workflow.Context, params sessionWorkfl
 	}
 
 	_ = workflow.ExecuteActivity(wctx, deactivateDrainedDeploymentActivityName, session.DeploymentID()).Get(wctx, nil)
-	// context might have been canceled, create a disconnected one.
-	_ = workflow.ExecuteActivity(dwctx, notifyWorkflowEndedActivity, session.ID()).Get(wctx, nil)
 
+	err = workflow.ExecuteActivity(dwctx, notifyWorkflowEndedActivity, session.ID()).Get(dwctx, nil)
+	if err != nil {
+		ws.l.Info("notify workflow ended activity failed", zap.Error(err))
+	}
+	didNotifyDone = true
 	return workflowErr
 }
 
@@ -399,42 +430,6 @@ func (ws *workflows) StopWorkflow(ctx context.Context, sessionID sdktypes.Sessio
 		}
 
 		return err
-	}
-
-	if !force {
-		// This is not a forced stop, we do not need to wait for the workflow to actually stop.
-		return nil
-	}
-
-	// run the termination in a separate workflow to avoid having the workflow terminated but not updated in
-	// the db if the caller croaks.
-	r, err := ws.svcs.Temporal.TemporalClient().ExecuteWorkflow(
-		ctx,
-		ws.cfg.TerminationWorkflow.ToStartWorkflowOptions(
-			ws.svcs.WorkflowExecutor.WorkflowQueue(),
-			"terminate_"+wid,
-			fmt.Sprintf("stop %v", sessionID),
-			map[string]string{
-				"process_id":   fixtures.ProcessID(),
-				"session_id":   sessionID.String(),
-				"session_uuid": sessionID.UUIDValue().String(),
-			},
-		),
-		delayedTerminateSessionWorkflowName,
-		&terminateSessionWorkflowParams{
-			SessionID: sessionID,
-			Reason:    reason,
-			Delay:     forceDelay,
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("execute terminate workflow: %w", err)
-	}
-
-	if forceDelay == 0 {
-		// wait for the deed to be done, as the termination workflow itself should not block on anything,
-		// this should be quick.
-		return r.Get(ctx, nil)
 	}
 
 	return nil

--- a/internal/backend/sessions/sessionworkflows/workflows.go
+++ b/internal/backend/sessions/sessionworkflows/workflows.go
@@ -322,9 +322,7 @@ func (ws *workflows) sessionWorkflow(wctx workflow.Context, params sessionWorkfl
 
 	_ = workflow.ExecuteActivity(wctx, deactivateDrainedDeploymentActivityName, session.DeploymentID()).Get(wctx, nil)
 	// context might have been canceled, create a disconnected one.
-	wctx, cancel := workflow.NewDisconnectedContext(wctx)
-	defer cancel()
-	_ = workflow.ExecuteActivity(wctx, notifyWorkflowEndedActivity, session.ID()).Get(wctx, nil)
+	_ = workflow.ExecuteActivity(dwctx, notifyWorkflowEndedActivity, session.ID()).Get(wctx, nil)
 
 	return workflowErr
 }

--- a/internal/backend/sessions/sessionworkflows/workflows.go
+++ b/internal/backend/sessions/sessionworkflows/workflows.go
@@ -321,7 +321,10 @@ func (ws *workflows) sessionWorkflow(wctx workflow.Context, params sessionWorkfl
 	}
 
 	_ = workflow.ExecuteActivity(wctx, deactivateDrainedDeploymentActivityName, session.DeploymentID()).Get(wctx, nil)
+	// context might have been canceled, create a disconnected one.
+	wctx, cancel := workflow.NewDisconnectedContext(wctx)
 	_ = workflow.ExecuteActivity(wctx, notifyWorkflowEndedActivity, session.ID()).Get(wctx, nil)
+	cancel()
 
 	return workflowErr
 }

--- a/internal/backend/sessions/sessionworkflows/workflows.go
+++ b/internal/backend/sessions/sessionworkflows/workflows.go
@@ -323,8 +323,8 @@ func (ws *workflows) sessionWorkflow(wctx workflow.Context, params sessionWorkfl
 	_ = workflow.ExecuteActivity(wctx, deactivateDrainedDeploymentActivityName, session.DeploymentID()).Get(wctx, nil)
 	// context might have been canceled, create a disconnected one.
 	wctx, cancel := workflow.NewDisconnectedContext(wctx)
+	defer cancel()
 	_ = workflow.ExecuteActivity(wctx, notifyWorkflowEndedActivity, session.ID()).Get(wctx, nil)
-	cancel()
 
 	return workflowErr
 }

--- a/internal/backend/workflowexecutor/enterprise_executor.go
+++ b/internal/backend/workflowexecutor/enterprise_executor.go
@@ -21,21 +21,21 @@ import (
 )
 
 type Config struct {
-	MaxConcurrentWorkflows  int                           `koanf:"max_concurrent_workflows"`
-	WorkerID                string                        `koanf:"worker_id"`
-	SessionWorkflow         temporalclient.WorkflowConfig `koanf:"session_workflow"`
-	EnablePoller            bool                          `koanf:"enable_poller"`
-	PollerIntervalMS        time.Duration                 `koanf:"poller_interval_ms"`
-	ReconcileLoopIntervalMS time.Duration                 `koanf:"reconcile_loop_interval_ms"`
+	MaxConcurrentWorkflows int                           `koanf:"max_concurrent_workflows"`
+	WorkerID               string                        `koanf:"worker_id"`
+	SessionWorkflow        temporalclient.WorkflowConfig `koanf:"session_workflow"`
+	EnablePoller           bool                          `koanf:"enable_poller"`
+	PollerIntervalMS       time.Duration                 `koanf:"poller_interval_ms"`
+	ReconcileLoopInterval  time.Duration                 `koanf:"reconcile_loop_interval"`
 }
 
 var (
 	Configs = configset.Set[Config]{
 		Default: &Config{
-			MaxConcurrentWorkflows:  1,
-			EnablePoller:            false,
-			PollerIntervalMS:        100 * time.Millisecond,
-			ReconcileLoopIntervalMS: 1 * time.Hour,
+			MaxConcurrentWorkflows: 1,
+			EnablePoller:           false,
+			PollerIntervalMS:       100 * time.Millisecond,
+			ReconcileLoopInterval:  1 * time.Hour,
 		},
 		Test: &Config{
 			WorkerID:     "test-worker",
@@ -101,7 +101,7 @@ func (e *executor) startReconcileLoop(ctx context.Context) {
 		e.l.Info("Starting workflow executor reconcile loop")
 		for {
 			select {
-			case <-time.After(e.cfg.ReconcileLoopIntervalMS):
+			case <-time.After(e.cfg.ReconcileLoopInterval):
 				e.reconcile(ctx)
 			case <-e.stopChannel:
 				e.l.Info("Stopping workflow executor reconcile loop")

--- a/internal/backend/workflowexecutor/enterprise_executor.go
+++ b/internal/backend/workflowexecutor/enterprise_executor.go
@@ -82,7 +82,7 @@ func (e *executor) Start(ctx context.Context) error {
 		return errors.New("worker_id is required")
 	}
 
-	// we do this synchronus just to ensure everything is aligned on start
+	// we do this synchronous just to ensure everything is aligned on start
 	e.reconcile(ctx)
 	e.startReconcileLoop(ctx)
 

--- a/internal/backend/workflowexecutor/enterprise_executor.go
+++ b/internal/backend/workflowexecutor/enterprise_executor.go
@@ -114,7 +114,7 @@ func (e *executor) startReconcileLoop(ctx context.Context) {
 }
 
 func (e *executor) reconcile(ctx context.Context) error {
-	workflowIds, err := e.svcs.DB.GetInProgressWorkflowIds(ctx, e.cfg.WorkerID)
+	workflowIds, err := e.svcs.DB.GetInProgressWorkflowIDs(ctx, e.cfg.WorkerID)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/workflowexecutor/enterprise_executor.go
+++ b/internal/backend/workflowexecutor/enterprise_executor.go
@@ -206,7 +206,7 @@ func (e *executor) startPoller(ctx context.Context) {
 }
 
 func (e *executor) NotifyDone(ctx context.Context, id string) error {
-	didUpdate, err := e.svcs.DB.UpdateRequestStatus(ctx, id, "done")
+	didUpdate, err := e.svcs.DB.UpdateWorkflowExecutionRequestStatus(ctx, id, "done")
 	if err != nil {
 		e.l.Error("Failed to update workflow execution request status", zap.Error(err), zap.String("workflow_id", id))
 		return err

--- a/internal/backend/workflowexecutor/enterprise_executor_test.go
+++ b/internal/backend/workflowexecutor/enterprise_executor_test.go
@@ -151,7 +151,7 @@ func (m *mockDB) GetWorkflowExecutionRequests(ctx context.Context, workerID stri
 
 	return m.dbResult()
 }
-func (m *mockDB) UpdateRequestStatus(ctx context.Context, workflowID string, status string) (bool, error) {
+func (m *mockDB) UpdateWorkflowExecutionRequestStatus(ctx context.Context, workflowID string, status string) (bool, error) {
 	// Mock implementation, just return nil to simulate success
 	return true, nil
 }

--- a/internal/backend/workflowexecutor/enterprise_executor_test.go
+++ b/internal/backend/workflowexecutor/enterprise_executor_test.go
@@ -151,9 +151,9 @@ func (m *mockDB) GetWorkflowExecutionRequests(ctx context.Context, workerID stri
 
 	return m.dbResult()
 }
-func (m *mockDB) UpdateRequestStatus(ctx context.Context, workflowID string, status string) error {
+func (m *mockDB) UpdateRequestStatus(ctx context.Context, workflowID string, status string) (bool, error) {
 	// Mock implementation, just return nil to simulate success
-	return nil
+	return true, nil
 }
 
 func getExecutor(


### PR DESCRIPTION
canclled workflows didn't release resources since the notify workflow ended activity was cancelled
this change uses a disconnected context to make sure the activity runs any way