### PR TITLE
feat: allow scripts to query webhook trigger urls

### DIFF
--- a/integrations/atlassian/confluence/webhooks.go
+++ b/integrations/atlassian/confluence/webhooks.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -17,6 +16,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/integrations/common"
+	"go.autokitteh.dev/autokitteh/internal/backend/fixtures"
 )
 
 const (
@@ -156,8 +156,7 @@ func getWebhook(ctx context.Context, l *zap.Logger, base, user, key, category st
 	}
 
 	// Finally, filter the results based on the AutoKitteh server address.
-	webhookBase := os.Getenv("WEBHOOK_ADDRESS")
-	url := fmt.Sprintf("https://%s/confluence/webhook/%s", webhookBase, category)
+	url := fmt.Sprintf("%s/confluence/webhook/%s", fixtures.ServiceBaseURL(), category)
 	for _, w := range list {
 		if w.URL == url {
 			id, err := extractIDSuffixFromURL(w.Self)
@@ -179,8 +178,7 @@ func registerWebhook(ctx context.Context, l *zap.Logger, base, user, key, catego
 
 	l = l.With(zap.String("category", category))
 
-	webhookBase := os.Getenv("WEBHOOK_ADDRESS")
-	url := fmt.Sprintf("https://%s/confluence/webhook/%s", webhookBase, category)
+	url := fmt.Sprintf("%s/confluence/webhook/%s", fixtures.ServiceBaseURL(), category)
 	secret := typeid.Must(typeid.WithPrefix("")).String()
 	r := webhook{
 		Name:        "AutoKitteh",

--- a/integrations/atlassian/jira/webhooks.go
+++ b/integrations/atlassian/jira/webhooks.go
@@ -161,7 +161,7 @@ type webhookRegistrationResult struct {
 // https://developer.atlassian.com/server/jira/platform/webhooks/
 func registerWebhook(ctx context.Context, l *zap.Logger, baseURL, token string) (int, bool) {
 	req := webhookRegisterRequest{
-		URL: fmt.Sprintf("%s/jira/webhook", fixtures.ServiceBaseURL()),
+		URL: fixtures.ServiceBaseURL() + "/jira/webhook",
 		Webhooks: []webhook{
 			{
 				Events: []string{

--- a/integrations/atlassian/jira/webhooks.go
+++ b/integrations/atlassian/jira/webhooks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"slices"
 	"strings"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/integrations/common"
+	"go.autokitteh.dev/autokitteh/internal/backend/fixtures"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 )
 
@@ -102,10 +102,9 @@ func getWebhook(ctx context.Context, l *zap.Logger, baseURL, token string) (int,
 	// ("GET .../webhook" doesn't show webhook URLs in the response, so
 	// we use a trick: we specify the AutoKitteh server address in the
 	// JQL filter, without affecting the actual event filtering).
-	webhookBase := os.Getenv("WEBHOOK_ADDRESS")
 	id := 0
 	for _, v := range list.Values {
-		if strings.Contains(v.JQLFilter, webhookBase) {
+		if strings.Contains(v.JQLFilter, fixtures.ServiceAddress()) {
 			if id == 0 {
 				id = v.ID
 			} else {
@@ -161,9 +160,8 @@ type webhookRegistrationResult struct {
 // https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-webhooks/#api-rest-api-3-webhook-post
 // https://developer.atlassian.com/server/jira/platform/webhooks/
 func registerWebhook(ctx context.Context, l *zap.Logger, baseURL, token string) (int, bool) {
-	webhookBase := os.Getenv("WEBHOOK_ADDRESS")
 	req := webhookRegisterRequest{
-		URL: fmt.Sprintf("https://%s/jira/webhook", webhookBase),
+		URL: fmt.Sprintf("%s/jira/webhook", fixtures.ServiceBaseURL()),
 		Webhooks: []webhook{
 			{
 				Events: []string{
@@ -173,7 +171,7 @@ func registerWebhook(ctx context.Context, l *zap.Logger, baseURL, token string) 
 				// "GET .../webhook" doesn't show webhook URLs in the response,
 				// so we use a trick: we specify the AutoKitteh server address in
 				// the JQL filter, without affecting the actual event filtering.
-				JQLFilter: "project != " + webhookBase,
+				JQLFilter: "project != " + fixtures.ServiceAddress(),
 			},
 		},
 	}

--- a/integrations/google/calendar/client.go
+++ b/integrations/google/calendar/client.go
@@ -101,7 +101,7 @@ func oauthConfig() *oauth2.Config {
 		ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
 		ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
 		Endpoint:     google.Endpoint,
-		RedirectURL:  fmt.Sprintf("%s/oauth/redirect/google", fixtures.ServiceBaseURL()),
+		RedirectURL:  fixtures.ServiceBaseURL() + "/oauth/redirect/google",
 		// https://developers.google.com/calendar/api/auth
 		Scopes: []string{
 			// Non-sensitive.
@@ -157,7 +157,7 @@ func (a api) watchEvents(ctx context.Context, connID sdktypes.ConnectionID, user
 	req := client.Events.Watch(calID, &calendar.Channel{
 		Id:      connID.String() + "/events",
 		Token:   fmt.Sprintf("%s/%s/events", userEmail, calID),
-		Address: fmt.Sprintf("%s/googlecalendar/notif", fixtures.ServiceBaseURL()),
+		Address: fixtures.ServiceBaseURL() + "googlecalendar/notif",
 		Type:    "web_hook",
 	})
 

--- a/integrations/google/calendar/client.go
+++ b/integrations/google/calendar/client.go
@@ -17,6 +17,7 @@ import (
 	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/google/connections"
 	"go.autokitteh.dev/autokitteh/integrations/google/vars"
+	"go.autokitteh.dev/autokitteh/internal/backend/fixtures"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
@@ -96,12 +97,11 @@ func oauthTokenSource(ctx context.Context, data string) (oauth2.TokenSource, err
 
 // TODO(ENG-112): Use OAuth().Get() instead of calling this function.
 func oauthConfig() *oauth2.Config {
-	addr := os.Getenv("WEBHOOK_ADDRESS")
 	return &oauth2.Config{
 		ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
 		ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
 		Endpoint:     google.Endpoint,
-		RedirectURL:  fmt.Sprintf("https://%s/oauth/redirect/google", addr),
+		RedirectURL:  fmt.Sprintf("%s/oauth/redirect/google", fixtures.ServiceBaseURL()),
 		// https://developers.google.com/calendar/api/auth
 		Scopes: []string{
 			// Non-sensitive.
@@ -154,11 +154,10 @@ func (a api) watchEvents(ctx context.Context, connID sdktypes.ConnectionID, user
 		return nil, err
 	}
 
-	addr := os.Getenv("WEBHOOK_ADDRESS")
 	req := client.Events.Watch(calID, &calendar.Channel{
 		Id:      connID.String() + "/events",
 		Token:   fmt.Sprintf("%s/%s/events", userEmail, calID),
-		Address: fmt.Sprintf("https://%s/googlecalendar/notif", addr),
+		Address: fmt.Sprintf("%s/googlecalendar/notif", fixtures.ServiceBaseURL()),
 		Type:    "web_hook",
 	})
 

--- a/integrations/google/drive/client.go
+++ b/integrations/google/drive/client.go
@@ -16,6 +16,7 @@ import (
 	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/google/connections"
 	"go.autokitteh.dev/autokitteh/integrations/google/vars"
+	"go.autokitteh.dev/autokitteh/internal/backend/fixtures"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
@@ -92,12 +93,11 @@ func jwtTokenSource(ctx context.Context, data string) (oauth2.TokenSource, error
 }
 
 func oauthConfig() *oauth2.Config {
-	addr := os.Getenv("WEBHOOK_ADDRESS")
 	return &oauth2.Config{
 		ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
 		ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
 		Endpoint:     google.Endpoint,
-		RedirectURL:  fmt.Sprintf("https://%s/oauth/redirect/google", addr),
+		RedirectURL:  fmt.Sprintf("%s/oauth/redirect/google", fixtures.ServiceBaseURL()),
 		// https://developers.google.com/drive/api/guides/api-specific-auth
 		Scopes: []string{
 			// Non-sensitive.
@@ -167,11 +167,10 @@ func (a api) watchEvents(ctx context.Context, connID sdktypes.ConnectionID, user
 		}
 	}
 
-	addr := os.Getenv("WEBHOOK_ADDRESS")
 	req := client.Changes.Watch(startToken.StartPageToken, &drive.Channel{
 		Id:         watchID,
 		Token:      userEmail + "/events",
-		Address:    fmt.Sprintf("https://%s/googledrive/notif", addr),
+		Address:    fmt.Sprintf("%s/googledrive/notif", fixtures.ServiceBaseURL()),
 		Type:       "web_hook",
 		Expiration: time.Now().Add(time.Hour*24*7).Unix() * 1000,
 	})

--- a/integrations/google/drive/client.go
+++ b/integrations/google/drive/client.go
@@ -97,7 +97,7 @@ func oauthConfig() *oauth2.Config {
 		ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
 		ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
 		Endpoint:     google.Endpoint,
-		RedirectURL:  fmt.Sprintf("%s/oauth/redirect/google", fixtures.ServiceBaseURL()),
+		RedirectURL:  fixtures.ServiceBaseURL() + "/oauth/redirect/google",
 		// https://developers.google.com/drive/api/guides/api-specific-auth
 		Scopes: []string{
 			// Non-sensitive.
@@ -170,7 +170,7 @@ func (a api) watchEvents(ctx context.Context, connID sdktypes.ConnectionID, user
 	req := client.Changes.Watch(startToken.StartPageToken, &drive.Channel{
 		Id:         watchID,
 		Token:      userEmail + "/events",
-		Address:    fmt.Sprintf("%s/googledrive/notif", fixtures.ServiceBaseURL()),
+		Address:    fixtures.ServiceBaseURL() + "/googledrive/notif",
 		Type:       "web_hook",
 		Expiration: time.Now().Add(time.Hour*24*7).Unix() * 1000,
 	})

--- a/integrations/google/forms/client.go
+++ b/integrations/google/forms/client.go
@@ -2,7 +2,6 @@ package forms
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"golang.org/x/oauth2"
@@ -137,7 +136,7 @@ func oauthConfig() *oauth2.Config {
 		ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
 		ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
 		Endpoint:     google.Endpoint,
-		RedirectURL:  fmt.Sprintf("%s/oauth/redirect/google", fixtures.ServiceBaseURL()),
+		RedirectURL:  fixtures.ServiceBaseURL() + "/oauth/redirect/google",
 		// https://developers.google.com/identity/protocols/oauth2/scopes#script
 		Scopes: []string{
 			// Non-sensitive.

--- a/integrations/google/forms/client.go
+++ b/integrations/google/forms/client.go
@@ -14,6 +14,7 @@ import (
 	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/google/connections"
 	"go.autokitteh.dev/autokitteh/integrations/google/vars"
+	"go.autokitteh.dev/autokitteh/internal/backend/fixtures"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
@@ -132,12 +133,11 @@ func oauthTokenSource(ctx context.Context, data string) (oauth2.TokenSource, err
 
 // TODO(ENG-112): Use OAuth().Get() instead of calling this function.
 func oauthConfig() *oauth2.Config {
-	addr := os.Getenv("WEBHOOK_ADDRESS")
 	return &oauth2.Config{
 		ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
 		ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
 		Endpoint:     google.Endpoint,
-		RedirectURL:  fmt.Sprintf("https://%s/oauth/redirect/google", addr),
+		RedirectURL:  fmt.Sprintf("%s/oauth/redirect/google", fixtures.ServiceBaseURL()),
 		// https://developers.google.com/identity/protocols/oauth2/scopes#script
 		Scopes: []string{
 			// Non-sensitive.

--- a/integrations/google/gmail/client.go
+++ b/integrations/google/gmail/client.go
@@ -2,7 +2,6 @@ package gmail
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"golang.org/x/oauth2"
@@ -105,7 +104,7 @@ func oauthConfig() *oauth2.Config {
 		ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
 		ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
 		Endpoint:     google.Endpoint,
-		RedirectURL:  fmt.Sprintf("%s/oauth/redirect/google", fixtures.ServiceBaseURL()),
+		RedirectURL:  fixtures.ServiceBaseURL() + "/oauth/redirect/google",
 		// https://developers.google.com/gmail/api/auth/scopes
 		Scopes: []string{
 			// Non-sensitive.

--- a/integrations/google/gmail/client.go
+++ b/integrations/google/gmail/client.go
@@ -14,6 +14,7 @@ import (
 	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/google/connections"
 	"go.autokitteh.dev/autokitteh/integrations/google/vars"
+	"go.autokitteh.dev/autokitteh/internal/backend/fixtures"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
@@ -100,12 +101,11 @@ func (a api) oauthTokenSource(ctx context.Context, data string) (oauth2.TokenSou
 
 // TODO(ENG-112): Use OAuth().Get() instead of calling this function.
 func oauthConfig() *oauth2.Config {
-	addr := os.Getenv("WEBHOOK_ADDRESS")
 	return &oauth2.Config{
 		ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
 		ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
 		Endpoint:     google.Endpoint,
-		RedirectURL:  fmt.Sprintf("https://%s/oauth/redirect/google", addr),
+		RedirectURL:  fmt.Sprintf("%s/oauth/redirect/google", fixtures.ServiceBaseURL()),
 		// https://developers.google.com/gmail/api/auth/scopes
 		Scopes: []string{
 			// Non-sensitive.

--- a/integrations/microsoft/connection/subscriptions.go
+++ b/integrations/microsoft/connection/subscriptions.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 
 	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/oauth"
+	"go.autokitteh.dev/autokitteh/internal/backend/fixtures"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
 )
@@ -136,7 +136,7 @@ func DeleteSubscription(ctx context.Context, svc Services, cid sdktypes.Connecti
 
 func webhookURLs() (changeURL, lifecycleURL string) {
 	var err error
-	changeURL, err = url.JoinPath("https://"+os.Getenv("WEBHOOK_ADDRESS"), ChangePath)
+	changeURL, err = url.JoinPath(fixtures.ServiceBaseURL(), ChangePath)
 	if err != nil {
 		changeURL = ""
 	}

--- a/integrations/oauth/fx.go
+++ b/integrations/oauth/fx.go
@@ -3,12 +3,12 @@ package oauth
 import (
 	"fmt"
 	"net/url"
-	"os"
 	"strings"
 
 	"go.uber.org/zap"
 
 	"go.autokitteh.dev/autokitteh/internal/backend/configset"
+	"go.autokitteh.dev/autokitteh/internal/backend/fixtures"
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 )
@@ -40,7 +40,7 @@ func (o *OAuth) Start(m *muxes.Muxes) error {
 	// Set the AutoKitteh server's base URL for webhooks.
 	o.BaseURL = o.cfg.Address
 	if o.BaseURL == "" {
-		o.BaseURL = os.Getenv("WEBHOOK_ADDRESS") // Legacy
+		o.BaseURL = fixtures.ServiceAddress()
 	}
 
 	var err error

--- a/internal/backend/fixtures/webhook.go
+++ b/internal/backend/fixtures/webhook.go
@@ -12,4 +12,10 @@ func init() {
 }
 
 func ServiceAddress() string { return webhookAddress }
-func ServiceBaseURL() string { return "https://" + webhookAddress }
+func ServiceBaseURL() string {
+	if webhookAddress == "" {
+		return ""
+	}
+
+	return "https://" + webhookAddress
+}

--- a/internal/backend/fixtures/webhook.go
+++ b/internal/backend/fixtures/webhook.go
@@ -1,0 +1,15 @@
+package fixtures
+
+import "os"
+
+var webhookAddress = os.Getenv("SERVICE_ADDRESS")
+
+func init() {
+	if webhookAddress == "" {
+		// fallback to legacy var name.
+		webhookAddress = os.Getenv("WEBHOOK_ADDRESS")
+	}
+}
+
+func ServiceAddress() string { return webhookAddress }
+func ServiceBaseURL() string { return "https://" + webhookAddress }

--- a/internal/backend/sessions/sessionworkflows/workflow.go
+++ b/internal/backend/sessions/sessionworkflows/workflow.go
@@ -20,6 +20,7 @@ import (
 	testtoolsmodule "go.autokitteh.dev/autokitteh/internal/backend/sessions/sessionworkflows/modules/testtools"
 	"go.autokitteh.dev/autokitteh/internal/backend/telemetry"
 	"go.autokitteh.dev/autokitteh/internal/backend/temporalclient"
+	"go.autokitteh.dev/autokitteh/internal/backend/webhookssvc"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
 	"go.autokitteh.dev/autokitteh/sdk/sdkexecutor"
@@ -191,6 +192,15 @@ func (w *sessionWorkflow) initEnvModule(cinfos map[string]connInfo) error {
 		}))
 		vs[name+"__connection_id"] = sdktypes.NewStringValue(conn.ID().String())
 
+	}
+
+	for _, t := range w.data.Triggers {
+		if t.SourceType() != sdktypes.TriggerSourceTypeWebhook {
+			continue
+		}
+
+		name := t.Name().String()
+		vs[name+"__webhook_url"] = sdktypes.NewStringValue(webhookssvc.WebhookSlugToAddress(t.WebhookSlug()))
 	}
 
 	mod := sdkexecutor.NewExecutor(

--- a/internal/backend/webhookssvc/svc.go
+++ b/internal/backend/webhookssvc/svc.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"go.autokitteh.dev/autokitteh/internal/backend/auth/authcontext"
 	"go.autokitteh.dev/autokitteh/internal/backend/configset"
 	"go.autokitteh.dev/autokitteh/internal/backend/db"
+	"go.autokitteh.dev/autokitteh/internal/backend/fixtures"
 	"go.autokitteh.dev/autokitteh/internal/backend/muxes"
 	"go.autokitteh.dev/autokitteh/internal/kittehs"
 	"go.autokitteh.dev/autokitteh/sdk/sdkerrors"
@@ -64,6 +66,10 @@ func (s *Service) Start(muxes *muxes.Muxes) {
 func InitTrigger(trigger sdktypes.Trigger) sdktypes.Trigger {
 	unique := typeid.Must(typeid.FromUUIDWithPrefix("", sdktypes.NewUUID().String()))
 	return trigger.WithWebhookSlug(unique.String())
+}
+
+func WebhookSlugToAddress(slug string) string {
+	return path.Join(fixtures.ServiceBaseURL(), WebhooksPathPrefix, slug)
 }
 
 func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/runtimes/pythonrt/py-sdk/autokitteh/__init__.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/__init__.py
@@ -20,11 +20,13 @@ from .store import (
     set_value,
     store,
 )
+from .triggers import get_webhook_url
 
 __all__ = [
     "AttrDict",
     "AutoKittehError",
     "errors",
+    "get_webhook_url",
     "http_outcome",
     "outcome",
     "start",

--- a/runtimes/pythonrt/py-sdk/autokitteh/triggers.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/triggers.py
@@ -1,3 +1,5 @@
+"""Utility functions for triggers."""
+
 import os
 
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/triggers.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/triggers.py
@@ -1,0 +1,8 @@
+import os
+
+
+def get_webhook_url(trigger_name: str) -> str:
+    url = os.getenv(f"{trigger_name}__webhook_url")
+    if not url:
+        raise ValueError(f"No such webhook URL for trigger {trigger_name!r}, or trigger does not exist")
+    return url

--- a/runtimes/pythonrt/py-sdk/autokitteh/triggers.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/triggers.py
@@ -4,5 +4,5 @@ import os
 def get_webhook_url(trigger_name: str) -> str:
     url = os.getenv(f"{trigger_name}__webhook_url")
     if not url:
-        raise ValueError(f"No such webhook URL for trigger {trigger_name!r}, or trigger does not exist")
+        raise ValueError(f"Webhook URL not found for trigger {trigger_name!r}")
     return url

--- a/runtimes/pythonrt/py-sdk/docs/index.rst
+++ b/runtimes/pythonrt/py-sdk/docs/index.rst
@@ -64,6 +64,14 @@ autokitteh.event module
    :undoc-members:
    :show-inheritance:
 
+autokitteh.triggers module
+--------------------------
+
+.. automodule:: autokitteh.triggers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 autokitteh.zoom module
 ----------------------
 

--- a/tests/system/testdata/sessions/events_python.txtar
+++ b/tests/system/testdata/sessions/events_python.txtar
@@ -29,6 +29,9 @@ ak session watch ses_0000000000000000000000000b --end-state COMPLETED
 return code == 0
 
 ak session prints ses_0000000000000000000000000b --no-timestamps
+output contains '/webhooks/00000000000000000000000005'
+output contains '/webhooks/00000000000000000000000007'
+output contains 'ready'
 output contains '1 a'
 output contains '2 b'
 output contains '3 None'
@@ -52,15 +55,21 @@ project:
       type: webhook
 
 -- program.py --
-from autokitteh import subscribe, next_event
+from autokitteh import subscribe, next_event, get_webhook_url
 
 def on_http_start(_):
+  print(get_webhook_url("http1"))
+  print(get_webhook_url("http2"))
+
   s1 = subscribe("http2", "true")
   s2 = subscribe("http1", "true")
+
   print("ready")
+
   print(1, next_event([s2])['body']['text'])
   print(2, next_event([s1])['body']['text'])
   print(3, next_event([s2], timeout=1))
   print(4, next_event([s1, s2], timeout=2)['body']['text'])
   print(5, next_event([s1, s2], timeout=2)['body']['text'])
+  
   print("done")

--- a/web/github/connect/index.go
+++ b/web/github/connect/index.go
@@ -4,9 +4,10 @@ import (
 	_ "embed"
 	"html/template"
 	"net/http"
-	"os"
 
 	"go.jetify.com/typeid"
+
+	"go.autokitteh.dev/autokitteh/internal/backend/fixtures"
 )
 
 //go:embed index.html
@@ -21,7 +22,7 @@ func ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// a millisecond-precision timestamp and a random value).
 	random := typeid.Must(typeid.WithPrefix(""))
 	data := map[string]string{
-		"address": os.Getenv("WEBHOOK_ADDRESS"),
+		"address": fixtures.ServiceAddress(),
 		"path":    random.String(),
 	}
 	if err := tmpl.Execute(w, data); err != nil {


### PR DESCRIPTION
- standardize WEBHOOK_ADDRESS env var. Support new name: SERVICE_ADDRESS. Fallback to WEBHOOK_ADDRESS.
- pass webhook trigger url via env var to script, add helper function to sdk to access it