### PR TITLE
fix: migration auth_type primary key conflict

### DIFF
--- a/migrations/postgres/20251130080002_migrate_auth_type.sql
+++ b/migrations/postgres/20251130080002_migrate_auth_type.sql
@@ -1,5 +1,10 @@
 -- +goose Up
 -- migrate "authType" variable name to "auth_type" in vars table
+-- Delete any authType entries where auth_type already exists for the same var_id (keep the newer auth_type)
+DELETE FROM "vars" WHERE "name" = 'authType' AND EXISTS (
+  SELECT 1 FROM "vars" v2 WHERE v2."name" = 'auth_type' AND v2."var_id" = "vars"."var_id"
+);
+-- Update remaining authType to auth_type
 UPDATE "vars" SET "name" = 'auth_type' WHERE "name" = 'authType';
 
 -- +goose Down

--- a/migrations/postgres/atlas.sum
+++ b/migrations/postgres/atlas.sum
@@ -1,4 +1,4 @@
-h1:iO4iqcvILXayERrpy5+C5SSOPqR67i+1nGginuf+h/U=
+h1:p2X7nvrC4MMICtiaz5uuDzDbE1PSe2pj4io+t69nHXo=
 20240704121932_baseline.sql h1:1JS9FYe08Ef0wTpJIeeL4wIqHc8E/RXhuqmTI/FwkzY=
 20240714051207_no-db-user.sql h1:tx0AwepNeeL/XWD74sLRGwisrkNs4lyH/H4BG/663FQ=
 20240727114921_project-not-nil-name.sql h1:ZG3tDLzQSxd81S4BDe/IOMktltkurwyuFwu5gkqQvrA=
@@ -39,4 +39,4 @@ h1:iO4iqcvILXayERrpy5+C5SSOPqR67i+1nGginuf+h/U=
 20251028120700_add_timezone_to_trigger.sql h1:mcoy8ikT3pICTXdJK2ZN/tSaET5medwiz6802Jrkhu0=
 20251114031101_store_public.sql h1:zr59i43hegJSZaGzzmY8ndJjDOFZVcwuO7RngjTVyxE=
 20251124123331_org-level-connections.sql h1:PYqJ3eI52kDirCy6LdPtRgjFxPFPwcfdoKAZsxucs6s=
-20251130080002_migrate_auth_type.sql h1:sN8mPRt22wxDkhno9Hthbb+hUOUkr1336WsCPDj7CLQ=
+20251130080002_migrate_auth_type.sql h1:GH5vH2+OTMOfKdtSO0B/wG80Via8etvRAeRRCIxzJGg=

--- a/migrations/postgres/atlas.sum
+++ b/migrations/postgres/atlas.sum
@@ -1,4 +1,4 @@
-h1:H+jB2pbW+le79sEEaQ2C8LGFCgSMahSqq559zvXjmVo=
+h1:iO4iqcvILXayERrpy5+C5SSOPqR67i+1nGginuf+h/U=
 20240704121932_baseline.sql h1:1JS9FYe08Ef0wTpJIeeL4wIqHc8E/RXhuqmTI/FwkzY=
 20240714051207_no-db-user.sql h1:tx0AwepNeeL/XWD74sLRGwisrkNs4lyH/H4BG/663FQ=
 20240727114921_project-not-nil-name.sql h1:ZG3tDLzQSxd81S4BDe/IOMktltkurwyuFwu5gkqQvrA=
@@ -39,4 +39,4 @@ h1:H+jB2pbW+le79sEEaQ2C8LGFCgSMahSqq559zvXjmVo=
 20251028120700_add_timezone_to_trigger.sql h1:mcoy8ikT3pICTXdJK2ZN/tSaET5medwiz6802Jrkhu0=
 20251114031101_store_public.sql h1:zr59i43hegJSZaGzzmY8ndJjDOFZVcwuO7RngjTVyxE=
 20251124123331_org-level-connections.sql h1:PYqJ3eI52kDirCy6LdPtRgjFxPFPwcfdoKAZsxucs6s=
-20251130080002_migrate_auth_type.sql h1:/TDoaU4yp6rc5QhF8Iv0yQAF1SrKe+b/HbE1QqPYu+s=
+20251130080002_migrate_auth_type.sql h1:sN8mPRt22wxDkhno9Hthbb+hUOUkr1336WsCPDj7CLQ=

--- a/migrations/postgres/enterprise/20251130080006_migrate_auth_type.sql
+++ b/migrations/postgres/enterprise/20251130080006_migrate_auth_type.sql
@@ -1,5 +1,10 @@
 -- +goose Up
 -- migrate "authType" variable name to "auth_type" in vars table
+-- Delete any authType entries where auth_type already exists for the same var_id (keep the newer auth_type)
+DELETE FROM "vars" WHERE "name" = 'authType' AND EXISTS (
+  SELECT 1 FROM "vars" v2 WHERE v2."name" = 'auth_type' AND v2."var_id" = "vars"."var_id"
+);
+-- Update remaining authType to auth_type
 UPDATE "vars" SET "name" = 'auth_type' WHERE "name" = 'authType';
 
 -- +goose Down

--- a/migrations/postgres/enterprise/atlas.sum
+++ b/migrations/postgres/enterprise/atlas.sum
@@ -1,4 +1,4 @@
-h1:KzzraYc08SgUkKRGR7mK6LiWBCy5N63kgC19tZE3PiA=
+h1:7JrMw2wpMHBUrW7MUcsW6K/e3rQXuWYFIqmKkiQKD5w=
 20240704121932_baseline.sql h1:1JS9FYe08Ef0wTpJIeeL4wIqHc8E/RXhuqmTI/FwkzY=
 20240714051207_no-db-user.sql h1:tx0AwepNeeL/XWD74sLRGwisrkNs4lyH/H4BG/663FQ=
 20240727114921_project-not-nil-name.sql h1:ZG3tDLzQSxd81S4BDe/IOMktltkurwyuFwu5gkqQvrA=
@@ -42,4 +42,4 @@ h1:KzzraYc08SgUkKRGR7mK6LiWBCy5N63kgC19tZE3PiA=
 20251028120704_add_timezone_to_trigger.sql h1:YLqxTrBVaf2p5fnI6o4NjtDDP+RqsYka5/qZZSfkvrE=
 20251114031105_store_public.sql h1:FVjEmQZZRT8sGhPVIwzig65H6w2ceWVOKl4HQy+uMyI=
 20251124123252_org-level-connections.sql h1:nDiGDU06qLnqwYlgKJrmz7wb5w03p8BbBfTqoCyrbdg=
-20251130080006_migrate_auth_type.sql h1:KoJPfKzQS0Ep/grwQsU1V4hTbTKtdWyV2glWkCTC4d4=
+20251130080006_migrate_auth_type.sql h1:6K8EjaoRWnDrooRzvsRp8LC9VX1bnObc9HMzDADGpdw=

--- a/migrations/postgres/enterprise/atlas.sum
+++ b/migrations/postgres/enterprise/atlas.sum
@@ -1,4 +1,4 @@
-h1:dBCrNq5Q1/o+tyk8SiSVgIc3+d4XdhR3PQ1jNff32ng=
+h1:KzzraYc08SgUkKRGR7mK6LiWBCy5N63kgC19tZE3PiA=
 20240704121932_baseline.sql h1:1JS9FYe08Ef0wTpJIeeL4wIqHc8E/RXhuqmTI/FwkzY=
 20240714051207_no-db-user.sql h1:tx0AwepNeeL/XWD74sLRGwisrkNs4lyH/H4BG/663FQ=
 20240727114921_project-not-nil-name.sql h1:ZG3tDLzQSxd81S4BDe/IOMktltkurwyuFwu5gkqQvrA=
@@ -42,4 +42,4 @@ h1:dBCrNq5Q1/o+tyk8SiSVgIc3+d4XdhR3PQ1jNff32ng=
 20251028120704_add_timezone_to_trigger.sql h1:YLqxTrBVaf2p5fnI6o4NjtDDP+RqsYka5/qZZSfkvrE=
 20251114031105_store_public.sql h1:FVjEmQZZRT8sGhPVIwzig65H6w2ceWVOKl4HQy+uMyI=
 20251124123252_org-level-connections.sql h1:nDiGDU06qLnqwYlgKJrmz7wb5w03p8BbBfTqoCyrbdg=
-20251130080006_migrate_auth_type.sql h1:S5+I7hsTx19n0rxWhozdhsktVeMoSG9CAHzJvMfH6o0=
+20251130080006_migrate_auth_type.sql h1:KoJPfKzQS0Ep/grwQsU1V4hTbTKtdWyV2glWkCTC4d4=

--- a/migrations/sqlite/20251130075958_migrate_auth_type.sql
+++ b/migrations/sqlite/20251130075958_migrate_auth_type.sql
@@ -1,12 +1,19 @@
 -- +goose Up
 -- migrate "authType" variable name to "auth_type" in vars table
--- Delete any authType entries where auth_type already exists for the same var_id (keep the newer auth_type)
-DELETE FROM `vars` WHERE `name` = 'authType' AND EXISTS (
-  SELECT 1 FROM `vars` v2 WHERE v2.`name` = 'auth_type' AND v2.`var_id` = `vars`.`var_id`
-);
--- Update remaining authType to auth_type
-UPDATE `vars` SET `name` = 'auth_type' WHERE `name` = 'authType';
+-- Insert auth_type copy for var_ids that only have authType (keep both for backward compatibility)
+INSERT INTO `vars` (`var_id`, `name`, `value`, `is_secret`, `integration_id`)
+SELECT `var_id`, 'auth_type', `value`, `is_secret`, `integration_id`
+FROM `vars`
+WHERE `name` = 'authType'
+  AND NOT EXISTS (
+    SELECT 1 FROM `vars` var
+    WHERE var.`name` = 'auth_type'
+      AND var.`var_id` = `vars`.`var_id`
+  );
 
 -- +goose Down
 -- reverse: migrate "authType" variable name to "auth_type" in vars table
-UPDATE `vars` SET `name` = 'authType' WHERE `name` = 'auth_type';
+-- Note: We cannot safely rollback this migration because we cannot distinguish between:
+-- 1. auth_type entries that were added by this migration
+-- 2. auth_type entries that already existed before the migration
+-- Therefore, we do nothing on rollback to avoid data loss.

--- a/migrations/sqlite/20251130075958_migrate_auth_type.sql
+++ b/migrations/sqlite/20251130075958_migrate_auth_type.sql
@@ -1,5 +1,10 @@
 -- +goose Up
 -- migrate "authType" variable name to "auth_type" in vars table
+-- Delete any authType entries where auth_type already exists for the same var_id (keep the newer auth_type)
+DELETE FROM `vars` WHERE `name` = 'authType' AND EXISTS (
+  SELECT 1 FROM `vars` v2 WHERE v2.`name` = 'auth_type' AND v2.`var_id` = `vars`.`var_id`
+);
+-- Update remaining authType to auth_type
 UPDATE `vars` SET `name` = 'auth_type' WHERE `name` = 'authType';
 
 -- +goose Down

--- a/migrations/sqlite/atlas.sum
+++ b/migrations/sqlite/atlas.sum
@@ -1,4 +1,4 @@
-h1:NR3Ewm4gKEaHhnnz2UlewqLWaIh7VLNoDpR6vesCM8Q=
+h1:K1fahJAeOjwCjAox5l2wcUPK6H4g/ZoSAGDi265s8hY=
 20240704121927_baseline.sql h1:Urgmm304lCno+ou4WguUjFGiqu2PYoIOlswHpSL1lRg=
 20240714051159_no-db-user.sql h1:FRReTH5AzKrGU3qp0laWWzkgiBc5693KZIpgrjY81d8=
 20240727114913_project-not-nil-name.sql h1:tRZh+O1yx/QZuytlirQJA0f9Ga/m3FDNM9yE5eJDv1I=
@@ -39,4 +39,4 @@ h1:NR3Ewm4gKEaHhnnz2UlewqLWaIh7VLNoDpR6vesCM8Q=
 20251028120656_add_timezone_to_trigger.sql h1:kwRA+DU6lTnKIRdz+H/Tsr+BjwaCyCk5+ukJR1XX0zQ=
 20251114031057_store_public.sql h1:rQmf23LFm3e6WdgKVMylEQU8ULtVDf5nNnbN8vNKvA8=
 20251124090942_connection-unique-index.sql h1:0Cg5+R9wSJbe2bccTJ+EZ3woZwrP+Y2mKccj3KkjIvg=
-20251130075958_migrate_auth_type.sql h1:rii3CEO+n0AcqnPAgQi8i7lPlNR/0aVTrYVHzx4m7+Q=
+20251130075958_migrate_auth_type.sql h1:AKRH35gfcOhbYnsUA8EWAdSrI4E7AOMP/rq3ovG4yts=

--- a/migrations/sqlite/atlas.sum
+++ b/migrations/sqlite/atlas.sum
@@ -1,4 +1,4 @@
-h1:K1fahJAeOjwCjAox5l2wcUPK6H4g/ZoSAGDi265s8hY=
+h1:it3ZwK/oBL6F7PXwFawXtAFx2xnFBoTuYftqhnTfk7c=
 20240704121927_baseline.sql h1:Urgmm304lCno+ou4WguUjFGiqu2PYoIOlswHpSL1lRg=
 20240714051159_no-db-user.sql h1:FRReTH5AzKrGU3qp0laWWzkgiBc5693KZIpgrjY81d8=
 20240727114913_project-not-nil-name.sql h1:tRZh+O1yx/QZuytlirQJA0f9Ga/m3FDNM9yE5eJDv1I=
@@ -39,4 +39,4 @@ h1:K1fahJAeOjwCjAox5l2wcUPK6H4g/ZoSAGDi265s8hY=
 20251028120656_add_timezone_to_trigger.sql h1:kwRA+DU6lTnKIRdz+H/Tsr+BjwaCyCk5+ukJR1XX0zQ=
 20251114031057_store_public.sql h1:rQmf23LFm3e6WdgKVMylEQU8ULtVDf5nNnbN8vNKvA8=
 20251124090942_connection-unique-index.sql h1:0Cg5+R9wSJbe2bccTJ+EZ3woZwrP+Y2mKccj3KkjIvg=
-20251130075958_migrate_auth_type.sql h1:AKRH35gfcOhbYnsUA8EWAdSrI4E7AOMP/rq3ovG4yts=
+20251130075958_migrate_auth_type.sql h1:0+pNZOykOnp+YykFaBJgfrS8yBrZZi5f6hx3QauAk4M=

--- a/runtimes/pythonrt/py-sdk/autokitteh/google.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/google.py
@@ -278,8 +278,7 @@ def google_creds(integration: str, connection: str, scopes: list[str], **kwargs)
     """
     check_connection_name(connection)
 
-    auth_type = os.getenv(connection + "__auth_type")
-    if auth_type == "oauth":  # User (OAuth 2.0)
+    if os.getenv(connection + "__auth_type") == "oauth": # User (OAuth 2.0)
         return _google_creds_oauth2(integration, connection, scopes)
 
     json_key = os.getenv(connection + "__JSON")  # Service Account (JSON key)

--- a/runtimes/pythonrt/py-sdk/autokitteh/google.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/google.py
@@ -278,10 +278,7 @@ def google_creds(integration: str, connection: str, scopes: list[str], **kwargs)
     """
     check_connection_name(connection)
 
-    # Check for both auth_type and authType for legacy compatibility.
-    auth_type = os.getenv(connection + "__auth_type") or os.getenv(
-        connection + "__authType"
-    )
+    auth_type = os.getenv(connection + "__auth_type")
     if auth_type == "oauth":  # User (OAuth 2.0)
         return _google_creds_oauth2(integration, connection, scopes)
 

--- a/runtimes/pythonrt/py-sdk/autokitteh/google.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/google.py
@@ -278,7 +278,9 @@ def google_creds(integration: str, connection: str, scopes: list[str], **kwargs)
     """
     check_connection_name(connection)
 
-    if os.getenv(connection + "__authType") == "oauth":  # User (OAuth 2.0)
+    # Check for both auth_type and authType for legacy compatibility.
+    auth_type = os.getenv(connection + "__auth_type") or os.getenv(connection + "__authType")
+    if auth_type == "oauth":  # User (OAuth 2.0)
         return _google_creds_oauth2(integration, connection, scopes)
 
     json_key = os.getenv(connection + "__JSON")  # Service Account (JSON key)

--- a/runtimes/pythonrt/py-sdk/autokitteh/google.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/google.py
@@ -278,7 +278,7 @@ def google_creds(integration: str, connection: str, scopes: list[str], **kwargs)
     """
     check_connection_name(connection)
 
-    if os.getenv(connection + "__auth_type") == "oauth": # User (OAuth 2.0)
+    if os.getenv(connection + "__auth_type") == "oauth":  # User (OAuth 2.0)
         return _google_creds_oauth2(integration, connection, scopes)
 
     json_key = os.getenv(connection + "__JSON")  # Service Account (JSON key)

--- a/runtimes/pythonrt/py-sdk/autokitteh/google.py
+++ b/runtimes/pythonrt/py-sdk/autokitteh/google.py
@@ -279,7 +279,9 @@ def google_creds(integration: str, connection: str, scopes: list[str], **kwargs)
     check_connection_name(connection)
 
     # Check for both auth_type and authType for legacy compatibility.
-    auth_type = os.getenv(connection + "__auth_type") or os.getenv(connection + "__authType")
+    auth_type = os.getenv(connection + "__auth_type") or os.getenv(
+        connection + "__authType"
+    )
     if auth_type == "oauth":  # User (OAuth 2.0)
         return _google_creds_oauth2(integration, connection, scopes)
 


### PR DESCRIPTION
 The original migration renamed authType → auth_type using UPDATE, which caused issues:
  - Some var_ids had BOTH authType AND auth_type (from partial migration runs or code changes during migration)
  - Migration failed with duplicate key errors due to composite primary key (var_id, name)
  - Deleting duplicates risked data loss and broke backward compatibility

Changed migration strategy from UPDATE to INSERT:
  - Inserts auth_type copy for var_ids that only have authType
  - Keeps both authType and auth_type for backward compatibility
  - Skips var_ids that already have auth_type 