### PR TITLE
fix: render structs as attr dicts in value to string

### DIFF
--- a/runtimes/pythonrt/py-sdk/autokitteh/attr_dict.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/attr_dict.py
@@ -9,6 +9,8 @@ class AttrDict(dict):
     8080
     >>> config.debug
     True
+    >>> config["debug"]
+    True
     """
 
     def __getattr__(self, name: str):

--- a/runtimes/pythonrt/runner/tests/values_test.py
+++ b/runtimes/pythonrt/runner/tests/values_test.py
@@ -56,19 +56,6 @@ wrap_test_cases = [
         id="dict",
     ),
     pytest.param(
-        namedtuple("Point", ["y", "x"])(2, 1),
-        pb.Value(
-            struct=pb.Struct(
-                ctor=pb.Value(string=pb.String(v="Point")),
-                fields={
-                    "x": intv(1),
-                    "y": intv(2),
-                },
-            )
-        ),
-        id="namedtuple",
-    ),
-    pytest.param(
         timedelta(days=1),
         pb.Value(duration=pb.Duration(v=duration_pb2.Duration(seconds=86400))),
         id="timedelta",
@@ -129,7 +116,7 @@ def test_special_wraps():
 
     assert wrap(C()) == cv
 
-    assert unwrap(cv) == namedtuple("C", ["a", "b"])(1, "meow")
+    assert unwrap(cv) == {"a": 1, "b": "meow"}
 
     class D:
         __slots__ = ("a", "b")
@@ -142,7 +129,20 @@ def test_special_wraps():
 
     assert wrap(D()) == dv
 
-    assert unwrap(dv) == namedtuple("D", ["a", "b"])(1, "meow")
+    unw = unwrap(dv)
+    assert unw == {"a": 1, "b": "meow"}
+    assert unw.a == 1
+
+    t = namedtuple("Point", ["y", "x"])(2, 1)
+    assert wrap(t) == pb.Value(
+        struct=pb.Struct(
+            ctor=pb.Value(string=pb.String(v="Point")),
+            fields={
+                "x": intv(1),
+                "y": intv(2),
+            },
+        )
+    )
 
 
 def test_safe_wrap():

--- a/runtimes/pythonrt/runner/values.py
+++ b/runtimes/pythonrt/runner/values.py
@@ -195,7 +195,7 @@ def unwrap(v: pb.Value, custom: Callable[[pb.Value], Any] = None) -> Any:
     if v.HasField("bytes"):
         return v.bytes.v
     if v.HasField("struct"):
-        return AttrDict({k: unwrap(v) for k, v in v.struct.fields.items()})
+        return AttrDict({k: unwrap(v, custom) for k, v in v.struct.fields.items()})
     if v.HasField("time"):
         return v.time.v.ToDatetime(UTC)
     if v.HasField("duration"):

--- a/runtimes/pythonrt/runner/values.py
+++ b/runtimes/pythonrt/runner/values.py
@@ -3,7 +3,6 @@
 Wraps and unwraps autokitteh values.
 """
 
-from collections import namedtuple
 from datetime import UTC, datetime, timedelta
 from typing import Any, Callable
 

--- a/runtimes/pythonrt/runner/values.py
+++ b/runtimes/pythonrt/runner/values.py
@@ -12,6 +12,7 @@ import requests
 import pb.autokitteh.values.v1.values_pb2 as pb
 from google.protobuf.duration_pb2 import Duration
 from google.protobuf.timestamp_pb2 import Timestamp
+from autokitteh import AttrDict
 
 
 def wrap_unhandled(v: Any) -> pb.Value:
@@ -164,7 +165,7 @@ def wrap(v: Any, unhandled: Callable[[Any], pb.Value] = None, history=None) -> p
 def unwrap(v: pb.Value, custom: Callable[[pb.Value], Any] = None) -> Any:
     """Unwrap an autokitteh value into a python value.
 
-    Note that wrap and unwrap are guaranteed to be symmetric.
+    Note that wrap and unwrap are NOT guaranteed to be symmetric.
     Two notable examples:
 
     >>> unwrap(wrap((1, 2))) == [1, 2]
@@ -172,7 +173,7 @@ def unwrap(v: pb.Value, custom: Callable[[pb.Value], Any] = None) -> Any:
     >>> class C:
     ...   def __init__(self):
     ...     self.x = 42
-    >>> unwrap(wrap(C())) == namedtuple("C", {"x"})(42)
+    >>> unwrap(wrap(C())) == AttrDict({"x": 42})
     True
     """
 
@@ -195,8 +196,7 @@ def unwrap(v: pb.Value, custom: Callable[[pb.Value], Any] = None) -> Any:
     if v.HasField("bytes"):
         return v.bytes.v
     if v.HasField("struct"):
-        tpl = namedtuple(str(unwrap(v.struct.ctor, custom)), v.struct.fields.keys())
-        return tpl(*[unwrap(x, custom) for x in v.struct.fields.values()])
+        return AttrDict({k: unwrap(v) for k, v in v.struct.fields.items()})
     if v.HasField("time"):
         return v.time.v.ToDatetime(UTC)
     if v.HasField("duration"):

--- a/sdk/sdktypes/value.go
+++ b/sdk/sdktypes/value.go
@@ -269,19 +269,11 @@ func (v Value) UnwrapInto(dst any) error { return UnwrapValueInto(dst, v) }
 
 // An unwrapper that is always safe to serialize to string afterwards.
 var valueStringUnwrapper = ValueWrapper{
-	SafeForJSON: true,
+	SafeForJSON:         true,
+	UnwrapStructsAsJSON: true,
 	Preunwrap: func(v Value) (Value, error) {
 		if v.IsFunction() {
 			return NewStringValuef("|function: %v|", v.GetFunction().Name()), nil
-		}
-
-		if v.IsStruct() {
-			ctor := v.GetStruct().Ctor()
-			str, err := ctor.ToString()
-			if err != nil {
-				str = ctor.String()
-			}
-			return NewStringValuef("|struct: %v|", str), nil
 		}
 
 		return v, nil


### PR DESCRIPTION
will allow ui to properly render it.

This is, in principle, a theoretical breaking change for python users as responses structures that come from activities are now AttrDicts and not namedtuples, but this should these are virtually the same unless someone tries to use int indexes on namedtuples, which there is no reason to.