### PR TITLE
fix: Don't save Gemini connection if key is not valid

### DIFF
--- a/integrations/google/gemini/client.go
+++ b/integrations/google/gemini/client.go
@@ -3,6 +3,8 @@ package gemini
 import (
 	"context"
 
+	"go.uber.org/zap"
+
 	"go.autokitteh.dev/autokitteh/integrations"
 	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/integrations/google/vars"
@@ -10,7 +12,6 @@ import (
 	"go.autokitteh.dev/autokitteh/sdk/sdkmodule"
 	"go.autokitteh.dev/autokitteh/sdk/sdkservices"
 	"go.autokitteh.dev/autokitteh/sdk/sdktypes"
-	"go.uber.org/zap"
 )
 
 const IntegrationName = "googlegemini"

--- a/integrations/google/gemini/client.go
+++ b/integrations/google/gemini/client.go
@@ -17,7 +17,7 @@ const IntegrationName = "googlegemini"
 
 var desc = common.Descriptor(IntegrationName, "Google Gemini", "/static/images/google_gemini.svg")
 
-func New(cvars sdkservices.Vars, l *zap.Logger) sdkservices.Integration {
+func New(cvars sdkservices.Vars) sdkservices.Integration {
 	return sdkintegrations.NewIntegration(
 		desc,
 		sdkmodule.New(),

--- a/integrations/google/gemini/save.go
+++ b/integrations/google/gemini/save.go
@@ -55,7 +55,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	api_key := r.Form.Get("key")
 	if api_key == "" {
-		l.Warn("API key is missing")
+		l.Debug("API key is missing")
 		c.AbortBadRequest("API key is required")
 		return
 	}

--- a/integrations/google/gemini/save.go
+++ b/integrations/google/gemini/save.go
@@ -1,9 +1,13 @@
 package gemini
 
 import (
+	"context"
 	"net/http"
 
+	"github.com/google/generative-ai-go/genai"
 	"go.uber.org/zap"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 
 	"go.autokitteh.dev/autokitteh/integrations/common"
 	"go.autokitteh.dev/autokitteh/sdk/sdkintegrations"
@@ -41,5 +45,48 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Sanity check: the connection ID is valid.
+	cid, err := sdktypes.StrictParseConnectionID(c.ConnectionID)
+	if err != nil {
+		l.Warn("save connection: invalid connection ID", zap.Error(err))
+		c.AbortBadRequest("invalid connection ID")
+		return
+	}
+
+	api_key := r.Form.Get("key")
+	if api_key == "" {
+		l.Warn("API key is missing")
+		c.AbortBadRequest("API key is required")
+		return
+	}
+
+	err = validateGeminiAPIKey(r.Context(), api_key)
+	if err != nil {
+		l.Debug("Failed to create Google Gemini client for connection "+cid.String()+": "+err.Error(), zap.Error(err))
+		c.AbortBadRequest("failed to validate API key, please check your credentials and try again")
+		return
+	}
+
 	c.Finalize(sdktypes.NewVars().Set(apiKeyVar, r.Form.Get("key"), true))
+}
+
+// validateGeminiAPIKey makes a test request to validate the provided API key.
+func validateGeminiAPIKey(ctx context.Context, apiKey string) error {
+	client, err := genai.NewClient(ctx, option.WithAPIKey(apiKey))
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	iter := client.ListModels(ctx)
+	for {
+		_, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/integrations/google/gemini/save.go
+++ b/integrations/google/gemini/save.go
@@ -69,7 +69,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c.Finalize(sdktypes.NewVars().Set(apiKeyVar, r.Form.Get("key"), true))
+	c.Finalize(sdktypes.NewVars().Set(apiKeyVar, api_key, true))
 }
 
 // validateGeminiAPIKey makes a test request to validate the provided API key.

--- a/runtimes/pythonrt/runner/tests/deterministic_test.py
+++ b/runtimes/pythonrt/runner/tests/deterministic_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import deterministic
 
-nonact_caes = [
+nonact_case = [
     # function, result
     (b64decode, True),
     (datetime.now, False),
@@ -16,7 +16,7 @@ nonact_caes = [
 ]
 
 
-@pytest.mark.parametrize("func, expected", nonact_caes)
+@pytest.mark.parametrize("func, expected", nonact_case)
 def test_is_deterministic(func, expected):
     out = deterministic.is_deterministic(func)
     assert out == expected, func.__qualname__


### PR DESCRIPTION
- Validate gemini api key before saving connection
- Add Sanity check: the connection ID is valid
- Added logs to contest func 