### PR TITLE
fix: Install py-sdk with [all] extras in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY ./runtimes/pythonrt/runner/pyproject.toml pyproject.toml
 RUN python -m pip install .[all]
 
 COPY ./runtimes/pythonrt/py-sdk py-sdk
-RUN cd py-sdk && python -m pip install .
+RUN cd py-sdk && python -m pip install .[all]
 
 FROM python:3.11-slim AS final
 


### PR DESCRIPTION
The Docker build is failing because `gspread`, `praw` and other optional dependencies are not available in the runtime environment, causing import errors when Python workflows try to use these libraries. 

Note: still as a draft PR because its not clear, why did it work until recently 