### PR TITLE
fix: not delete global conn while creating a project from template

### DIFF
--- a/internal/manifest/plan.go
+++ b/internal/manifest/plan.go
@@ -203,6 +203,12 @@ func planConnections(ctx context.Context, mconns []*Connection, client sdkservic
 			return nil, fmt.Errorf("list connections: %w", err)
 		}
 
+		// Filter to only include connections that belong specifically to this project.
+		// Exclude global connections (project_id IS NULL) that may be returned by the List API.
+		conns = kittehs.Filter(conns, func(c sdktypes.Connection) bool {
+			return c.ProjectID().IsValid() && c.ProjectID() == pid
+		})
+
 		log.Printf("found %d connections", len(conns))
 	}
 


### PR DESCRIPTION
When creating a project from template the global connections were being returned in the connection list alongside the connection for the specific project ID, this created two issues:

- Delete the global connection
- If the global connection had associated triggers, the triggers for the newly created project were not created.

This PR solves both bugs.

ref: ENG-2319