### PR TITLE
fix(pythonrt): exit process on uncaught exceptions

### DIFF
--- a/runtimes/pythonrt/pythonrt.go
+++ b/runtimes/pythonrt/pythonrt.go
@@ -705,7 +705,7 @@ func (py *pySvc) Call(ctx context.Context, v sdktypes.Value, args []sdktypes.Val
 			span.AddEvent("health")
 
 			if healthErr != nil {
-				py.cbs.Print(ctx, py.runID, healthErr.Error()) // remove
+				py.log.Error("runner health error", zap.Error(healthErr))
 				return sdktypes.InvalidValue, sdkerrors.NewRetryableErrorf("runner health: %w", healthErr)
 			}
 		case done := <-py.channels.done:

--- a/runtimes/pythonrt/pythonrt.go
+++ b/runtimes/pythonrt/pythonrt.go
@@ -705,7 +705,7 @@ func (py *pySvc) Call(ctx context.Context, v sdktypes.Value, args []sdktypes.Val
 			span.AddEvent("health")
 
 			if healthErr != nil {
-				py.cbs.Print(ctx, py.runID, healthErr.Error())
+				py.cbs.Print(ctx, py.runID, healthErr.Error()) // remove
 				return sdktypes.InvalidValue, sdkerrors.NewRetryableErrorf("runner health: %w", healthErr)
 			}
 		case done := <-py.channels.done:


### PR DESCRIPTION
catches in threadpool and grpc.

there is no need to break down the grpc interceptor, just renamed it - otherwise is overkill.

for some reason though, the pythonrt worker does not fail the activity although it detects the runner exiting. next steps:
1. make it fail the activity as retryable
2. hook up temportal heartbeat to the runner health check, to cover all our bases