### PR TITLE
fix: dispatch global connections

### DIFF
--- a/internal/backend/db/dbgorm/events.go
+++ b/internal/backend/db/dbgorm/events.go
@@ -87,9 +87,7 @@ func (db *gormdb) SaveEvent(ctx context.Context, event sdktypes.Event) error {
 	var cid sdktypes.ConnectionID
 	if did.IsConnectionID() {
 		cid = did.ToConnectionID()
-	}
-
-	if did.IsTriggerID() {
+	} else if did.IsTriggerID() {
 		trigger, err := db.GetTriggerByID(ctx, did.ToTriggerID())
 		if err != nil {
 			return err

--- a/internal/backend/dispatcher/dispatcher.go
+++ b/internal/backend/dispatcher/dispatcher.go
@@ -60,7 +60,7 @@ func (d *Dispatcher) DispatchExternal(ctx context.Context, event sdktypes.Event,
 	did := event.DestinationID()
 	orgID, err := d.svcs.DB.GetOrgIDOf(ctx, did)
 	if err != nil {
-		return nil, fmt.Errorf("get org id of desitnationID %v: %w", did, err)
+		return nil, fmt.Errorf("get org id of destinationID %v: %w", did, err)
 	}
 
 	d.sl.Info("external dispatch found orgID", orgID.String(), "for eventID", event.ID().String(), "and destinationID", event.DestinationID().String())


### PR DESCRIPTION
use triggers instead of connections for global connections since a connection is not bound to a project but a trigger is also update save event to handle this change to use the correct integration from the global connection