### PR TITLE
fix: microsoft integration user with no org fix

### DIFF
--- a/integrations/microsoft/oauth.go
+++ b/integrations/microsoft/oauth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
@@ -58,18 +59,28 @@ func (h handler) handleOAuth(w http.ResponseWriter, r *http.Request) {
 
 	// Test the token's usability and get authoritative connection details.
 	ctx := r.Context()
-	org, err := connection.GetOrgInfo(ctx, data.Token)
-	if err != nil {
-		l.Warn("MS organization details request failed", zap.Error(err))
-		c.AbortServerError("organization details request failed")
-		return
-	}
-
 	user, err := connection.GetUserInfo(ctx, data.Token)
 	if err != nil {
 		l.Warn("MS user details request failed", zap.Error(err))
 		c.AbortServerError("user details request failed")
 		return
+	}
+
+	// Try to get organization details, but handle MSA accounts gracefully
+	var org *connection.OrgInfo
+	org, err = connection.GetOrgInfo(ctx, data.Token)
+	if err != nil {
+		// Check if this is a personal Microsoft account (MSA) error.
+		if strings.Contains(err.Error(), "MSA accounts") ||
+			strings.Contains(err.Error(), "DirectoryServices") {
+			l.Info("Personal Microsoft account detected - organization info not available")
+			// Create empty org info for personal accounts.
+			org = &connection.OrgInfo{}
+		} else {
+			l.Warn("MS organization details request failed", zap.Error(err))
+			c.AbortServerError("organization details request failed")
+			return
+		}
 	}
 
 	vsid := sdktypes.NewVarScopeID(cid)


### PR DESCRIPTION
Problem: Personal Microsoft accounts fail with organization details request failed during OAuth flow.
Solution: Handle MSA-specific errors gracefully by creating empty org info instead of aborting the connection.
Result: Personal accounts can now connect successfully while work accounts continue working normally.


