### PR TITLE
fix: support grpc requests instead of connect

### DIFF
--- a/internal/backend/externalclient/externalclient.go
+++ b/internal/backend/externalclient/externalclient.go
@@ -42,6 +42,7 @@ func (c *cli) NewOrgImpersonator(orgID sdktypes.OrgID) (sdkservices.Services, er
 	cli := sdkclients.New(sdkclient.Params{
 		URL:       c.externalEndpoint,
 		AuthToken: internalToken,
+		UseGRPC:   true,
 	}.Safe())
 
 	c.l.Debug("created internal client for org: " + orgID.UUIDValue().String())

--- a/sdk/sdkclients/internal/newclient.go
+++ b/sdk/sdkclients/internal/newclient.go
@@ -22,10 +22,10 @@ func New[
 				newClientAuthUnaryInterceptor(p.AuthToken),
 			),
 		)
+	}
 
-		if p.UseGRPC {
-			p.Options = append(p.Options, connect.WithGRPC())
-		}
+	if p.UseGRPC {
+		p.Options = append(p.Options, connect.WithGRPC())
 	}
 
 	return f(p.HTTPClient, p.URL, p.Options...)

--- a/sdk/sdkclients/internal/newclient.go
+++ b/sdk/sdkclients/internal/newclient.go
@@ -22,6 +22,10 @@ func New[
 				newClientAuthUnaryInterceptor(p.AuthToken),
 			),
 		)
+
+		if p.UseGRPC {
+			p.Options = append(p.Options, connect.WithGRPC())
+		}
 	}
 
 	return f(p.HTTPClient, p.URL, p.Options...)

--- a/sdk/sdkclients/sdkclient/sdkclient.go
+++ b/sdk/sdkclients/sdkclient/sdkclient.go
@@ -22,6 +22,7 @@ type Params struct {
 	URL        string
 	Options    []connect.ClientOption
 	AuthToken  string
+	UseGRPC    bool
 }
 
 func (p Params) Safe() Params {


### PR DESCRIPTION
This change allow using grpc protocol instead of connect protocol 
when going through the internal clients
