### PR TITLE
feat: cli deploy/apply/plan does not overwrite secrets

### DIFF
--- a/cmd/ak/cmd/deploy.go
+++ b/cmd/ak/cmd/deploy.go
@@ -21,10 +21,12 @@ var (
 	manifestPath, project, projectName, org string
 
 	filePaths, dirPaths []string
+
+	overwriteSecrets bool
 )
 
 var deployCmd = common.StandardCommand(&cobra.Command{
-	Use:   "deploy {--manifest <file> [--project-name <name>]|--project <name or ID>} [--org org] [--dir <path> [...]] [--file <path> [...]] ",
+	Use:   "deploy {--manifest <file> [--project-name <name>]|--project <name or ID>} [--org org] [--dir <path> [...]] [--file <path> [...]] [--overwrite-secrets]",
 	Short: "Create, configure, build, deploy, and activate project",
 	Long:  `Create, configure, build, deploy, and activate project - see also the "manifest", "build", "deployment", and "project" parent commands`,
 	Args:  cobra.NoArgs,
@@ -120,6 +122,7 @@ func init() {
 	deployCmd.MarkFlagsOneRequired("manifest", "project")
 	deployCmd.MarkFlagsMutuallyExclusive("manifest", "project")
 	deployCmd.MarkFlagsMutuallyExclusive("project-name", "project")
+	deployCmd.Flags().BoolVar(&overwriteSecrets, "overwrite-secrets", false, "overwrite secret variables when values differ")
 
 	deployCmd.Flags().StringArrayVarP(&dirPaths, "dir", "d", []string{}, "0 or more directory paths (default = manifest directory)")
 	deployCmd.Flags().StringArrayVarP(&filePaths, "file", "f", []string{}, "0 or more file paths")
@@ -151,6 +154,7 @@ func applyManifest(cmd *cobra.Command, manifestPath, projectName string, oid sdk
 		manifest.WithLogger(logFunc(cmd, "plan")),
 		manifest.WithProjectName(projectName),
 		manifest.WithOrgID(oid),
+		manifest.WithOverwriteSecrets(overwriteSecrets),
 	)
 	if err != nil {
 		return "", err

--- a/cmd/ak/cmd/manifest/apply.go
+++ b/cmd/ak/cmd/manifest/apply.go
@@ -11,7 +11,7 @@ import (
 var projectName string
 
 var applyCmd = common.StandardCommand(&cobra.Command{
-	Use:     "apply [file] [--project-name <name>] [--org org] [--no-validate] [--from-scratch] [--quiet] [--rm-unused-cvars]",
+	Use:     "apply [file] [--project-name <name>] [--org org] [--no-validate] [--from-scratch] [--quiet] [--rm-unused-cvars] [--overwrite-secrets]",
 	Short:   "Apply project configuration from file or stdin",
 	Aliases: []string{"a"},
 	Args:    cobra.MaximumNArgs(1),
@@ -52,4 +52,5 @@ func init() {
 	applyCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "only show errors, if any")
 	applyCmd.Flags().StringVarP(&projectName, "project-name", "n", "", "project name")
 	applyCmd.Flags().StringVarP(&org, "org", "o", "", "org name or id")
+	applyCmd.Flags().BoolVar(&overwriteSecrets, "overwrite-secrets", false, "overwrite secret variables when values differ")
 }

--- a/cmd/ak/cmd/manifest/deploy.go
+++ b/cmd/ak/cmd/manifest/deploy.go
@@ -24,7 +24,7 @@ var (
 // Allow no dir/file - use manifest dir by default
 
 var deployCmd = common.StandardCommand(&cobra.Command{
-	Use:   "deploy <manifest file> [--project-name <name>] [--org org] [--dir <path> [...]] [--file <path> [...]] [--env <name or ID>] [--quiet]",
+	Use:   "deploy <manifest file> [--project-name <name>] [--org org] [--dir <path> [...]] [--file <path> [...]] [--env <name or ID>] [--quiet] [--overwrite-secrets]",
 	Short: "Create, configure, build, deploy, and activate project",
 	Long:  `Create, configure, build, deploy, and activate project - see also the "build", "deployment", and "project" parent commands`,
 	Args:  cobra.ExactArgs(1),
@@ -102,6 +102,7 @@ func init() {
 	deployCmd.Flags().StringVarP(&env, "env", "e", "", "environment name or ID")
 	deployCmd.Flags().StringVarP(&projectName, "project-name", "n", "", "project name")
 	deployCmd.Flags().StringVarP(&org, "org", "o", "", "org name or id")
+	deployCmd.Flags().BoolVar(&overwriteSecrets, "overwrite-secrets", false, "overwrite secret variables when values differ")
 }
 
 func applyManifest(ctx context.Context, cmd *cobra.Command, args []string, oid sdktypes.OrgID) (manifest.Effects, string, error) {

--- a/cmd/ak/cmd/manifest/plan.go
+++ b/cmd/ak/cmd/manifest/plan.go
@@ -10,12 +10,12 @@ import (
 )
 
 var (
-	noValidate, fromScratch bool
-	org                     string
+	noValidate, fromScratch, overwriteSecrets bool
+	org                                       string
 )
 
 var planCmd = common.StandardCommand(&cobra.Command{
-	Use:     "plan [file] [--project-name <name>] [--org org] [--no-validate] [--from-scratch] [--quiet] [--rm-unused-cvars]",
+	Use:     "plan [file] [--project-name <name>] [--org org] [--no-validate] [--from-scratch] [--quiet] [--rm-unused-cvars] [--overwrite-secrets]",
 	Short:   "Dry-run for applying a YAML manifest, from a file or stdin",
 	Aliases: []string{"p"},
 	Args:    cobra.MaximumNArgs(1),
@@ -53,6 +53,7 @@ func init() {
 	planCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "only show errors, if any")
 	planCmd.Flags().StringVarP(&projectName, "project-name", "n", "", "project name")
 	planCmd.Flags().StringVarP(&org, "org", "o", "", "org name or id")
+	planCmd.Flags().BoolVar(&overwriteSecrets, "overwrite-secrets", false, "overwrite secret variables when values differ")
 }
 
 func plan(cmd *cobra.Command, data []byte, projectName string, oid sdktypes.OrgID) (manifest.Actions, error) {
@@ -71,5 +72,6 @@ func plan(cmd *cobra.Command, data []byte, projectName string, oid sdktypes.OrgI
 		manifest.WithProjectName(projectName),
 		manifest.WithRemoveUnusedConnFlags(rmUnusedConnVars),
 		manifest.WithOrgID(oid),
+		manifest.WithOverwriteSecrets(overwriteSecrets),
 	)
 }

--- a/internal/manifest/plan.go
+++ b/internal/manifest/plan.go
@@ -169,6 +169,11 @@ func planProjectVars(ctx context.Context, mvars []*Var, client sdkservices.Servi
 			currVal := v.Value()
 
 			if currVal != mvar.Value {
+				if !opts.overwriteSecrets && (v.IsSecret() || mvar.Secret) {
+					log.Printf("value differs but one of them is secret is false, skipping")
+					continue
+				}
+
 				log("differs, will set")
 				add(setAction)
 			}

--- a/internal/manifest/plan.go
+++ b/internal/manifest/plan.go
@@ -170,7 +170,7 @@ func planProjectVars(ctx context.Context, mvars []*Var, client sdkservices.Servi
 
 			if currVal != mvar.Value {
 				if !opts.overwriteSecrets && (v.IsSecret() || mvar.Secret) {
-					log.Printf("value differs but one of them is secret is false, skipping")
+					log.Printf("value differs but one of them is secret, skipping")
 					continue
 				}
 

--- a/internal/manifest/plan_opts.go
+++ b/internal/manifest/plan_opts.go
@@ -9,6 +9,7 @@ type opts struct {
 	oid              sdktypes.OrgID
 	rmUnusedConnVars bool
 	version          string
+	overwriteSecrets bool
 }
 
 func applyOptions(optfns []Option) (opts opts) {
@@ -25,5 +26,6 @@ func WithRemoveUnusedConnFlags(s bool) Option { return func(o *opts) { o.rmUnuse
 func WithLogger(l Log) Option                 { return func(o *opts) { o.log = l } }
 func WithProjectName(n string) Option         { return func(o *opts) { o.projectName = n } }
 func WithOrgID(id sdktypes.OrgID) Option      { return func(o *opts) { o.oid = id } }
+func WithOverwriteSecrets(b bool) Option      { return func(o *opts) { o.overwriteSecrets = b } }
 
 func withVersion(v string) Option { return func(o *opts) { o.version = v } }

--- a/tests/system/testdata/manifest/reapply.txtar
+++ b/tests/system/testdata/manifest/reapply.txtar
@@ -38,7 +38,7 @@ project:
 -- second.txt --
 [plan] project "my_project": found, id="prj_00000000000000000000000001"
 [plan] project "my_project": no changes needed
-[plan] var "my_project/shhh": value differs but one of them is secret is false, skipping
+[plan] var "my_project/shhh": value differs but one of them is secret, skipping
 [plan] project "my_project": found 0 connections
 [plan] project "my_project": found 0 triggers
 

--- a/tests/system/testdata/manifest/reapply.txtar
+++ b/tests/system/testdata/manifest/reapply.txtar
@@ -1,5 +1,51 @@
-# TODO: The first apply defines a new project.
+ak manifest apply manifest.yaml
+return code == 0
+output equals file first.txt
 
-# TODO: The second apply (of the same file) updates nothing.
+ak var set shhh hiss -p my_project --secret
+return code == 0
 
-# TODO: The third apply (of a different file) updates everything.
+ak manifest apply manifest.yaml
+return code == 0
+output equals file second.txt
+
+ak manifest apply manifest.yaml --overwrite-secrets
+return code == 0
+output equals file third.txt
+
+-- manifest.yaml --
+version: v1
+
+project:
+  name: my_project
+  display_name: My Telepathy Project
+  vars:
+    - name: v
+      value: initial_value
+      description: Initial project variable
+    - name: shhh
+      value: ""
+      secret: true
+
+-- first.txt --
+[plan] project "my_project": not found, will create
+[plan] var "my_project/v": not found, will set
+[plan] var "my_project/shhh": not found, will set
+[exec] create_project "my_project": prj_00000000000000000000000001 created
+[exec] set_var "my_project/v": prj_00000000000000000000000001 updated
+[exec] set_var "my_project/shhh": prj_00000000000000000000000001 updated
+
+-- second.txt --
+[plan] project "my_project": found, id="prj_00000000000000000000000001"
+[plan] project "my_project": no changes needed
+[plan] var "my_project/shhh": value differs but one of them is secret is false, skipping
+[plan] project "my_project": found 0 connections
+[plan] project "my_project": found 0 triggers
+
+-- third.txt --
+[plan] project "my_project": found, id="prj_00000000000000000000000001"
+[plan] project "my_project": no changes needed
+[plan] var "my_project/shhh": differs, will set
+[plan] project "my_project": found 0 connections
+[plan] project "my_project": found 0 triggers
+[exec] set_var "my_project/shhh": prj_00000000000000000000000001 updated


### PR DESCRIPTION
unless told to explicitly using `--overwrite-secrets`.