### PR TITLE
fix: linter errors

### DIFF
--- a/internal/backend/storehttpsvc/svc.go
+++ b/internal/backend/storehttpsvc/svc.go
@@ -15,8 +15,7 @@ import (
 
 // An unwrapper that is always safe to serialize to string afterwards.
 var unwrapper = sdktypes.ValueWrapper{
-	SafeForJSON:         true,
-	UnwrapStructsAsJSON: true,
+	SafeForJSON: true,
 }
 
 const storePathPrefix = "store/"

--- a/tests/system/server.go
+++ b/tests/system/server.go
@@ -73,7 +73,12 @@ func startAKServer(t *testing.T, ctx context.Context, akPath string, userCfg map
 	if subproc, _ := strconv.ParseBool(os.Getenv("AK_SYSTEST_USE_PROC_SVC")); subproc {
 		server, err = svcproc.NewSvcProc(akPath, cfgMap, runOpts)
 	} else {
-		server, err = svc.New(kittehs.Must1(svc.LoadConfig("", cfgMap, "")), runOpts)
+		var cfg *svc.Config
+		cfg, err = svc.LoadConfig("", cfgMap, "")
+		if err != nil {
+			return nil, "", fmt.Errorf("load config: %w", err)
+		}
+		server, err = svc.New(cfg, runOpts)
 	}
 	if err != nil {
 		return nil, "", fmt.Errorf("new AK server: %w", err)


### PR DESCRIPTION
 1.  Removed non-existent field `UnwrapStructsAsJSON` from `ValueWrapper` initialization. 
 
  2. Fixed incorrect use of `kittehs.Must1`. Separated `svc.LoadConfig` call into its own statement with proper error handling instead of trying to pass a multi-return function directly to `Must1`.