### PR TITLE
fix: match youtube default oauth app with integration name

### DIFF
--- a/integrations/oauth/configs.go
+++ b/integrations/oauth/configs.go
@@ -261,7 +261,7 @@ func (o *OAuth) initConfigs() {
 		},
 
 		// https://developers.google.com/youtube/v3/guides/authentication
-		"googleyoutube": {
+		"youtube": {
 			Config: googleConfig([]string{
 				// Non-sensitive.
 				googleoauth2.OpenIDScope,


### PR DESCRIPTION
refresh token function was not working for YouTube due to a mismatch between integration name and the default OAuth app