### PR TITLE
fix: do not return non-final outcomes multiple times

### DIFF
--- a/internal/backend/db/db.go
+++ b/internal/backend/db/db.go
@@ -108,6 +108,8 @@ type Shared interface {
 	AddSessionOutcome(ctx context.Context, sessionID sdktypes.SessionID, v sdktypes.Value, eid sdktypes.EventID) error
 	ListSessions(ctx context.Context, f sdkservices.ListSessionsFilter) (*sdkservices.ListSessionResult, error)
 	DeleteSession(ctx context.Context, sessionID sdktypes.SessionID) error
+
+	// If no new outcome is available, returns (InvalidValue, InvalidSessionID, lastSeq, nil).
 	GetNextSessionOutcomeForEvent(ctx context.Context, eventID sdktypes.EventID, lastSeq uint64) (sdktypes.Value, sdktypes.SessionID, uint64, error)
 
 	// -----------------------------------------------------------------------

--- a/internal/backend/db/dbgorm/sessions.go
+++ b/internal/backend/db/dbgorm/sessions.go
@@ -342,7 +342,8 @@ func (db *gormdb) GetNextSessionOutcomeForEvent(ctx context.Context, eventID sdk
 	}
 
 	if len(lrs) == 0 {
-		return sdktypes.InvalidValue, sdktypes.InvalidSessionID, 0, nil
+		// Return lastSeq to make using more ergonomic.
+		return sdktypes.InvalidValue, sdktypes.InvalidSessionID, lastSeq, nil
 	}
 
 	lr := lrs[0]


### PR DESCRIPTION
this prevents returning a non-final (more=False) outcome multiple times due to reseting `lastSeq` when a new outcome is not found.