### PR TITLE
fix(python): Catch exception when setting err.args

### DIFF
--- a/runtimes/pythonrt/runner/main.py
+++ b/runtimes/pythonrt/runner/main.py
@@ -164,7 +164,11 @@ def set_exception_args(err):
     for name in init_args[len(err_args) :]:
         extra.append(getattr(err, name, None))
 
-    err.args += tuple(extra)
+    try:
+        err.args += tuple(extra)
+    except Exception as e:
+        # Some errors (msgraph ODataError) raise when you set args
+        log.warning("can't set args for %r - %r", err, e)
 
 
 Call = namedtuple("Call", "fn args kw fut")

--- a/runtimes/pythonrt/runner/pyproject.toml
+++ b/runtimes/pythonrt/runner/pyproject.toml
@@ -5,6 +5,7 @@ dependencies = [
 	"grpcio ~= 1.68",
 	"autokitteh[all] ~= 0.6",
 ]
+requires-python = ">= 3.11"
 
 [project.optional-dependencies]
 all = [

--- a/runtimes/pythonrt/runner/tests/main_test.py
+++ b/runtimes/pythonrt/runner/tests/main_test.py
@@ -346,3 +346,17 @@ def test_async(workflow, capsys):
 
     captured = capsys.readouterr()
     assert "on_event: end (out=8)" in captured.out
+
+
+def test_async_exc():
+    clear_module_cache("program")
+    runner = new_test_runner(workflows.async_exc, server=MagicMock())
+    worker = MockWorker(runner)
+    runner.worker = worker
+    breakpoint()
+
+    event = json.dumps({"data": {"cat": "mitzi"}})
+    worker.start("program.py:on_event", event.encode())
+    worker.event.wait(1)
+
+    assert worker.calls.get("ACTIVITY")

--- a/runtimes/pythonrt/runner/tests/main_test.py
+++ b/runtimes/pythonrt/runner/tests/main_test.py
@@ -353,7 +353,6 @@ def test_async_exc():
     runner = new_test_runner(workflows.async_exc, server=MagicMock())
     worker = MockWorker(runner)
     runner.worker = worker
-    breakpoint()
 
     event = json.dumps({"data": {"cat": "mitzi"}})
     worker.start("program.py:on_event", event.encode())

--- a/runtimes/pythonrt/runner/tests/main_test.py
+++ b/runtimes/pythonrt/runner/tests/main_test.py
@@ -8,6 +8,7 @@ Need much more:
 
 import builtins
 import json
+import os
 import pickle
 import sys
 import traceback
@@ -348,11 +349,16 @@ def test_async(workflow, capsys):
     assert "on_event: end (out=8)" in captured.out
 
 
-def test_async_exc():
+def test_async_exc(monkeypatch):
     clear_module_cache("program")
     runner = new_test_runner(workflows.async_exc, server=MagicMock())
     worker = MockWorker(runner)
     runner.worker = worker
+
+    def exit():
+        raise SystemExit(1)
+
+    monkeypatch.setattr(os, "_exit", exit)
 
     event = json.dumps({"data": {"cat": "mitzi"}})
     worker.start("program.py:on_event", event.encode())

--- a/runtimes/pythonrt/runner/tests/workflows/async_exc/program.py
+++ b/runtimes/pythonrt/runner/tests/workflows/async_exc/program.py
@@ -1,0 +1,15 @@
+from unittest.mock import AsyncMock
+from msgraph.generated.models.o_data_errors.o_data_error import ODataError
+
+teams = AsyncMock()
+teams.me.joined_teams.get.side_effect = ODataError(message="oops (1)")
+
+
+async def on_event(_):
+    try:
+        res = await teams.me.joined_teams.get()
+        for t in res.value:
+            print(t.display_name, t.id)
+    except Exception as err:
+        print("ERROR:", err)
+        raise (err)


### PR DESCRIPTION
msgraph OData error does some funky validation when setting `err.args` in `set_exception_args`. Add a try/catch to catch these errors.

Fixes: ENG-2241