### PR TITLE
fix con name duplicate in org/project level

### DIFF
--- a/internal/backend/db/dbgorm/connections.go
+++ b/internal/backend/db/dbgorm/connections.go
@@ -147,7 +147,7 @@ func (gdb *gormdb) updateConnection(ctx context.Context, id uuid.UUID, data map[
 		} else {
 			// project level connection
 			for _, otherConnectionWithSamename := range connectionsWithSameName {
-				if otherConnectionWithSamename.ProjectID == conn.ProjectID {
+				if *otherConnectionWithSamename.ProjectID == *conn.ProjectID {
 					return errors.New("duplicate name in same project")
 				}
 			}

--- a/internal/backend/db/dbgorm/connections_test.go
+++ b/internal/backend/db/dbgorm/connections_test.go
@@ -264,42 +264,6 @@ func TestCreateProjectLevelConnection(t *testing.T) {
 	assert.Equal(t, "project_level_connection", retrieved.Name)
 }
 
-// TestOrgLevelAndProjectLevelConnectionsWithSameName tests that org-level and project-level
-// connections can have the same name within the same org
-func TestOrgLevelAndProjectLevelConnectionsWithSameName(t *testing.T) {
-	f := newDBFixture()
-	orgID := f.newOrg()
-
-	// Create a project in the org
-	p := f.newProject(orgID)
-	f.createProjectsAndAssert(t, p)
-
-	connName := "shared_connection_name"
-
-	// Create an org-level connection
-	orgConn := f.newConnection()
-	orgConn.ProjectID = nil
-	orgConn.OrgID = orgID
-	orgConn.Name = connName
-	f.createConnectionsAndAssert(t, orgConn)
-
-	// Create a project-level connection with the same name - should succeed
-	projectConn := f.newConnection(p)
-	projectConn.Name = connName
-	f.createConnectionsAndAssert(t, projectConn)
-
-	// Verify both exist
-	orgRetrieved, err := f.gormdb.getConnection(f.ctx, orgConn.ConnectionID)
-	assert.NoError(t, err)
-	assert.Nil(t, orgRetrieved.ProjectID)
-	assert.Equal(t, connName, orgRetrieved.Name)
-
-	projectRetrieved, err := f.gormdb.getConnection(f.ctx, projectConn.ConnectionID)
-	assert.NoError(t, err)
-	assert.NotNil(t, projectRetrieved.ProjectID)
-	assert.Equal(t, connName, projectRetrieved.Name)
-}
-
 // TestUniqueConstraintOrgLevelConnections tests that org-level connections
 // must have unique names within an org
 func TestUniqueConstraintOrgLevelConnections(t *testing.T) {

--- a/internal/backend/db/dbgorm/scheme/records.go
+++ b/internal/backend/db/dbgorm/scheme/records.go
@@ -56,11 +56,11 @@ func ParseBuild(b Build) (sdktypes.Build, error) {
 type Connection struct {
 	Base
 
-	ProjectID     *uuid.UUID `gorm:"uniqueIndex:idx_connection_org_id_project_id_name,priority:2,where:project_id is not null and deleted_at is null;index;type:uuid;"`
-	OrgID         uuid.UUID  `gorm:"uniqueIndex:idx_connection_org_id_name,priority:1,where:project_id is null and deleted_at is null;uniqueIndex:idx_connection_org_id_project_id_name,priority:1,where:project_id is not null and deleted_at is null;type:uuid;not null"`
+	ProjectID     *uuid.UUID `gorm:"index:idx_connection_org_id_project_id,priority:2;type:uuid;"`
+	OrgID         uuid.UUID  `gorm:"index:idx_connection_org_id_project_id,priority:1;type:uuid;not null"`
 	ConnectionID  uuid.UUID  `gorm:"primaryKey;type:uuid;not null"`
 	IntegrationID *uuid.UUID `gorm:"index;type:uuid"`
-	Name          string     `gorm:"uniqueIndex:idx_connection_org_id_name,priority:2,where:project_id is null and deleted_at is null;not null;uniqueIndex:idx_connection_org_id_project_id_name,priority:3,where:project_id is not null and deleted_at is null"`
+	Name          string     `gorm:"not null"`
 	StatusCode    int32      `gorm:"index"`
 	StatusMessage string
 

--- a/migrations/postgres/20251222172329_simplify-connection-indexes.sql
+++ b/migrations/postgres/20251222172329_simplify-connection-indexes.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- drop index "idx_connection_org_id_name" from table: "connections"
+DROP INDEX "idx_connection_org_id_name";
+-- drop index "idx_connection_org_id_project_id_name" from table: "connections"
+DROP INDEX "idx_connection_org_id_project_id_name";
+-- drop index "idx_connections_project_id" from table: "connections"
+DROP INDEX "idx_connections_project_id";
+-- create index "idx_connection_org_id_project_id" to table: "connections"
+CREATE INDEX "idx_connection_org_id_project_id" ON "connections" ("org_id", "project_id");
+
+-- +goose Down
+-- reverse: create index "idx_connection_org_id_project_id" to table: "connections"
+DROP INDEX "idx_connection_org_id_project_id";
+-- reverse: drop index "idx_connections_project_id" from table: "connections"
+CREATE INDEX "idx_connections_project_id" ON "connections" ("project_id");
+-- reverse: drop index "idx_connection_org_id_project_id_name" from table: "connections"
+CREATE UNIQUE INDEX "idx_connection_org_id_project_id_name" ON "connections" ("org_id", "project_id", "name") WHERE ((project_id IS NOT NULL) AND (deleted_at IS NULL));
+-- reverse: drop index "idx_connection_org_id_name" from table: "connections"
+CREATE UNIQUE INDEX "idx_connection_org_id_name" ON "connections" ("org_id", "name") WHERE ((project_id IS NULL) AND (deleted_at IS NULL));

--- a/migrations/postgres/atlas.sum
+++ b/migrations/postgres/atlas.sum
@@ -1,4 +1,4 @@
-h1:ZgLORlFWY6V2daVEl0Nd76DqoZqvNFAJFSpmRsTB2oQ=
+h1:5RK2uUaRQp5S6MH57WjpN4BhW2cB0IlIDd5CDvnRH0I=
 20240704121932_baseline.sql h1:1JS9FYe08Ef0wTpJIeeL4wIqHc8E/RXhuqmTI/FwkzY=
 20240714051207_no-db-user.sql h1:tx0AwepNeeL/XWD74sLRGwisrkNs4lyH/H4BG/663FQ=
 20240727114921_project-not-nil-name.sql h1:ZG3tDLzQSxd81S4BDe/IOMktltkurwyuFwu5gkqQvrA=
@@ -41,3 +41,4 @@ h1:ZgLORlFWY6V2daVEl0Nd76DqoZqvNFAJFSpmRsTB2oQ=
 20251124123331_org-level-connections.sql h1:PYqJ3eI52kDirCy6LdPtRgjFxPFPwcfdoKAZsxucs6s=
 20251130080002_migrate_auth_type.sql h1:GH5vH2+OTMOfKdtSO0B/wG80Via8etvRAeRRCIxzJGg=
 20251218044324_slr_outcome_eid.sql h1:odl0Zih9Bpzvn3QBAOTRuMbXQoMgIfJrITm9yHJOkbQ=
+20251222172329_simplify-connection-indexes.sql h1:ES4tmK3riaT30Yxf1SP2aQVFz63pCpqX18ZNuAryL4k=

--- a/migrations/postgres/enterprise/20251222172334_simplify-connection-indexes.sql
+++ b/migrations/postgres/enterprise/20251222172334_simplify-connection-indexes.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- drop index "idx_connection_org_id_name" from table: "connections"
+DROP INDEX "idx_connection_org_id_name";
+-- drop index "idx_connection_org_id_project_id_name" from table: "connections"
+DROP INDEX "idx_connection_org_id_project_id_name";
+-- drop index "idx_connections_project_id" from table: "connections"
+DROP INDEX "idx_connections_project_id";
+-- create index "idx_connection_org_id_project_id" to table: "connections"
+CREATE INDEX "idx_connection_org_id_project_id" ON "connections" ("org_id", "project_id");
+
+-- +goose Down
+-- reverse: create index "idx_connection_org_id_project_id" to table: "connections"
+DROP INDEX "idx_connection_org_id_project_id";
+-- reverse: drop index "idx_connections_project_id" from table: "connections"
+CREATE INDEX "idx_connections_project_id" ON "connections" ("project_id");
+-- reverse: drop index "idx_connection_org_id_project_id_name" from table: "connections"
+CREATE UNIQUE INDEX "idx_connection_org_id_project_id_name" ON "connections" ("org_id", "project_id", "name") WHERE ((project_id IS NOT NULL) AND (deleted_at IS NULL));
+-- reverse: drop index "idx_connection_org_id_name" from table: "connections"
+CREATE UNIQUE INDEX "idx_connection_org_id_name" ON "connections" ("org_id", "name") WHERE ((project_id IS NULL) AND (deleted_at IS NULL));

--- a/migrations/postgres/enterprise/atlas.sum
+++ b/migrations/postgres/enterprise/atlas.sum
@@ -1,4 +1,4 @@
-h1:0pLOpXM1feI3C0n8USAygkt14bHZ37Rrpw1r8N9UVuA=
+h1:iB16QHySG1yO2yqFLQBkPS5fLkV5Ya/KGWTZ436JF60=
 20240704121932_baseline.sql h1:1JS9FYe08Ef0wTpJIeeL4wIqHc8E/RXhuqmTI/FwkzY=
 20240714051207_no-db-user.sql h1:tx0AwepNeeL/XWD74sLRGwisrkNs4lyH/H4BG/663FQ=
 20240727114921_project-not-nil-name.sql h1:ZG3tDLzQSxd81S4BDe/IOMktltkurwyuFwu5gkqQvrA=
@@ -44,3 +44,4 @@ h1:0pLOpXM1feI3C0n8USAygkt14bHZ37Rrpw1r8N9UVuA=
 20251124123252_org-level-connections.sql h1:nDiGDU06qLnqwYlgKJrmz7wb5w03p8BbBfTqoCyrbdg=
 20251130080006_migrate_auth_type.sql h1:6K8EjaoRWnDrooRzvsRp8LC9VX1bnObc9HMzDADGpdw=
 20251218044328_slr_outcome_eid.sql h1:vozVJtX4/tRFlElP2yV/UKvtuJ4m7PF+o5z8jK/3l9g=
+20251222172334_simplify-connection-indexes.sql h1:JtG9rW6zmvRC5Q5O/N+WDBI/vE9QSlRGVocgP6x8Hok=

--- a/migrations/sqlite/20251222172325_simplify-connection-indexes.sql
+++ b/migrations/sqlite/20251222172325_simplify-connection-indexes.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- drop index "idx_connection_org_id_name" from table: "connections"
+DROP INDEX `idx_connection_org_id_name`;
+-- drop index "idx_connections_project_id" from table: "connections"
+DROP INDEX `idx_connections_project_id`;
+-- drop index "idx_connection_org_id_project_id_name" from table: "connections"
+DROP INDEX `idx_connection_org_id_project_id_name`;
+-- create index "idx_connection_org_id_project_id" to table: "connections"
+CREATE INDEX `idx_connection_org_id_project_id` ON `connections` (`org_id`, `project_id`);
+
+-- +goose Down
+-- reverse: create index "idx_connection_org_id_project_id" to table: "connections"
+DROP INDEX `idx_connection_org_id_project_id`;
+-- reverse: drop index "idx_connection_org_id_project_id_name" from table: "connections"
+CREATE UNIQUE INDEX `idx_connection_org_id_project_id_name` ON `connections` (`org_id`, `project_id`, `name`) WHERE project_id is not null and deleted_at is null;
+-- reverse: drop index "idx_connections_project_id" from table: "connections"
+CREATE INDEX `idx_connections_project_id` ON `connections` (`project_id`);
+-- reverse: drop index "idx_connection_org_id_name" from table: "connections"
+CREATE UNIQUE INDEX `idx_connection_org_id_name` ON `connections` (`org_id`, `name`) WHERE project_id is null and deleted_at is null;

--- a/migrations/sqlite/atlas.sum
+++ b/migrations/sqlite/atlas.sum
@@ -1,4 +1,4 @@
-h1:pFE0fMbOfTSVUvajyDbi+PJmDYXi3DBzzJzU6VL8IYM=
+h1:143gPnV57ZlBSozmJIZtlWkT6wjKUZHWpjoOs9YDnPs=
 20240704121927_baseline.sql h1:Urgmm304lCno+ou4WguUjFGiqu2PYoIOlswHpSL1lRg=
 20240714051159_no-db-user.sql h1:FRReTH5AzKrGU3qp0laWWzkgiBc5693KZIpgrjY81d8=
 20240727114913_project-not-nil-name.sql h1:tRZh+O1yx/QZuytlirQJA0f9Ga/m3FDNM9yE5eJDv1I=
@@ -41,3 +41,4 @@ h1:pFE0fMbOfTSVUvajyDbi+PJmDYXi3DBzzJzU6VL8IYM=
 20251124090942_connection-unique-index.sql h1:0Cg5+R9wSJbe2bccTJ+EZ3woZwrP+Y2mKccj3KkjIvg=
 20251130075958_migrate_auth_type.sql h1:0+pNZOykOnp+YykFaBJgfrS8yBrZZi5f6hx3QauAk4M=
 20251218044320_slr_outcome_eid.sql h1:pqvlLT2i7MDBux1M0zcFLrP8WBSu9xiKLrE0Mb/zMcQ=
+20251222172325_simplify-connection-indexes.sql h1:U69r7wzKRdPDzTmXzy0A0YuMA0pSEXzFmjX0ReyWf0Q=


### PR DESCRIPTION
- use a lock for postgres to prevent race conditions
- sqlite assume to be one writer so no lock needed
- handle create - prevent org level duplicate and project level duplicate, allow cross project duplicate names
- handle update with lock only if name is changed