### PR TITLE
feat: github slash commands recognition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -252,6 +252,7 @@ require (
 	github.com/golangci/plugin-module-register v0.1.1 // indirect
 	github.com/golangci/revgrep v0.8.0 // indirect
 	github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e // indirect
+	github.com/gomarkdown/markdown v0.0.0-20250810172220-2e2c11897d1a // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-github/v52 v52.0.0 // indirect
 	github.com/google/go-github/v71 v71.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -252,7 +252,6 @@ require (
 	github.com/golangci/plugin-module-register v0.1.1 // indirect
 	github.com/golangci/revgrep v0.8.0 // indirect
 	github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e // indirect
-	github.com/gomarkdown/markdown v0.0.0-20250810172220-2e2c11897d1a // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-github/v52 v52.0.0 // indirect
 	github.com/google/go-github/v71 v71.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,6 @@ github.com/alecthomas/chroma/v2 v2.16.0 h1:QC5ZMizk67+HzxFDjQ4ASjni5kWBTGiigRG1u
 github.com/alecthomas/chroma/v2 v2.16.0/go.mod h1:RVX6AvYm4VfYe/zsk7mjHueLDZor3aWCNE14TFlepBk=
 github.com/alecthomas/go-check-sumtype v0.3.1 h1:u9aUvbGINJxLVXiFvHUlPEaD7VDULsrxJb4Aq31NLkU=
 github.com/alecthomas/go-check-sumtype v0.3.1/go.mod h1:A8TSiN3UPRw3laIgWEUOHHLPa6/r9MtoigdlP5h3K/E=
-github.com/alecthomas/kong v1.9.0 h1:Wgg0ll5Ys7xDnpgYBuBn/wPeLGAuK0NvYmEcisJgrIs=
-github.com/alecthomas/kong v1.9.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/alexkohler/nakedret/v2 v2.0.6 h1:ME3Qef1/KIKr3kWX3nti3hhgNxw6aqN5pZmQiFSsuzQ=
@@ -469,8 +467,6 @@ github.com/golangci/revgrep v0.8.0 h1:EZBctwbVd0aMeRnNUsFogoyayvKHyxlV3CdUA46FX2
 github.com/golangci/revgrep v0.8.0/go.mod h1:U4R/s9dlXZsg8uJmaR1GrloUr14D7qDl8gi2iPXJH8k=
 github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e h1:gD6P7NEo7Eqtt0ssnqSJNNndxe69DOQ24A5h7+i3KpM=
 github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e/go.mod h1:h+wZwLjUTJnm/P2rwlbJdRPZXOzaT36/FwnPnY2inzc=
-github.com/gomarkdown/markdown v0.0.0-20250810172220-2e2c11897d1a h1:l7A0loSszR5zHd/qK53ZIHMO8b3bBSmENnQ6eKnUT0A=
-github.com/gomarkdown/markdown v0.0.0-20250810172220-2e2c11897d1a/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/cel-go v0.25.0 h1:jsFw9Fhn+3y2kBbltZR4VEz5xKkcIFRPDnuEzAGv5GY=
 github.com/google/cel-go v0.25.0/go.mod h1:hjEb6r5SuOSlhCHmFoLzu8HGCERvIsDAbxDAyNU/MmI=
 github.com/google/flatbuffers v25.2.10+incompatible h1:F3vclr7C3HpB1k9mxCGRMXq6FdUalZ6H/pNX4FP1v0Q=

--- a/go.sum
+++ b/go.sum
@@ -469,6 +469,8 @@ github.com/golangci/revgrep v0.8.0 h1:EZBctwbVd0aMeRnNUsFogoyayvKHyxlV3CdUA46FX2
 github.com/golangci/revgrep v0.8.0/go.mod h1:U4R/s9dlXZsg8uJmaR1GrloUr14D7qDl8gi2iPXJH8k=
 github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e h1:gD6P7NEo7Eqtt0ssnqSJNNndxe69DOQ24A5h7+i3KpM=
 github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e/go.mod h1:h+wZwLjUTJnm/P2rwlbJdRPZXOzaT36/FwnPnY2inzc=
+github.com/gomarkdown/markdown v0.0.0-20250810172220-2e2c11897d1a h1:l7A0loSszR5zHd/qK53ZIHMO8b3bBSmENnQ6eKnUT0A=
+github.com/gomarkdown/markdown v0.0.0-20250810172220-2e2c11897d1a/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/cel-go v0.25.0 h1:jsFw9Fhn+3y2kBbltZR4VEz5xKkcIFRPDnuEzAGv5GY=
 github.com/google/cel-go v0.25.0/go.mod h1:hjEb6r5SuOSlhCHmFoLzu8HGCERvIsDAbxDAyNU/MmI=
 github.com/google/flatbuffers v25.2.10+incompatible h1:F3vclr7C3HpB1k9mxCGRMXq6FdUalZ6H/pNX4FP1v0Q=

--- a/integrations/github/webhooks/slash_commands.go
+++ b/integrations/github/webhooks/slash_commands.go
@@ -41,7 +41,21 @@ func extractSlashCommands(event any) []slashCommand {
 }
 
 func extractSlashCommandsFromMD(md string) (commands []slashCommand) {
+	inCodeBlock := false
+
 	for line := range strings.SplitSeq(md, "\n") {
+		// Check for code block delimiters (``` or ~~~)
+		trimmedLine := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmedLine, "```") || strings.HasPrefix(trimmedLine, "~~~") {
+			inCodeBlock = !inCodeBlock
+			continue
+		}
+
+		// Skip lines inside code blocks
+		if inCodeBlock {
+			continue
+		}
+
 		if !strings.HasPrefix(line, "/") {
 			continue
 		}

--- a/integrations/github/webhooks/slash_commands.go
+++ b/integrations/github/webhooks/slash_commands.go
@@ -7,6 +7,8 @@ import (
 	"github.com/google/go-github/v60/github"
 )
 
+const maxSlackCommands = 16
+
 type slashCommand struct {
 	Name string   `json:"name"`
 	Args []string `json:"args"`
@@ -40,9 +42,10 @@ func extractSlashCommands(event any) []slashCommand {
 	return extractSlashCommandsFromMD(md)
 }
 
-func extractSlashCommandsFromMD(md string) (commands []slashCommand) {
-	inCodeBlock := false
+func extractSlashCommandsFromMD(md string) []slashCommand {
+	var commands []slashCommand
 
+	inCodeBlock := false
 	for line := range strings.SplitSeq(md, "\n") {
 		// Check for code block delimiters (``` or ~~~)
 		trimmedLine := strings.TrimSpace(line)
@@ -72,9 +75,15 @@ func extractSlashCommandsFromMD(md string) (commands []slashCommand) {
 				Args: parts[1:],
 				Raw:  line,
 			}
+
 			commands = append(commands, cmd)
+
+			if len(commands) >= maxSlackCommands {
+				// ignore any commands beyond the maximum allowed.
+				break
+			}
 		}
 	}
 
-	return
+	return commands
 }

--- a/integrations/github/webhooks/slash_commands.go
+++ b/integrations/github/webhooks/slash_commands.go
@@ -1,0 +1,91 @@
+package webhooks
+
+import (
+	"strings"
+
+	"github.com/gomarkdown/markdown/ast"
+	"github.com/gomarkdown/markdown/parser"
+	"github.com/google/go-github/v52/github"
+)
+
+type slashCommand struct {
+	Name string   `json:"name"`
+	Args []string `json:"args"`
+	Raw  string   `json:"raw"`
+}
+
+func extractSlashCommands(event any) []slashCommand {
+	var md string
+
+	switch e := event.(type) {
+	case *github.IssueCommentEvent:
+		md = e.GetComment().GetBody()
+	case *github.PullRequestReviewCommentEvent:
+		md = e.GetComment().GetBody()
+	case *github.PullRequestReviewEvent:
+		md = e.GetReview().GetBody()
+	case *github.PullRequestEvent:
+		md = e.GetPullRequest().GetBody()
+	case *github.IssuesEvent:
+		md = e.GetIssue().GetBody()
+	case *github.DiscussionEvent:
+		md = e.GetDiscussion().GetBody()
+	case *github.DiscussionCommentEvent:
+		md = e.GetComment().GetBody()
+	case *github.CommitCommentEvent:
+		md = e.GetComment().GetBody()
+	default:
+		return nil
+	}
+
+	text := extractMDText(md)
+
+	return parseSlashCommands(text)
+}
+
+func parseSlashCommands(md string) []slashCommand {
+	var commands []slashCommand
+	for line := range strings.SplitSeq(md, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "/") {
+			parts := strings.Fields(line)
+			if len(parts) > 0 {
+				cmd := slashCommand{
+					Name: strings.TrimPrefix(parts[0], "/"),
+					Args: parts[1:],
+					Raw:  line,
+				}
+				commands = append(commands, cmd)
+			}
+		}
+	}
+	return commands
+}
+
+func extractMDText(md string) string {
+	p := parser.NewWithExtensions(parser.CommonExtensions | parser.AutoHeadingIDs | parser.FencedCode)
+
+	doc := p.Parse([]byte(md))
+
+	var text strings.Builder
+
+	// Walk the AST and extract only text nodes (not code)
+	ast.WalkFunc(doc, func(node ast.Node, entering bool) ast.WalkStatus {
+		if !entering {
+			return ast.GoToNext
+		}
+
+		switch n := node.(type) {
+		case *ast.Text:
+			text.Write(n.Literal)
+		case *ast.Softbreak, *ast.Hardbreak:
+			text.WriteString("\n")
+		case *ast.Code, *ast.CodeBlock:
+			return ast.SkipChildren
+		}
+
+		return ast.GoToNext
+	})
+
+	return text.String()
+}

--- a/integrations/github/webhooks/slash_commands.go
+++ b/integrations/github/webhooks/slash_commands.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/google/go-github/v52/github"
+	"github.com/google/go-github/v60/github"
 )
 
 type slashCommand struct {

--- a/integrations/github/webhooks/slash_commands_test.go
+++ b/integrations/github/webhooks/slash_commands_test.go
@@ -1,0 +1,174 @@
+package webhooks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractSlashCommandsFromMD(t *testing.T) {
+	tests := []struct {
+		name     string
+		md       string
+		expected []slashCommand
+	}{
+		{
+			name:     "empty string",
+			md:       "",
+			expected: nil,
+		},
+		{
+			name:     "no slash commands",
+			md:       "This is just regular markdown text\nwith multiple lines\nbut no commands",
+			expected: nil,
+		},
+		{
+			name: "single command without args",
+			md:   "/deploy",
+			expected: []slashCommand{
+				{Name: "deploy", Args: []string{}, Raw: "/deploy"},
+			},
+		},
+		{
+			name: "single command with one arg",
+			md:   "/deploy production",
+			expected: []slashCommand{
+				{Name: "deploy", Args: []string{"production"}, Raw: "/deploy production"},
+			},
+		},
+		{
+			name: "single command with multiple args",
+			md:   "/deploy staging --force --verbose",
+			expected: []slashCommand{
+				{Name: "deploy", Args: []string{"staging", "--force", "--verbose"}, Raw: "/deploy staging --force --verbose"},
+			},
+		},
+		{
+			name: "multiple commands on separate lines",
+			md:   "/build\n/test\n/deploy",
+			expected: []slashCommand{
+				{Name: "build", Args: []string{}, Raw: "/build"},
+				{Name: "test", Args: []string{}, Raw: "/test"},
+				{Name: "deploy", Args: []string{}, Raw: "/deploy"},
+			},
+		},
+		{
+			name: "commands mixed with regular text",
+			md:   "Please review this PR\n/build\nLooks good to me\n/approve\nThanks!",
+			expected: []slashCommand{
+				{Name: "build", Args: []string{}, Raw: "/build"},
+				{Name: "approve", Args: []string{}, Raw: "/approve"},
+			},
+		},
+		{
+			name: "command with trailing whitespace",
+			md:   "/deploy production   \n/test  ",
+			expected: []slashCommand{
+				{Name: "deploy", Args: []string{"production"}, Raw: "/deploy production"},
+				{Name: "test", Args: []string{}, Raw: "/test"},
+			},
+		},
+		{
+			name: "command with trailing tabs",
+			md:   "/deploy\t\t\n/test arg\t",
+			expected: []slashCommand{
+				{Name: "deploy", Args: []string{}, Raw: "/deploy"},
+				{Name: "test", Args: []string{"arg"}, Raw: "/test arg"},
+			},
+		},
+		{
+			name:     "slash not at beginning of line",
+			md:       "Please run /deploy to deploy",
+			expected: nil,
+		},
+		{
+			name: "slash at beginning after newline",
+			md:   "Please run:\n/deploy production",
+			expected: []slashCommand{
+				{Name: "deploy", Args: []string{"production"}, Raw: "/deploy production"},
+			},
+		},
+		{
+			name:     "only slash character",
+			md:       "/",
+			expected: nil,
+		},
+		{
+			name:     "slash followed by only whitespace",
+			md:       "/   \n/\t\t",
+			expected: nil,
+		},
+		{
+			name: "command in code block should still be extracted",
+			md:   "```\n/deploy\n```",
+			expected: []slashCommand{
+				{Name: "deploy", Args: []string{}, Raw: "/deploy"},
+			},
+		},
+		{
+			name: "multiple args with various spacing",
+			md:   "/run  arg1   arg2    arg3",
+			expected: []slashCommand{
+				{Name: "run", Args: []string{"arg1", "arg2", "arg3"}, Raw: "/run  arg1   arg2    arg3"},
+			},
+		},
+		{
+			name: "command with special characters in args",
+			md:   "/notify @user #channel https://example.com",
+			expected: []slashCommand{
+				{Name: "notify", Args: []string{"@user", "#channel", "https://example.com"}, Raw: "/notify @user #channel https://example.com"},
+			},
+		},
+		{
+			name: "command names with numbers and underscores",
+			md:   "/cmd_123\n/test2",
+			expected: []slashCommand{
+				{Name: "cmd_123", Args: []string{}, Raw: "/cmd_123"},
+				{Name: "test2", Args: []string{}, Raw: "/test2"},
+			},
+		},
+		{
+			name: "windows-style line endings",
+			md:   "/build\r\n/test\r\n/deploy",
+			expected: []slashCommand{
+				{Name: "build", Args: []string{}, Raw: "/build"},
+				{Name: "test", Args: []string{}, Raw: "/test"},
+				{Name: "deploy", Args: []string{}, Raw: "/deploy"},
+			},
+		},
+		{
+			name: "empty lines between commands",
+			md:   "/start\n\n\n/middle\n\n/end",
+			expected: []slashCommand{
+				{Name: "start", Args: []string{}, Raw: "/start"},
+				{Name: "middle", Args: []string{}, Raw: "/middle"},
+				{Name: "end", Args: []string{}, Raw: "/end"},
+			},
+		},
+		{
+			name: "real world example - PR comment",
+			md: `Thanks for the contribution!
+
+/build all
+/test integration
+
+LGTM! Let's deploy this.
+
+/approve
+/deploy staging`,
+			expected: []slashCommand{
+				{Name: "build", Args: []string{"all"}, Raw: "/build all"},
+				{Name: "test", Args: []string{"integration"}, Raw: "/test integration"},
+				{Name: "approve", Args: []string{}, Raw: "/approve"},
+				{Name: "deploy", Args: []string{"staging"}, Raw: "/deploy staging"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractSlashCommandsFromMD(tt.md)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/integrations/github/webhooks/slash_commands_test.go
+++ b/integrations/github/webhooks/slash_commands_test.go
@@ -99,13 +99,6 @@ func TestExtractSlashCommandsFromMD(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "command in code block should still be extracted",
-			md:   "```\n/deploy\n```",
-			expected: []slashCommand{
-				{Name: "deploy", Args: []string{}, Raw: "/deploy"},
-			},
-		},
-		{
 			name: "multiple args with various spacing",
 			md:   "/run  arg1   arg2    arg3",
 			expected: []slashCommand{
@@ -161,6 +154,36 @@ LGTM! Let's deploy this.
 				{Name: "test", Args: []string{"integration"}, Raw: "/test integration"},
 				{Name: "approve", Args: []string{}, Raw: "/approve"},
 				{Name: "deploy", Args: []string{"staging"}, Raw: "/deploy staging"},
+			},
+		},
+		{
+			name:     "command in code block should be ignored",
+			md:       "```\n/deploy\n```",
+			expected: nil,
+		},
+		{
+			name:     "command in code block with language",
+			md:       "```bash\n/deploy production\n```",
+			expected: nil,
+		},
+		{
+			name: "commands before and after code block",
+			md:   "/before\n```\n/inside\n```\n/after",
+			expected: []slashCommand{
+				{Name: "before", Args: []string{}, Raw: "/before"},
+				{Name: "after", Args: []string{}, Raw: "/after"},
+			},
+		},
+		{
+			name:     "command in tilde code block",
+			md:       "~~~\n/deploy\n~~~",
+			expected: nil,
+		},
+		{
+			name: "nested code blocks not supported - toggles on each delimiter",
+			md:   "```\n/first\n```\n/middle\n```\n/second\n```",
+			expected: []slashCommand{
+				{Name: "middle", Args: []string{}, Raw: "/middle"},
 			},
 		},
 	}

--- a/integrations/github/webhooks/webhook.go
+++ b/integrations/github/webhooks/webhook.go
@@ -156,12 +156,13 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// To preserve the original event format instead of using the go-github event format,
 	// we unmarshal the payload into a map and use that map to transform the event.
 	var jsonEvent map[string]any
-	err = json.Unmarshal(payload, &jsonEvent)
-	if err != nil {
+	if err := json.Unmarshal(payload, &jsonEvent); err != nil {
 		l.Error("failed to unmarshal payload to map", zap.Error(err))
 		common.HTTPError(w, http.StatusInternalServerError)
 		return
 	}
+
+	jsonEvent["slash_commands"] = extractSlashCommands(ghEvent)
 
 	// Transform the GitHub event into an AutoKitteh event.
 	akEvent, err := common.TransformEvent(l, jsonEvent, eventType)

--- a/integrations/github/webhooks/webhook.go
+++ b/integrations/github/webhooks/webhook.go
@@ -163,6 +163,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	slashCommands := extractSlashCommands(ghEvent)
+
 	jsonEvent["slash_commands"] = slashCommands
 
 	// Transform the GitHub event into an AutoKitteh event.

--- a/integrations/github/webhooks/webhook.go
+++ b/integrations/github/webhooks/webhook.go
@@ -199,8 +199,9 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	for _, cmd := range slashCommands {
 		m := map[string]any{
-			"command": cmd,
-			"actual":  jsonEvent,
+			"command":           cmd,
+			"actual_data":       jsonEvent,
+			"actual_event_type": eventType,
 		}
 
 		akEvent, err := common.TransformEvent(l, m, "slash_command")


### PR DESCRIPTION
this will add to all slash command capable events `slash_commands` key at the top level. this will allow for filtering for them.

also send slash_command events per command.
